### PR TITLE
NIAD-2582: Bugfix - NACK should not be processed for a conversation after final ack has been sent

### DIFF
--- a/gp2gp-translator/src/integrationTest/java/uk/nhs/adaptors/pss/translator/AcknowledgeMessageHandlingIT.java
+++ b/gp2gp-translator/src/integrationTest/java/uk/nhs/adaptors/pss/translator/AcknowledgeMessageHandlingIT.java
@@ -4,6 +4,7 @@ import static org.awaitility.Awaitility.await;
 import static org.springframework.boot.test.context.SpringBootTest.WebEnvironment.RANDOM_PORT;
 
 import static uk.nhs.adaptors.common.util.FileUtil.readResourceAsString;
+import static uk.nhs.adaptors.connector.model.MigrationStatus.EHR_EXTRACT_REQUEST_ACCEPTED;
 import static uk.nhs.adaptors.connector.model.MigrationStatus.EHR_EXTRACT_REQUEST_ACKNOWLEDGED;
 import static uk.nhs.adaptors.connector.model.MigrationStatus.EHR_EXTRACT_REQUEST_NEGATIVE_ACK;
 
@@ -61,6 +62,7 @@ public class AcknowledgeMessageHandlingIT {
     public void setUp() {
         conversationId = generateConversationId();
         patientMigrationRequestDao.addNewRequest(generatePatientNhsNumber(), conversationId, LOSING_ODS_CODE, WINNING_ODS_CODE);
+        migrationStatusLogService.addMigrationStatusLog(EHR_EXTRACT_REQUEST_ACCEPTED, conversationId, null);
     }
 
     @Test


### PR DESCRIPTION
**Acceptance Criteria** 

If the latest migration status of a transfer is `FINAL_ACK_SENT` then any further NACK message sent by the incumbent should not be processed.   