### PR TITLE
Niad 2031 update fhir bundle with references

### DIFF
--- a/gp2gp-translator/src/main/java/uk/nhs/adaptors/pss/translator/exception/AttachmentNotFoundException.java
+++ b/gp2gp-translator/src/main/java/uk/nhs/adaptors/pss/translator/exception/AttachmentNotFoundException.java
@@ -1,0 +1,7 @@
+package uk.nhs.adaptors.pss.translator.exception;
+
+public class AttachmentNotFoundException extends Throwable {
+    public AttachmentNotFoundException(String message) {
+        super(message);
+    }
+}

--- a/gp2gp-translator/src/main/java/uk/nhs/adaptors/pss/translator/exception/AttachmentNotFoundException.java
+++ b/gp2gp-translator/src/main/java/uk/nhs/adaptors/pss/translator/exception/AttachmentNotFoundException.java
@@ -1,6 +1,6 @@
 package uk.nhs.adaptors.pss.translator.exception;
 
-public class AttachmentNotFoundException extends Throwable {
+public class AttachmentNotFoundException extends Exception {
     public AttachmentNotFoundException(String message) {
         super(message);
     }

--- a/gp2gp-translator/src/main/java/uk/nhs/adaptors/pss/translator/service/AttachmentReferenceUpdaterService.java
+++ b/gp2gp-translator/src/main/java/uk/nhs/adaptors/pss/translator/service/AttachmentReferenceUpdaterService.java
@@ -22,7 +22,8 @@ import java.util.regex.Pattern;
 public class AttachmentReferenceUpdaterService {
 
     private final StorageManagerService storageManagerService;
-    public String updateReferenceToAttachment(List<InboundMessage.Attachment> attachments, String conversationId, String payloadStr) throws ValidationException, AttachmentNotFoundException, InlineAttachmentProcessingException {
+    public String updateReferenceToAttachment(List<InboundMessage.Attachment> attachments, String conversationId, String payloadStr)
+            throws ValidationException, AttachmentNotFoundException, InlineAttachmentProcessingException {
         if (conversationId == null || conversationId.isEmpty()) {
             throw new ValidationException("ConversationId cannot be null or empty");
         }
@@ -50,8 +51,7 @@ public class AttachmentReferenceUpdaterService {
                         String fileLocation = storageManagerService.getFileLocation(filename);
                         var replaceStr = String.format("<reference value=\"%s\" />", fileLocation);
                         resultPayload = matcher.replaceAll(replaceStr);
-                    }
-                    else {
+                    } else {
                         var message = String.format("Could not find file %s in payload", filename);
                         throw new AttachmentNotFoundException(message);
                     }

--- a/gp2gp-translator/src/main/java/uk/nhs/adaptors/pss/translator/service/AttachmentReferenceUpdaterService.java
+++ b/gp2gp-translator/src/main/java/uk/nhs/adaptors/pss/translator/service/AttachmentReferenceUpdaterService.java
@@ -37,11 +37,7 @@ public class AttachmentReferenceUpdaterService {
                     InlineAttachment inlineAttachment = new InlineAttachment(attachment);
                     String filename = inlineAttachment.getOriginalFilename();
 
-                    // get file storage reference
-                    String fileLocation = storageManagerService.getFileLocation(filename);
-
-                    // find "local" reference
-                    // search payloadStr for filename &
+                    // find "local" reference by finding the following:
                     // "<reference value=\"file://localhost/${filename}\" />"
                     var patternStr = String.format("<reference value=.*%s.* \\/>", filename);
                     Pattern pattern = Pattern.compile(patternStr);
@@ -51,6 +47,7 @@ public class AttachmentReferenceUpdaterService {
 
                     if (matchFound) {
                         // update local ref with external reference
+                        String fileLocation = storageManagerService.getFileLocation(filename);
                         var replaceStr = String.format("<reference value=\"%s\" />", fileLocation);
                         resultPayload = matcher.replaceAll(replaceStr);
                     }

--- a/gp2gp-translator/src/main/java/uk/nhs/adaptors/pss/translator/service/AttachmentReferenceUpdaterService.java
+++ b/gp2gp-translator/src/main/java/uk/nhs/adaptors/pss/translator/service/AttachmentReferenceUpdaterService.java
@@ -1,0 +1,71 @@
+package uk.nhs.adaptors.pss.translator.service;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+import uk.nhs.adaptors.pss.translator.exception.AttachmentNotFoundException;
+import uk.nhs.adaptors.pss.translator.exception.InlineAttachmentProcessingException;
+import uk.nhs.adaptors.pss.translator.mhs.model.InboundMessage;
+import uk.nhs.adaptors.pss.translator.model.InlineAttachment;
+import uk.nhs.adaptors.pss.translator.storage.StorageManagerService;
+
+import javax.xml.bind.ValidationException;
+import java.text.ParseException;
+import java.util.List;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor(onConstructor = @__(@Autowired))
+public class AttachmentReferenceUpdaterService {
+
+    private final StorageManagerService storageManagerService;
+    public String updateReferenceToAttachment(List<InboundMessage.Attachment> attachments, String conversationId, String payloadStr) throws ValidationException, AttachmentNotFoundException, InlineAttachmentProcessingException {
+        if (conversationId == null || conversationId.isEmpty()) {
+            throw new ValidationException("ConversationId cannot be null or empty");
+        }
+
+        String resultPayload = payloadStr;
+
+        if (attachments != null) {
+
+            for (InboundMessage.Attachment attachment : attachments) {
+
+                try {
+                    InlineAttachment inlineAttachment = new InlineAttachment(attachment);
+                    String filename = inlineAttachment.getOriginalFilename();
+
+                    // get file storage reference
+                    String fileLocation = storageManagerService.getFileLocation(filename);
+
+                    // find "local" reference
+                    // search payloadStr for filename &
+                    // "<reference value=\"file://localhost/${filename}\" />"
+                    var patternStr = String.format("<reference value=.*%s.* \\/>", filename);
+                    Pattern pattern = Pattern.compile(patternStr);
+                    Matcher matcher = pattern.matcher(resultPayload);
+
+                    var matchFound = matcher.find();
+
+                    if (matchFound) {
+                        // update local ref with external reference
+                        var replaceStr = String.format("<reference value=\"%s\" />", fileLocation);
+                        resultPayload = matcher.replaceAll(replaceStr);
+                    }
+                    else {
+                        var message = String.format("Could not find file %s in payload", filename);
+                        throw new AttachmentNotFoundException(message);
+                    }
+                } catch (ParseException ex) {
+                    throw new InlineAttachmentProcessingException("Unable to parse inline attachment description: " + ex.getMessage());
+                } catch (AttachmentNotFoundException e) {
+                    throw new AttachmentNotFoundException(e.getMessage());
+                }
+            }
+        }
+
+        return resultPayload;
+    }
+}

--- a/gp2gp-translator/src/main/java/uk/nhs/adaptors/pss/translator/storage/AWSStorageService.java
+++ b/gp2gp-translator/src/main/java/uk/nhs/adaptors/pss/translator/storage/AWSStorageService.java
@@ -3,6 +3,9 @@ package uk.nhs.adaptors.pss.translator.storage;
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.io.InputStream;
+import java.net.URL;
+import java.time.Instant;
+import java.util.Date;
 
 import com.amazonaws.auth.AWSCredentials;
 import com.amazonaws.auth.AWSStaticCredentialsProvider;
@@ -61,6 +64,18 @@ public class AWSStorageService implements StorageService {
 
     public void deleteFile(String filename) {
         s3Client.deleteObject(bucketName, filename);
+    }
+
+    public String getFileLocation(String filename) {
+        // https://docs.aws.amazon.com/AmazonS3/latest/userguide/ShareObjectPreSignedURL.html
+        // sharing file location from AWS is not straightforward as files are private by default
+        Date expiration = new Date();
+        long expTimeMillis = Instant.now().toEpochMilli();
+        expTimeMillis += 1000 * 60 * 60;
+        expiration.setTime(expTimeMillis);
+
+        URL url = s3Client.generatePresignedUrl(bucketName, filename, expiration);
+        return url.toString();
     }
 
     private S3ObjectInputStream downloadFileToStream(String filename) throws StorageException {

--- a/gp2gp-translator/src/main/java/uk/nhs/adaptors/pss/translator/storage/AWSStorageService.java
+++ b/gp2gp-translator/src/main/java/uk/nhs/adaptors/pss/translator/storage/AWSStorageService.java
@@ -22,6 +22,7 @@ import org.springframework.stereotype.Service;
 @Service
 public class AWSStorageService implements StorageService {
 
+    private static final long SIXY_MINUTES = 1000 * 60 * 60;
     private final AmazonS3 s3Client;
     private String bucketName;
 
@@ -71,7 +72,7 @@ public class AWSStorageService implements StorageService {
         // sharing file location from AWS is not straightforward as files are private by default
         Date expiration = new Date();
         long expTimeMillis = Instant.now().toEpochMilli();
-        expTimeMillis += 1000 * 60 * 60;
+        expTimeMillis += SIXY_MINUTES;
         expiration.setTime(expTimeMillis);
 
         URL url = s3Client.generatePresignedUrl(bucketName, filename, expiration);

--- a/gp2gp-translator/src/main/java/uk/nhs/adaptors/pss/translator/storage/AzureStorageService.java
+++ b/gp2gp-translator/src/main/java/uk/nhs/adaptors/pss/translator/storage/AzureStorageService.java
@@ -53,6 +53,11 @@ public class AzureStorageService implements StorageService {
         blobClient.delete();
     }
 
+    public String getFileLocation(String filename) {
+        var blobClient = createBlobBlockClient(filename);
+        return blobClient.getBlobUrl();
+    }
+
     private StorageSharedKeyCredential createAzureCredentials(String accountName, String accountKey) {
         return new StorageSharedKeyCredential(accountName, accountKey);
     }
@@ -73,10 +78,14 @@ public class AzureStorageService implements StorageService {
         return blobServiceClient.getBlobContainerClient(containerName);
     }
 
+    private BlockBlobClient createBlobBlockClient(String filename) {
+        BlobContainerClient containerClient = createBlobContainerClient();
+        return containerClient.getBlobClient(filename).getBlockBlobClient();
+    }
+
     private void addFileStringToMainContainer(String filename, byte[] fileAsString) throws StorageException, IOException {
         try {
-            BlobContainerClient containerClient = createBlobContainerClient();
-            BlockBlobClient blobClient = containerClient.getBlobClient(filename).getBlockBlobClient();
+            BlockBlobClient blobClient = createBlobBlockClient(filename);
             InputStream dataStream = new ByteArrayInputStream(fileAsString);
             blobClient.upload(dataStream, fileAsString.length);
             dataStream.close();
@@ -87,8 +96,7 @@ public class AzureStorageService implements StorageService {
 
     private ByteArrayOutputStream downloadFileToStream(String filename) throws StorageException {
         try {
-            BlobContainerClient containerClient = createBlobContainerClient();
-            BlockBlobClient blobClient = containerClient.getBlobClient(filename).getBlockBlobClient();
+            BlockBlobClient blobClient = createBlobBlockClient(filename);
             int dataSize = (int) blobClient.getProperties().getBlobSize();
             ByteArrayOutputStream outputStream = new ByteArrayOutputStream(dataSize);
             blobClient.downloadStream(outputStream);

--- a/gp2gp-translator/src/main/java/uk/nhs/adaptors/pss/translator/storage/LocalStorageService.java
+++ b/gp2gp-translator/src/main/java/uk/nhs/adaptors/pss/translator/storage/LocalStorageService.java
@@ -43,6 +43,10 @@ public class LocalStorageService implements StorageService {
         }
     }
 
+    public String getFileLocation(String filename) {
+        return filename;
+    }
+
     private InputStream downloadFileToStream(String filename) throws StorageException {
         try {
             byte[] objectBytes = storage.get(filename);

--- a/gp2gp-translator/src/main/java/uk/nhs/adaptors/pss/translator/storage/StorageManagerService.java
+++ b/gp2gp-translator/src/main/java/uk/nhs/adaptors/pss/translator/storage/StorageManagerService.java
@@ -56,6 +56,14 @@ public class StorageManagerService {
         }
     }
 
+    public String getFileLocation(String filename) {
+        try {
+            return storageService.getFileLocation(filename);
+        } catch (Exception e) {
+            throw new StorageException("Error occurred getting file location from Storage", e);
+        }
+    }
+
     private Boolean validateUploadedFile(String filename, byte[] fileAsString) throws StorageException {
         byte[] downloadedFile = storageService.downloadFile(filename);
         return Arrays.equals(fileAsString, downloadedFile);

--- a/gp2gp-translator/src/main/java/uk/nhs/adaptors/pss/translator/storage/StorageService.java
+++ b/gp2gp-translator/src/main/java/uk/nhs/adaptors/pss/translator/storage/StorageService.java
@@ -4,4 +4,5 @@ public interface StorageService {
     void uploadFile(String filename, byte[] fileAsString) throws StorageException;
     byte[] downloadFile(String filename) throws StorageException;
     void deleteFile(String filename) throws StorageException;
+    String getFileLocation(String filename) throws StorageException;
 }

--- a/gp2gp-translator/src/main/java/uk/nhs/adaptors/pss/translator/task/EhrExtractMessageHandler.java
+++ b/gp2gp-translator/src/main/java/uk/nhs/adaptors/pss/translator/task/EhrExtractMessageHandler.java
@@ -29,6 +29,7 @@ import uk.nhs.adaptors.connector.dao.PatientMigrationRequestDao;
 import uk.nhs.adaptors.connector.model.MigrationStatusLog;
 import uk.nhs.adaptors.connector.model.PatientMigrationRequest;
 import uk.nhs.adaptors.connector.service.MigrationStatusLogService;
+import uk.nhs.adaptors.pss.translator.exception.AttachmentNotFoundException;
 import uk.nhs.adaptors.pss.translator.exception.BundleMappingException;
 import uk.nhs.adaptors.pss.translator.exception.InlineAttachmentProcessingException;
 import uk.nhs.adaptors.pss.translator.mhs.model.InboundMessage;
@@ -37,6 +38,7 @@ import uk.nhs.adaptors.pss.translator.model.ContinueRequestData;
 import uk.nhs.adaptors.pss.translator.model.NACKMessageData;
 import uk.nhs.adaptors.pss.translator.model.NACKReason;
 import uk.nhs.adaptors.pss.translator.service.AttachmentHandlerService;
+import uk.nhs.adaptors.pss.translator.service.AttachmentReferenceUpdaterService;
 import uk.nhs.adaptors.pss.translator.service.BundleMapperService;
 import uk.nhs.adaptors.pss.translator.service.XPathService;
 import uk.nhs.adaptors.pss.translator.util.DateFormatUtil;
@@ -53,11 +55,12 @@ public class EhrExtractMessageHandler {
     private final XPathService xPathService;
     private final SendContinueRequestHandler sendContinueRequestHandler;
     private final AttachmentHandlerService attachmentHandlerService;
+    private final AttachmentReferenceUpdaterService attachmentReferenceUpdaterService;
     private final SendNACKMessageHandler sendNACKMessageHandler;
     private final SendACKMessageHandler sendACKMessageHandler;
 
     public void handleMessage(InboundMessage inboundMessage, String conversationId) throws JAXBException, JsonProcessingException,
-        SAXException, InlineAttachmentProcessingException, BundleMappingException {
+        SAXException, InlineAttachmentProcessingException, BundleMappingException, AttachmentNotFoundException {
 
         RCMRIN030000UK06Message payload = unmarshallString(inboundMessage.getPayload(), RCMRIN030000UK06Message.class);
         PatientMigrationRequest migrationRequest = migrationRequestDao.getMigrationRequest(conversationId);
@@ -67,8 +70,18 @@ public class EhrExtractMessageHandler {
 
 
         try {
-            var bundle = bundleMapperService.mapToBundle(payload, migrationRequest.getLosingPracticeOdsCode());
             attachmentHandlerService.storeAttachments(inboundMessage.getAttachments(), conversationId);
+
+            var newPayloadStr = attachmentReferenceUpdaterService.updateReferenceToAttachment(
+                    inboundMessage.getAttachments(),
+                    conversationId,
+                    inboundMessage.getPayload()
+            );
+            inboundMessage.setPayload(newPayloadStr);
+            payload = unmarshallString(inboundMessage.getPayload(), RCMRIN030000UK06Message.class);
+
+            var bundle = bundleMapperService.mapToBundle(payload, migrationRequest.getLosingPracticeOdsCode());
+
             migrationStatusLogService.updatePatientMigrationRequestAndAddMigrationStatusLog(
                 conversationId,
                 fhirParser.encodeToJson(bundle),
@@ -100,12 +113,12 @@ public class EhrExtractMessageHandler {
 
             sendAckMessage(payload, conversationId);
 
-        } catch (BundleMappingException | DataFormatException | JsonProcessingException | InlineAttachmentProcessingException ex) {
+        } catch (BundleMappingException | DataFormatException | JsonProcessingException | InlineAttachmentProcessingException | AttachmentNotFoundException ex) {
             sendNackMessage(EHR_EXTRACT_CANNOT_BE_PROCESSED, payload, conversationId);
             throw ex;
         } catch (SAXException e) {
             LOGGER.error("failed to parse RCMR_IN030000UK06 ebxml: "
-                + "failed to extract \"mid:\" from xlink:href, before sending the continue message", e);
+                    + "failed to extract \"mid:\" from xlink:href, before sending the continue message", e);
             sendNackMessage(EHR_EXTRACT_CANNOT_BE_PROCESSED, payload, conversationId);
             throw e;
         }

--- a/gp2gp-translator/src/main/java/uk/nhs/adaptors/pss/translator/task/EhrExtractMessageHandler.java
+++ b/gp2gp-translator/src/main/java/uk/nhs/adaptors/pss/translator/task/EhrExtractMessageHandler.java
@@ -113,7 +113,8 @@ public class EhrExtractMessageHandler {
 
             sendAckMessage(payload, conversationId);
 
-        } catch (BundleMappingException | DataFormatException | JsonProcessingException | InlineAttachmentProcessingException | AttachmentNotFoundException ex) {
+        } catch (BundleMappingException | DataFormatException | JsonProcessingException
+                 | InlineAttachmentProcessingException | AttachmentNotFoundException ex) {
             sendNackMessage(EHR_EXTRACT_CANNOT_BE_PROCESSED, payload, conversationId);
             throw ex;
         } catch (SAXException e) {

--- a/gp2gp-translator/src/main/java/uk/nhs/adaptors/pss/translator/task/MhsQueueMessageHandler.java
+++ b/gp2gp-translator/src/main/java/uk/nhs/adaptors/pss/translator/task/MhsQueueMessageHandler.java
@@ -17,6 +17,7 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import uk.nhs.adaptors.common.service.MDCService;
 import uk.nhs.adaptors.pss.translator.amqp.JmsReader;
+import uk.nhs.adaptors.pss.translator.exception.AttachmentNotFoundException;
 import uk.nhs.adaptors.pss.translator.exception.BundleMappingException;
 import uk.nhs.adaptors.pss.translator.exception.InlineAttachmentProcessingException;
 import uk.nhs.adaptors.pss.translator.mhs.model.InboundMessage;
@@ -66,6 +67,9 @@ public class MhsQueueMessageHandler {
             return false;
         } catch (InlineAttachmentProcessingException e) {
             LOGGER.error("Unable to process inline attachments", e);
+            return false;
+        } catch (AttachmentNotFoundException e) {
+            LOGGER.error("Unable to find attachment reference inbound message", e);
             return false;
         } catch (BundleMappingException e) {
             LOGGER.error("Unable to map EHR Extract to FHIR bundle", e);

--- a/gp2gp-translator/src/test/java/uk/nhs/adaptors/pss/translator/service/AttachmentReferenceUpdaterServiceTests.java
+++ b/gp2gp-translator/src/test/java/uk/nhs/adaptors/pss/translator/service/AttachmentReferenceUpdaterServiceTests.java
@@ -1,47 +1,35 @@
 package uk.nhs.adaptors.pss.translator.service;
 
-import lombok.SneakyThrows;
-import org.apache.commons.codec.Charsets;
-import org.hl7.v3.RCMRIN030000UK06Message;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
-import org.mockito.ArgumentCaptor;
-import org.mockito.Captor;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.core.io.ClassPathResource;
 import org.springframework.core.io.Resource;
-import org.springframework.util.ClassUtils;
 import uk.nhs.adaptors.pss.translator.exception.AttachmentNotFoundException;
 import uk.nhs.adaptors.pss.translator.exception.InlineAttachmentProcessingException;
 import uk.nhs.adaptors.pss.translator.mhs.model.InboundMessage;
-import uk.nhs.adaptors.pss.translator.storage.StorageDataUploadWrapper;
 import uk.nhs.adaptors.pss.translator.storage.StorageManagerService;
 
 import javax.xml.bind.ValidationException;
-import java.io.File;
 import java.io.IOException;
-import java.net.URL;
 import java.nio.file.Files;
-import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.List;
 
-import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.*;
-import static org.springframework.util.ResourceUtils.getFile;
 import static uk.nhs.adaptors.common.util.FileUtil.readResourceAsString;
-import static uk.nhs.adaptors.pss.translator.util.XmlUnmarshallUtil.unmarshallFile;
 
 @ExtendWith(MockitoExtension.class)
 public class AttachmentReferenceUpdaterServiceTests {
 
     private static final String XML_RESOURCES_BASE = "xml/RCMRIN030000UK06_LARGE_MSG/";
     private static final String PAYLOAD_XML = "payload.xml";
+    private static final String CONVERSATION_ID = "1";
     @Mock
     private StorageManagerService storageManagerService;
 
@@ -92,12 +80,12 @@ public class AttachmentReferenceUpdaterServiceTests {
     @Test
     public void When_NoAttachmentsGiven_NothingChanges() throws AttachmentNotFoundException, ValidationException, InlineAttachmentProcessingException {
         //arrange
-        final String conversationId = "convo";
+
 
         var content = getFileContent(PAYLOAD_XML);
 
         //act
-        var result = attachmentReferenceUpdaterService.updateReferenceToAttachment(null, conversationId, content);
+        var result = attachmentReferenceUpdaterService.updateReferenceToAttachment(null, CONVERSATION_ID, content);
 
         //assert
         assertEquals(content, result);
@@ -105,32 +93,22 @@ public class AttachmentReferenceUpdaterServiceTests {
     
     @Test
     public void When_AttachmentGiven_GetUrlHitOnce() throws AttachmentNotFoundException, ValidationException, InlineAttachmentProcessingException {
-        //arrange
-        final String conversationId = "convo";
-        final RCMRIN030000UK06Message xml = unmarshallCodeElement(PAYLOAD_XML);
 
         var content = getFileContent(PAYLOAD_XML);
 
-        //act
-        var result = attachmentReferenceUpdaterService.updateReferenceToAttachment(mockAttachment, conversationId, content);
+        attachmentReferenceUpdaterService.updateReferenceToAttachment(mockAttachment, CONVERSATION_ID, content);
 
-        //assert
         verify(storageManagerService, times(1)).getFileLocation(any());
     }
 
     @Test
     public void When_AttachmentGiven_PayloadXmlChanged() throws AttachmentNotFoundException, ValidationException, InlineAttachmentProcessingException {
-        //arrange
-        final String conversationId = "convo";
-        final RCMRIN030000UK06Message xml = unmarshallCodeElement(PAYLOAD_XML);
-        when(storageManagerService.getFileLocation(any())).thenReturn("https://location.com");
 
         var content = getFileContent(PAYLOAD_XML);
+        when(storageManagerService.getFileLocation(any())).thenReturn("https://location.com");
 
-        //act
-        var result = attachmentReferenceUpdaterService.updateReferenceToAttachment(mockAttachment, conversationId, content);
+        var result = attachmentReferenceUpdaterService.updateReferenceToAttachment(mockAttachment, CONVERSATION_ID, content);
 
-        //assert
         assertNotEquals(content, result);
         assertTrue(result.contains("https://location.com"));
         assertFalse(result.contains("file://localhost/277F29F1-FEAB-4D38-8266-FEB7A1E6227D_LICENSE.txt"));
@@ -138,29 +116,21 @@ public class AttachmentReferenceUpdaterServiceTests {
 
     @Test
     public void When_MultipleAttachmentsGiven_GetFileLocationHitMultipleTimes() throws AttachmentNotFoundException, ValidationException, InlineAttachmentProcessingException {
-        //arrange
-        final String conversationId = "convo";
-        final RCMRIN030000UK06Message xml = unmarshallCodeElement(PAYLOAD_XML);
-        when(storageManagerService.getFileLocation(any())).thenReturn("https://location.com");
 
         var content = getFileContent(PAYLOAD_XML);
+        when(storageManagerService.getFileLocation(any())).thenReturn("https://location.com");
 
-        //act
-        var result = attachmentReferenceUpdaterService.updateReferenceToAttachment(mockThreeAttachments, conversationId, content);
+        var result = attachmentReferenceUpdaterService.updateReferenceToAttachment(mockThreeAttachments, CONVERSATION_ID, content);
 
-        //assert
         verify(storageManagerService, times(3)).getFileLocation(any());
+        assertTrue(result.contains("https://location.com"));
         assertFalse(result.contains("file://localhost/277F29F1-FEAB-4D38-8266-FEB7A1E6227D_LICENSE.txt"));
         assertFalse(result.contains("file://localhost/7CCB6A77-360E-434E-8CF4-97C7C2B47D70_book.txt"));
         assertFalse(result.contains("file://localhost/8681AF4F-E577-4C8D-A2CE-43CABE3D5FB4_sample_mpeg4.mp4"));
     }
 
     private String getFileContent(String filename) {
-        return readResourceAsString("/" + XML_RESOURCES_BASE + filename);
-    }
 
-    @SneakyThrows
-    private RCMRIN030000UK06Message unmarshallCodeElement(String fileName) {
-        return unmarshallFile(getFile("classpath:" + XML_RESOURCES_BASE + fileName), RCMRIN030000UK06Message.class);
+        return readResourceAsString("/" + XML_RESOURCES_BASE + filename);
     }
 }

--- a/gp2gp-translator/src/test/java/uk/nhs/adaptors/pss/translator/service/AttachmentReferenceUpdaterServiceTests.java
+++ b/gp2gp-translator/src/test/java/uk/nhs/adaptors/pss/translator/service/AttachmentReferenceUpdaterServiceTests.java
@@ -6,8 +6,6 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
-import org.springframework.core.io.ClassPathResource;
-import org.springframework.core.io.Resource;
 import uk.nhs.adaptors.pss.translator.exception.AttachmentNotFoundException;
 import uk.nhs.adaptors.pss.translator.exception.InlineAttachmentProcessingException;
 import uk.nhs.adaptors.pss.translator.mhs.model.InboundMessage;
@@ -15,13 +13,18 @@ import uk.nhs.adaptors.pss.translator.storage.StorageManagerService;
 
 import javax.xml.bind.ValidationException;
 import java.io.IOException;
-import java.nio.file.Files;
-import java.nio.file.Paths;
 import java.util.List;
 
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.Mockito.*;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.when;
+
 import static uk.nhs.adaptors.common.util.FileUtil.readResourceAsString;
 
 @ExtendWith(MockitoExtension.class)
@@ -39,18 +42,14 @@ public class AttachmentReferenceUpdaterServiceTests {
     private static List<InboundMessage.Attachment> mockAttachment;
     private static List<InboundMessage.Attachment> mockThreeAttachments;
 
-    private static String readFileAsString(String path) throws IOException {
-        Resource resource = new ClassPathResource(path);
-        return Files.readString(Paths.get(resource.getURI()));
-    }
-    
     @BeforeAll
     static void setMockedAttachments() throws IOException {
         mockAttachment = List.of(
                 InboundMessage.Attachment.builder()
                         .contentType("txt")
                         .isBase64("true")
-                        .description("Filename=\"277F29F1-FEAB-4D38-8266-FEB7A1E6227D_LICENSE.txt\" ContentType=text/plain Compressed=No "
+                        .description("Filename=\"277F29F1-FEAB-4D38-8266-FEB7A1E6227D_LICENSE.txt\" "
+                                + "ContentType=text/plain Compressed=No "
                                 + "LargeAttachment=No OriginalBase64=Yes")
                         .payload("SGVsbG8gV29ybGQgZnJvbSBTY290dCBBbGV4YW5kZXI=").build()
         );
@@ -59,40 +58,42 @@ public class AttachmentReferenceUpdaterServiceTests {
                 InboundMessage.Attachment.builder()
                         .contentType("txt")
                         .isBase64("true")
-                        .description("Filename=\"277F29F1-FEAB-4D38-8266-FEB7A1E6227D_LICENSE.txt\" ContentType=text/plain Compressed=No "
+                        .description("Filename=\"277F29F1-FEAB-4D38-8266-FEB7A1E6227D_LICENSE.txt\" "
+                                + "ContentType=text/plain Compressed=No "
                                 + "LargeAttachment=No OriginalBase64=Yes")
                         .payload("SGVsbG8gV29ybGQgZnJvbSBTY290dCBBbGV4YW5kZXI=").build(),
                 InboundMessage.Attachment.builder()
                         .contentType("txt")
                         .isBase64("true")
-                        .description("Filename=\"7CCB6A77-360E-434E-8CF4-97C7C2B47D70_book.txt\" ContentType=text/plain Compressed=No "
+                        .description("Filename=\"7CCB6A77-360E-434E-8CF4-97C7C2B47D70_book.txt\" "
+                                + "ContentType=text/plain Compressed=No "
                                 + "LargeAttachment=No OriginalBase64=Yes")
                         .payload("SGVsbG8gV29ybGQgZnJvbSBTY290dCBBbGV4YW5kZXI=").build(),
                 InboundMessage.Attachment.builder()
                         .contentType("txt")
                         .isBase64("true")
-                        .description("Filename=\"8681AF4F-E577-4C8D-A2CE-43CABE3D5FB4_sample_mpeg4.mp4\" ContentType=video/mpeg Compressed=No "
+                        .description(
+                                "Filename=\"8681AF4F-E577-4C8D-A2CE-43CABE3D5FB4_sample_mpeg4.mp4\" "
+                                + "ContentType=video/mpeg Compressed=No "
                                 + "LargeAttachment=No OriginalBase64=Yes")
                         .payload("SGVsbG8gV29ybGQgZnJvbSBTY290dCBBbGV4YW5kZXI=").build()
         );
     }
-    
-    @Test
-    public void When_NoAttachmentsGiven_NothingChanges() throws AttachmentNotFoundException, ValidationException, InlineAttachmentProcessingException {
-        //arrange
 
+    @Test
+    public void When_NoAttachmentsGiven_Expect_NoChanges()
+            throws AttachmentNotFoundException, ValidationException, InlineAttachmentProcessingException {
 
         var content = getFileContent(PAYLOAD_XML);
 
-        //act
         var result = attachmentReferenceUpdaterService.updateReferenceToAttachment(null, CONVERSATION_ID, content);
 
-        //assert
         assertEquals(content, result);
     }
-    
+
     @Test
-    public void When_AttachmentGiven_GetUrlHitOnce() throws AttachmentNotFoundException, ValidationException, InlineAttachmentProcessingException {
+    public void When_AttachmentGiven_Expect_GetFileLocationHitOnce()
+            throws AttachmentNotFoundException, ValidationException, InlineAttachmentProcessingException {
 
         var content = getFileContent(PAYLOAD_XML);
 
@@ -102,7 +103,8 @@ public class AttachmentReferenceUpdaterServiceTests {
     }
 
     @Test
-    public void When_AttachmentGiven_PayloadXmlChanged() throws AttachmentNotFoundException, ValidationException, InlineAttachmentProcessingException {
+    public void When_AttachmentGiven_Expect_PayloadXmlChanged()
+            throws AttachmentNotFoundException, ValidationException, InlineAttachmentProcessingException {
 
         var content = getFileContent(PAYLOAD_XML);
         when(storageManagerService.getFileLocation(any())).thenReturn("https://location.com");
@@ -115,14 +117,15 @@ public class AttachmentReferenceUpdaterServiceTests {
     }
 
     @Test
-    public void When_MultipleAttachmentsGiven_GetFileLocationHitMultipleTimes() throws AttachmentNotFoundException, ValidationException, InlineAttachmentProcessingException {
+    public void When_MultipleAttachmentsGiven_Expect_GetFileLocationHitMultipleTimes()
+            throws AttachmentNotFoundException, ValidationException, InlineAttachmentProcessingException {
 
         var content = getFileContent(PAYLOAD_XML);
         when(storageManagerService.getFileLocation(any())).thenReturn("https://location.com");
 
         var result = attachmentReferenceUpdaterService.updateReferenceToAttachment(mockThreeAttachments, CONVERSATION_ID, content);
 
-        verify(storageManagerService, times(3)).getFileLocation(any());
+        verify(storageManagerService, times(mockThreeAttachments.size())).getFileLocation(any());
         assertTrue(result.contains("https://location.com"));
         assertFalse(result.contains("file://localhost/277F29F1-FEAB-4D38-8266-FEB7A1E6227D_LICENSE.txt"));
         assertFalse(result.contains("file://localhost/7CCB6A77-360E-434E-8CF4-97C7C2B47D70_book.txt"));

--- a/gp2gp-translator/src/test/java/uk/nhs/adaptors/pss/translator/service/AttachmentReferenceUpdaterServiceTests.java
+++ b/gp2gp-translator/src/test/java/uk/nhs/adaptors/pss/translator/service/AttachmentReferenceUpdaterServiceTests.java
@@ -1,0 +1,166 @@
+package uk.nhs.adaptors.pss.translator.service;
+
+import lombok.SneakyThrows;
+import org.apache.commons.codec.Charsets;
+import org.hl7.v3.RCMRIN030000UK06Message;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.core.io.ClassPathResource;
+import org.springframework.core.io.Resource;
+import org.springframework.util.ClassUtils;
+import uk.nhs.adaptors.pss.translator.exception.AttachmentNotFoundException;
+import uk.nhs.adaptors.pss.translator.exception.InlineAttachmentProcessingException;
+import uk.nhs.adaptors.pss.translator.mhs.model.InboundMessage;
+import uk.nhs.adaptors.pss.translator.storage.StorageDataUploadWrapper;
+import uk.nhs.adaptors.pss.translator.storage.StorageManagerService;
+
+import javax.xml.bind.ValidationException;
+import java.io.File;
+import java.io.IOException;
+import java.net.URL;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.List;
+
+import static java.nio.charset.StandardCharsets.UTF_8;
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+import static org.springframework.util.ResourceUtils.getFile;
+import static uk.nhs.adaptors.common.util.FileUtil.readResourceAsString;
+import static uk.nhs.adaptors.pss.translator.util.XmlUnmarshallUtil.unmarshallFile;
+
+@ExtendWith(MockitoExtension.class)
+public class AttachmentReferenceUpdaterServiceTests {
+
+    private static final String XML_RESOURCES_BASE = "xml/RCMRIN030000UK06_LARGE_MSG/";
+    private static final String PAYLOAD_XML = "payload.xml";
+    @Mock
+    private StorageManagerService storageManagerService;
+
+    @InjectMocks
+    private AttachmentReferenceUpdaterService attachmentReferenceUpdaterService;
+
+    private static List<InboundMessage.Attachment> mockAttachment;
+    private static List<InboundMessage.Attachment> mockThreeAttachments;
+
+    private static String readFileAsString(String path) throws IOException {
+        Resource resource = new ClassPathResource(path);
+        return Files.readString(Paths.get(resource.getURI()));
+    }
+    
+    @BeforeAll
+    static void setMockedAttachments() throws IOException {
+        mockAttachment = List.of(
+                InboundMessage.Attachment.builder()
+                        .contentType("txt")
+                        .isBase64("true")
+                        .description("Filename=\"277F29F1-FEAB-4D38-8266-FEB7A1E6227D_LICENSE.txt\" ContentType=text/plain Compressed=No "
+                                + "LargeAttachment=No OriginalBase64=Yes")
+                        .payload("SGVsbG8gV29ybGQgZnJvbSBTY290dCBBbGV4YW5kZXI=").build()
+        );
+
+        mockThreeAttachments = List.of(
+                InboundMessage.Attachment.builder()
+                        .contentType("txt")
+                        .isBase64("true")
+                        .description("Filename=\"277F29F1-FEAB-4D38-8266-FEB7A1E6227D_LICENSE.txt\" ContentType=text/plain Compressed=No "
+                                + "LargeAttachment=No OriginalBase64=Yes")
+                        .payload("SGVsbG8gV29ybGQgZnJvbSBTY290dCBBbGV4YW5kZXI=").build(),
+                InboundMessage.Attachment.builder()
+                        .contentType("txt")
+                        .isBase64("true")
+                        .description("Filename=\"7CCB6A77-360E-434E-8CF4-97C7C2B47D70_book.txt\" ContentType=text/plain Compressed=No "
+                                + "LargeAttachment=No OriginalBase64=Yes")
+                        .payload("SGVsbG8gV29ybGQgZnJvbSBTY290dCBBbGV4YW5kZXI=").build(),
+                InboundMessage.Attachment.builder()
+                        .contentType("txt")
+                        .isBase64("true")
+                        .description("Filename=\"8681AF4F-E577-4C8D-A2CE-43CABE3D5FB4_sample_mpeg4.mp4\" ContentType=video/mpeg Compressed=No "
+                                + "LargeAttachment=No OriginalBase64=Yes")
+                        .payload("SGVsbG8gV29ybGQgZnJvbSBTY290dCBBbGV4YW5kZXI=").build()
+        );
+    }
+    
+    @Test
+    public void When_NoAttachmentsGiven_NothingChanges() throws AttachmentNotFoundException, ValidationException, InlineAttachmentProcessingException {
+        //arrange
+        final String conversationId = "convo";
+
+        var content = getFileContent(PAYLOAD_XML);
+
+        //act
+        var result = attachmentReferenceUpdaterService.updateReferenceToAttachment(null, conversationId, content);
+
+        //assert
+        assertEquals(content, result);
+    }
+    
+    @Test
+    public void When_AttachmentGiven_GetUrlHitOnce() throws AttachmentNotFoundException, ValidationException, InlineAttachmentProcessingException {
+        //arrange
+        final String conversationId = "convo";
+        final RCMRIN030000UK06Message xml = unmarshallCodeElement(PAYLOAD_XML);
+
+        var content = getFileContent(PAYLOAD_XML);
+
+        //act
+        var result = attachmentReferenceUpdaterService.updateReferenceToAttachment(mockAttachment, conversationId, content);
+
+        //assert
+        verify(storageManagerService, times(1)).getFileLocation(any());
+    }
+
+    @Test
+    public void When_AttachmentGiven_PayloadXmlChanged() throws AttachmentNotFoundException, ValidationException, InlineAttachmentProcessingException {
+        //arrange
+        final String conversationId = "convo";
+        final RCMRIN030000UK06Message xml = unmarshallCodeElement(PAYLOAD_XML);
+        when(storageManagerService.getFileLocation(any())).thenReturn("https://location.com");
+
+        var content = getFileContent(PAYLOAD_XML);
+
+        //act
+        var result = attachmentReferenceUpdaterService.updateReferenceToAttachment(mockAttachment, conversationId, content);
+
+        //assert
+        assertNotEquals(content, result);
+        assertTrue(result.contains("https://location.com"));
+        assertFalse(result.contains("file://localhost/277F29F1-FEAB-4D38-8266-FEB7A1E6227D_LICENSE.txt"));
+    }
+
+    @Test
+    public void When_MultipleAttachmentsGiven_GetFileLocationHitMultipleTimes() throws AttachmentNotFoundException, ValidationException, InlineAttachmentProcessingException {
+        //arrange
+        final String conversationId = "convo";
+        final RCMRIN030000UK06Message xml = unmarshallCodeElement(PAYLOAD_XML);
+        when(storageManagerService.getFileLocation(any())).thenReturn("https://location.com");
+
+        var content = getFileContent(PAYLOAD_XML);
+
+        //act
+        var result = attachmentReferenceUpdaterService.updateReferenceToAttachment(mockThreeAttachments, conversationId, content);
+
+        //assert
+        verify(storageManagerService, times(3)).getFileLocation(any());
+        assertFalse(result.contains("file://localhost/277F29F1-FEAB-4D38-8266-FEB7A1E6227D_LICENSE.txt"));
+        assertFalse(result.contains("file://localhost/7CCB6A77-360E-434E-8CF4-97C7C2B47D70_book.txt"));
+        assertFalse(result.contains("file://localhost/8681AF4F-E577-4C8D-A2CE-43CABE3D5FB4_sample_mpeg4.mp4"));
+    }
+
+    private String getFileContent(String filename) {
+        return readResourceAsString("/" + XML_RESOURCES_BASE + filename);
+    }
+
+    @SneakyThrows
+    private RCMRIN030000UK06Message unmarshallCodeElement(String fileName) {
+        return unmarshallFile(getFile("classpath:" + XML_RESOURCES_BASE + fileName), RCMRIN030000UK06Message.class);
+    }
+}

--- a/gp2gp-translator/src/test/java/uk/nhs/adaptors/pss/translator/task/EhrExtractMessageHandlerTest.java
+++ b/gp2gp-translator/src/test/java/uk/nhs/adaptors/pss/translator/task/EhrExtractMessageHandlerTest.java
@@ -121,8 +121,8 @@ public class EhrExtractMessageHandlerTest {
 
     @Test
     public void When_HandleMessageWithValidDataIsCalled_Expect_CallsMigrationStatusLogServiceAddMigrationStatusLog()
-
-            throws JsonProcessingException, JAXBException, SAXException, InlineAttachmentProcessingException, BundleMappingException, AttachmentNotFoundException {
+            throws JsonProcessingException, JAXBException, SAXException,
+                InlineAttachmentProcessingException, BundleMappingException, AttachmentNotFoundException {
 
         InboundMessage inboundMessage = new InboundMessage();
         prepareMocks(inboundMessage);
@@ -167,7 +167,10 @@ public class EhrExtractMessageHandlerTest {
         when(migrationRequestDao.getMigrationRequest(CONVERSATION_ID)).thenReturn(migrationRequest);
         when(bundleMapperService.mapToBundle(any(RCMRIN030000UK06Message.class), eq(LOSING_ODE_CODE))).thenReturn(bundle);
         when(sendACKMessageHandler.prepareAndSendMessage(any())).thenReturn(true);
-        when(attachmentReferenceUpdaterService.updateReferenceToAttachment(inboundMessage.getAttachments(), CONVERSATION_ID, inboundMessage.getPayload())).thenReturn(inboundMessage.getPayload());
+        when(attachmentReferenceUpdaterService
+                .updateReferenceToAttachment(
+                        inboundMessage.getAttachments(), CONVERSATION_ID, inboundMessage.getPayload()
+                )).thenReturn(inboundMessage.getPayload());
     }
 
     @SneakyThrows
@@ -182,7 +185,8 @@ public class EhrExtractMessageHandlerTest {
 
     @Test
     public void When_HandleMessageWithValidDataIsCalled_Expect_CallsBundleMapperServiceMapToBundle()
-            throws JsonProcessingException, JAXBException, SAXException, InlineAttachmentProcessingException, BundleMappingException, AttachmentNotFoundException {
+            throws JsonProcessingException, JAXBException, SAXException,
+                InlineAttachmentProcessingException, BundleMappingException, AttachmentNotFoundException {
         InboundMessage inboundMessage = new InboundMessage();
         prepareMocks(inboundMessage);
 
@@ -192,8 +196,8 @@ public class EhrExtractMessageHandlerTest {
 
     @Test
     public void When_HandleMessageWithValidDataIsCalled_Expect_CallsAttachmentHandlerServiceStoreAttachments()
-
-            throws JsonProcessingException, JAXBException, SAXException, InlineAttachmentProcessingException, BundleMappingException, AttachmentNotFoundException {
+            throws JsonProcessingException, JAXBException, SAXException,
+                InlineAttachmentProcessingException, BundleMappingException, AttachmentNotFoundException {
 
         InboundMessage inboundMessage = new InboundMessage();
         prepareMocks(inboundMessage);
@@ -205,20 +209,22 @@ public class EhrExtractMessageHandlerTest {
 
     @Test
     public void When_HandleMessageWithValidDataIsCalled_Expect_CallsAttachmentReferenceUpdaterServiceUpdateReferences()
-
-            throws JsonProcessingException, JAXBException, SAXException, InlineAttachmentProcessingException, BundleMappingException, AttachmentNotFoundException {
+            throws JsonProcessingException, JAXBException, SAXException,
+                InlineAttachmentProcessingException, BundleMappingException, AttachmentNotFoundException {
 
         InboundMessage inboundMessage = new InboundMessage();
         prepareMocks(inboundMessage);
 
         ehrExtractMessageHandler.handleMessage(inboundMessage, CONVERSATION_ID);
 
-        verify(attachmentReferenceUpdaterService).updateReferenceToAttachment(inboundMessage.getAttachments(), CONVERSATION_ID, inboundMessage.getPayload());
+        verify(attachmentReferenceUpdaterService).updateReferenceToAttachment(
+                inboundMessage.getAttachments(), CONVERSATION_ID, inboundMessage.getPayload());
     }
 
     @Test
     public void When_HandleMessageWithValidDataIsCalled_Expect_CallSendContinueRequest()
-            throws JsonProcessingException, JAXBException, SAXException, InlineAttachmentProcessingException, BundleMappingException, AttachmentNotFoundException {
+            throws JsonProcessingException, JAXBException, SAXException,
+                InlineAttachmentProcessingException, BundleMappingException, AttachmentNotFoundException {
         final String REFERENCES_ATTACHMENTS_PATH = "/Envelope/Body/Manifest/Reference";
 
         Bundle bundle = new Bundle();
@@ -248,7 +254,10 @@ public class EhrExtractMessageHandlerTest {
         when(objectMapper.writeValueAsString(inboundMessage)).thenReturn(INBOUND_MESSAGE_STRING);
         when(migrationRequestDao.getMigrationRequest(CONVERSATION_ID)).thenReturn(migrationRequest);
         when(migrationStatusLogService.getLatestMigrationStatusLog(CONVERSATION_ID)).thenReturn(migrationStatusLog);
-        when(attachmentReferenceUpdaterService.updateReferenceToAttachment(inboundMessage.getAttachments(), CONVERSATION_ID, inboundMessage.getPayload())).thenReturn(inboundMessage.getPayload());
+        var payload = inboundMessage.getPayload();
+        when(attachmentReferenceUpdaterService
+                .updateReferenceToAttachment(inboundMessage.getAttachments(), CONVERSATION_ID, payload))
+                .thenReturn(payload);
 
         when(xPathService.parseDocumentFromXml(inboundMessage.getEbXML()))
             .thenReturn(xPathService2.parseDocumentFromXml(inboundMessage.getEbXML()));
@@ -281,7 +290,8 @@ public class EhrExtractMessageHandlerTest {
 
     @Test
     public void When_HandleMessageWithValidDataIsCalled_Expect_CallsStatusLogServiceUpdatePatientMigrationRequestAndAddMigrationStatusLog()
-            throws JsonProcessingException, JAXBException, SAXException, InlineAttachmentProcessingException, BundleMappingException, AttachmentNotFoundException {
+            throws JsonProcessingException, JAXBException, SAXException,
+                InlineAttachmentProcessingException, BundleMappingException, AttachmentNotFoundException {
 
         InboundMessage inboundMessage = new InboundMessage();
         prepareMocks(inboundMessage);
@@ -311,12 +321,13 @@ public class EhrExtractMessageHandlerTest {
         doThrow(new InlineAttachmentProcessingException("Test Exception"))
             .when(attachmentHandlerService).storeAttachments(any(), any());
 
-        assertThrows(InlineAttachmentProcessingException.class, () -> ehrExtractMessageHandler.handleMessage(inboundMessage,
-            CONVERSATION_ID));
+        assertThrows(InlineAttachmentProcessingException.class, () ->
+                        ehrExtractMessageHandler.handleMessage(inboundMessage, CONVERSATION_ID));
     }
 
     @Test
-    public void When_HandleMessage_WithMapToBundleThrows_Expect_BundleMappingException() throws BundleMappingException, AttachmentNotFoundException, ValidationException, InlineAttachmentProcessingException {
+    public void When_HandleMessage_WithMapToBundleThrows_Expect_BundleMappingException()
+            throws BundleMappingException, AttachmentNotFoundException, ValidationException, InlineAttachmentProcessingException {
         InboundMessage inboundMessage = new InboundMessage();
         inboundMessage.setPayload(readInboundMessagePayloadFromFile());
 
@@ -328,7 +339,9 @@ public class EhrExtractMessageHandlerTest {
                 .build();
 
         when(migrationRequestDao.getMigrationRequest(CONVERSATION_ID)).thenReturn(migrationRequest);
-        when(attachmentReferenceUpdaterService.updateReferenceToAttachment(inboundMessage.getAttachments(), CONVERSATION_ID, inboundMessage.getPayload())).thenReturn(inboundMessage.getPayload());
+        when(attachmentReferenceUpdaterService
+                .updateReferenceToAttachment(inboundMessage.getAttachments(), CONVERSATION_ID, inboundMessage.getPayload()))
+                .thenReturn(inboundMessage.getPayload());
 
         doThrow(new BundleMappingException("Test Exception"))
             .when(bundleMapperService).mapToBundle(any(), any());
@@ -337,7 +350,8 @@ public class EhrExtractMessageHandlerTest {
     }
 
     @Test
-    public void When_HandleMessage_WithEncodeToJsonThrows_Expect_DataFormatException() throws BundleMappingException, AttachmentNotFoundException, ValidationException, InlineAttachmentProcessingException {
+    public void When_HandleMessage_WithEncodeToJsonThrows_Expect_DataFormatException()
+            throws BundleMappingException, AttachmentNotFoundException, ValidationException, InlineAttachmentProcessingException {
         InboundMessage inboundMessage = new InboundMessage();
         inboundMessage.setPayload(readInboundMessagePayloadFromFile());
         Bundle bundle = new Bundle();
@@ -352,7 +366,9 @@ public class EhrExtractMessageHandlerTest {
 
         when(bundleMapperService.mapToBundle(any(RCMRIN030000UK06Message.class), eq(LOSING_ODE_CODE))).thenReturn(bundle);
         when(migrationRequestDao.getMigrationRequest(CONVERSATION_ID)).thenReturn(migrationRequest);
-        when(attachmentReferenceUpdaterService.updateReferenceToAttachment(inboundMessage.getAttachments(), CONVERSATION_ID, inboundMessage.getPayload())).thenReturn(inboundMessage.getPayload());
+        when(attachmentReferenceUpdaterService
+                .updateReferenceToAttachment(inboundMessage.getAttachments(), CONVERSATION_ID, inboundMessage.getPayload()))
+                .thenReturn(inboundMessage.getPayload());
 
         doThrow(new DataFormatException()).when(fhirParser).encodeToJson(bundle);
 

--- a/gp2gp-translator/src/test/java/uk/nhs/adaptors/pss/translator/task/MhsQueueMessageHandlerTest.java
+++ b/gp2gp-translator/src/test/java/uk/nhs/adaptors/pss/translator/task/MhsQueueMessageHandlerTest.java
@@ -92,8 +92,9 @@ public class MhsQueueMessageHandlerTest {
     }
 
     @Test
-    public void handleEhrExtractMessageWhenEhrExtractMessageHandlerThrowsErrorShouldReturnFalse() throws JAXBException,
-            JsonProcessingException, SAXException, InlineAttachmentProcessingException, BundleMappingException, AttachmentNotFoundException {
+    public void handleEhrExtractMessageWhenEhrExtractMessageHandlerThrowsErrorShouldReturnFalse()
+            throws JAXBException, JsonProcessingException, SAXException,
+                InlineAttachmentProcessingException, BundleMappingException, AttachmentNotFoundException {
 
         inboundMessage = new InboundMessage();
         prepareMocks(EHR_EXTRACT_INTERACTION_ID);

--- a/gp2gp-translator/src/test/java/uk/nhs/adaptors/pss/translator/task/MhsQueueMessageHandlerTest.java
+++ b/gp2gp-translator/src/test/java/uk/nhs/adaptors/pss/translator/task/MhsQueueMessageHandlerTest.java
@@ -30,6 +30,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import lombok.SneakyThrows;
 import uk.nhs.adaptors.common.service.MDCService;
 import uk.nhs.adaptors.pss.translator.amqp.JmsReader;
+import uk.nhs.adaptors.pss.translator.exception.AttachmentNotFoundException;
 import uk.nhs.adaptors.pss.translator.exception.BundleMappingException;
 import uk.nhs.adaptors.pss.translator.exception.InlineAttachmentProcessingException;
 import uk.nhs.adaptors.pss.translator.mhs.model.InboundMessage;
@@ -78,7 +79,7 @@ public class MhsQueueMessageHandlerTest {
 
     @Test
     public void handleEhrExtractMessageWithoutErrorsShouldReturnTrue() throws JsonProcessingException, JAXBException,
-        SAXException, InlineAttachmentProcessingException, BundleMappingException {
+            SAXException, InlineAttachmentProcessingException, BundleMappingException, AttachmentNotFoundException {
         inboundMessage = new InboundMessage();
         prepareMocks(EHR_EXTRACT_INTERACTION_ID);
 
@@ -92,7 +93,7 @@ public class MhsQueueMessageHandlerTest {
 
     @Test
     public void handleEhrExtractMessageWhenEhrExtractMessageHandlerThrowsErrorShouldReturnFalse() throws JAXBException,
-        JsonProcessingException, SAXException, InlineAttachmentProcessingException, BundleMappingException {
+            JsonProcessingException, SAXException, InlineAttachmentProcessingException, BundleMappingException, AttachmentNotFoundException {
 
         inboundMessage = new InboundMessage();
         prepareMocks(EHR_EXTRACT_INTERACTION_ID);


### PR DESCRIPTION
Ticket: https://gpitbjss.atlassian.net/browse/NIAD-2031

Purpose: enable documents to be downloaded via the GPC Facade

Technical details:
- added a AttachmentReferenceUpdaterService and relevant tests which for each attachment:
1.  gets the file name & when the filename is present as a "reference" in the payload xml
2. replaces the local reference to be one pulled from the storage service(s)
- added 'getFileLocation' method to storage manage and all storage specific implementations of storage service