### PR TITLE
Niad-2509: bugfix - medication request prepended true

### DIFF
--- a/gp2gp-translator/src/integrationTest/resources/e2e-mapping/output-json/PWTP4-output.json
+++ b/gp2gp-translator/src/integrationTest/resources/e2e-mapping/output-json/PWTP4-output.json
@@ -4343,7 +4343,7 @@
               {
                 "url": "statusReason",
                 "valueCodeableConcept": {
-                  "text": "true Patient no longer requires these "
+                  "text": "Patient no longer requires these"
                 }
               }
             ]
@@ -4959,7 +4959,7 @@
               {
                 "url": "statusReason",
                 "valueCodeableConcept": {
-                  "text": "true zzzzzss "
+                  "text": "zzzzzss"
                 }
               }
             ]
@@ -5278,7 +5278,7 @@
               {
                 "url": "statusReason",
                 "valueCodeableConcept": {
-                  "text": "true allergy "
+                  "text": "allergy"
                 }
               }
             ]
@@ -7445,7 +7445,7 @@
               {
                 "url": "statusReason",
                 "valueCodeableConcept": {
-                  "text": "true Allergy "
+                  "text": "Allergy"
                 }
               }
             ]
@@ -7754,7 +7754,7 @@
               {
                 "url": "statusReason",
                 "valueCodeableConcept": {
-                  "text": "true Alergy "
+                  "text": "Alergy"
                 }
               }
             ]
@@ -8145,7 +8145,7 @@
               {
                 "url": "statusReason",
                 "valueCodeableConcept": {
-                  "text": "true John said "
+                  "text": "John said"
                 }
               }
             ]
@@ -9052,7 +9052,7 @@
               {
                 "url": "statusReason",
                 "valueCodeableConcept": {
-                  "text": "true kjhkjkjhjkjkj "
+                  "text": "kjhkjkjhjkjkj"
                 }
               }
             ]
@@ -9352,12 +9352,6 @@
               {
                 "url": "statusChangeDate",
                 "valueDateTime": "2010-03-23"
-              },
-              {
-                "url": "statusReason",
-                "valueCodeableConcept": {
-                  "text": "true "
-                }
               }
             ]
           },
@@ -13301,7 +13295,7 @@
               {
                 "url": "statusReason",
                 "valueCodeableConcept": {
-                  "text": "true some reason "
+                  "text": "some reason"
                 }
               }
             ]
@@ -13616,7 +13610,7 @@
               {
                 "url": "statusReason",
                 "valueCodeableConcept": {
-                  "text": "true Recreate 22047 "
+                  "text": "Recreate 22047"
                 }
               }
             ]
@@ -13770,7 +13764,7 @@
               {
                 "url": "statusReason",
                 "valueCodeableConcept": {
-                  "text": "true End course for acute post G -> T switch for 22047 "
+                  "text": "End course for acute post G -> T switch for 22047"
                 }
               }
             ]

--- a/gp2gp-translator/src/integrationTest/resources/e2e-mapping/output-json/PWTP4-output.json
+++ b/gp2gp-translator/src/integrationTest/resources/e2e-mapping/output-json/PWTP4-output.json
@@ -4367,7 +4367,7 @@
             "value": "057C98BF-CE2C-4F14-AF6B-EA7099088F0B"
           }
         ],
-        "status": "completed",
+        "status": "stopped",
         "intent": "plan",
         "medicationReference": {
           "reference": "Medication/1cb87799-4298-43c0-b526-104ff7b4d7cd"
@@ -4983,7 +4983,7 @@
             "value": "44771183-640A-4363-A14F-3096E8FAEED4"
           }
         ],
-        "status": "completed",
+        "status": "stopped",
         "intent": "plan",
         "medicationReference": {
           "reference": "Medication/014b5b50-718f-4b6e-92ef-0f997a9dda4d"
@@ -5302,7 +5302,7 @@
             "value": "8627572C-BAE5-4325-897E-F346C0B1F91B"
           }
         ],
-        "status": "completed",
+        "status": "stopped",
         "intent": "plan",
         "medicationReference": {
           "reference": "Medication/510efe79-fe85-4c29-a608-22396af3cd96"
@@ -7469,7 +7469,7 @@
             "value": "54BE52A7-6C07-4402-A57F-024B3C6A391E"
           }
         ],
-        "status": "completed",
+        "status": "stopped",
         "intent": "plan",
         "medicationReference": {
           "reference": "Medication/a0c09dc7-eafb-4b5e-9a3a-332c0cc745bb"
@@ -7778,7 +7778,7 @@
             "value": "60F73E74-25C6-4614-9507-B52134733085"
           }
         ],
-        "status": "completed",
+        "status": "stopped",
         "intent": "plan",
         "medicationReference": {
           "reference": "Medication/6fe495da-1920-4551-ae08-be19d3b83084"
@@ -8169,7 +8169,7 @@
             "value": "C3DE337C-18BE-4379-9EE8-38683327B53A"
           }
         ],
-        "status": "completed",
+        "status": "stopped",
         "intent": "plan",
         "medicationReference": {
           "reference": "Medication/4a362b9b-6d58-45a4-b5d0-63b3dd4c873c"
@@ -9076,7 +9076,7 @@
             "value": "BA6AA3F4-100F-4994-A12E-F96E7C931917"
           }
         ],
-        "status": "completed",
+        "status": "stopped",
         "intent": "plan",
         "medicationReference": {
           "reference": "Medication/7e4a75e6-21d1-4b9d-88e9-581cc514d486"
@@ -9380,7 +9380,7 @@
             "value": "B8EFEECF-A365-4C69-AB6E-6C5EFB0F71BD"
           }
         ],
-        "status": "completed",
+        "status": "stopped",
         "intent": "plan",
         "medicationReference": {
           "reference": "Medication/899ea7fe-366d-4a9e-8806-c0bafac12b17"
@@ -13325,7 +13325,7 @@
             "value": "8ACB6933-1543-47CF-B166-9938ABFCFDEE"
           }
         ],
-        "status": "completed",
+        "status": "stopped",
         "intent": "plan",
         "medicationReference": {
           "reference": "Medication/6fe495da-1920-4551-ae08-be19d3b83084"
@@ -13640,7 +13640,7 @@
             "value": "AB0A4AA9-79BB-4663-84E5-AD10DA05D50F"
           }
         ],
-        "status": "completed",
+        "status": "stopped",
         "intent": "plan",
         "medicationReference": {
           "reference": "Medication/2cbe3115-5f61-495a-8267-b42be82f3d9c"
@@ -13794,7 +13794,7 @@
             "value": "1458EF9E-D0EA-4745-BB46-C38668E0EC0C"
           }
         ],
-        "status": "completed",
+        "status": "stopped",
         "intent": "plan",
         "medicationReference": {
           "reference": "Medication/27ced5eb-791c-4766-900b-b6486ca9639f"

--- a/gp2gp-translator/src/integrationTest/resources/e2e-mapping/output-json/PWTP4-output.json
+++ b/gp2gp-translator/src/integrationTest/resources/e2e-mapping/output-json/PWTP4-output.json
@@ -9352,6 +9352,12 @@
               {
                 "url": "statusChangeDate",
                 "valueDateTime": "2010-03-23"
+              },
+              {
+                "url": "statusReason",
+                "valueCodeableConcept": {
+                  "text": "Medication Course Ended"
+                }
               }
             ]
           },

--- a/gp2gp-translator/src/integrationTest/resources/e2e-mapping/output-json/PWTP4-output.json
+++ b/gp2gp-translator/src/integrationTest/resources/e2e-mapping/output-json/PWTP4-output.json
@@ -9356,7 +9356,7 @@
               {
                 "url": "statusReason",
                 "valueCodeableConcept": {
-                  "text": "Medication Course Ended"
+                  "text": "No information available"
                 }
               }
             ]

--- a/gp2gp-translator/src/integrationTest/resources/json/expectedBundle.json
+++ b/gp2gp-translator/src/integrationTest/resources/json/expectedBundle.json
@@ -5857,7 +5857,7 @@
             "value": "87102979-C329-4194-819B-D057AAEA625B"
           }
         ],
-        "status": "completed",
+        "status": "stopped",
         "intent": "plan",
         "medicationReference": {
           "reference": "Medication/810fca00-091b-48be-80e0-343e20cac7b6"
@@ -6243,7 +6243,7 @@
             "value": "EA0D236C-2CD7-49EB-80D2-9AD58C3969F4"
           }
         ],
-        "status": "completed",
+        "status": "stopped",
         "intent": "plan",
         "medicationReference": {
           "reference": "Medication/ebfad4df-a985-409b-a474-789390b02cd4"
@@ -6784,7 +6784,7 @@
             "value": "E2E527ED-E7FB-4161-9D3C-04FF121BF267"
           }
         ],
-        "status": "completed",
+        "status": "stopped",
         "intent": "plan",
         "medicationReference": {
           "reference": "Medication/e8255910-06da-4bd0-80f5-f3fceecc3be7"
@@ -7253,7 +7253,7 @@
             "value": "5B72BB13-10A8-4AB3-8E13-B2C8428677BB"
           }
         ],
-        "status": "completed",
+        "status": "stopped",
         "intent": "plan",
         "medicationReference": {
           "reference": "Medication/b6f82a45-3e3f-46d7-bb98-0d45dcef1413"
@@ -12118,7 +12118,7 @@
             "value": "9A11E815-9320-4952-96BA-CC83BECF62A3"
           }
         ],
-        "status": "completed",
+        "status": "stopped",
         "intent": "plan",
         "medicationReference": {
           "reference": "Medication/1c97181f-4dac-4a37-b5bb-82b76c02b417"
@@ -12499,7 +12499,7 @@
             "value": "EF7BFB69-2694-46AE-8845-A49B83A88F16"
           }
         ],
-        "status": "completed",
+        "status": "stopped",
         "intent": "plan",
         "medicationReference": {
           "reference": "Medication/10dd5ffe-9586-4b64-80ef-9f95a77cbecb"
@@ -12968,7 +12968,7 @@
             "value": "6F3E8A7A-7C40-4ACF-AD97-43A2E5DA6B29"
           }
         ],
-        "status": "completed",
+        "status": "stopped",
         "intent": "plan",
         "medicationReference": {
           "reference": "Medication/d9271371-6470-4fe6-9222-95c4c90f222d"
@@ -13885,7 +13885,7 @@
             "value": "BCF39DFD-A6ED-43F7-A9BE-5A25EB970C8B"
           }
         ],
-        "status": "completed",
+        "status": "stopped",
         "intent": "plan",
         "medicationReference": {
           "reference": "Medication/1f05b691-e16a-4a51-a6a6-71f732695635"
@@ -14408,7 +14408,7 @@
             "value": "64D224E0-DE90-49BB-AF2D-ECA90BA2CE0D"
           }
         ],
-        "status": "completed",
+        "status": "stopped",
         "intent": "plan",
         "medicationReference": {
           "reference": "Medication/df926634-ac87-4c85-af22-143bfd7fe40e"
@@ -20796,7 +20796,7 @@
             "value": "E96B55C1-7C8E-40CA-A6C0-A2951CFEE860"
           }
         ],
-        "status": "completed",
+        "status": "stopped",
         "intent": "plan",
         "medicationReference": {
           "reference": "Medication/5eee072e-ae4b-479d-98a1-42bf30e21089"
@@ -23471,7 +23471,7 @@
             "value": "2810EE1B-93EE-4417-B70B-C692AD0B2A17"
           }
         ],
-        "status": "completed",
+        "status": "stopped",
         "intent": "plan",
         "medicationReference": {
           "reference": "Medication/5eee072e-ae4b-479d-98a1-42bf30e21089"
@@ -24925,7 +24925,7 @@
             "value": "447AE7B0-FA1A-4BEA-A90F-68C35240C5F9"
           }
         ],
-        "status": "completed",
+        "status": "stopped",
         "intent": "plan",
         "medicationReference": {
           "reference": "Medication/0c5b1cbb-63b7-418d-9415-c5a0ba0c5cc6"
@@ -25360,7 +25360,7 @@
             "value": "77730A08-B78F-448A-8810-D6CBBF86420E"
           }
         ],
-        "status": "completed",
+        "status": "stopped",
         "intent": "plan",
         "medicationReference": {
           "reference": "Medication/d9271371-6470-4fe6-9222-95c4c90f222d"
@@ -26338,7 +26338,7 @@
             "value": "047E10B7-9A38-46A4-B34C-CEBD35C8A4B7"
           }
         ],
-        "status": "completed",
+        "status": "stopped",
         "intent": "plan",
         "medicationReference": {
           "reference": "Medication/39c7ef46-628c-46e0-9963-da229270a000"
@@ -26715,7 +26715,7 @@
             "value": "1751F68E-56EA-4DAE-904B-A1028952B01F"
           }
         ],
-        "status": "completed",
+        "status": "stopped",
         "intent": "plan",
         "medicationReference": {
           "reference": "Medication/44123956-bb4e-4417-a3ff-cf7e3c1dbb8f"

--- a/gp2gp-translator/src/integrationTest/resources/json/expectedBundle.json
+++ b/gp2gp-translator/src/integrationTest/resources/json/expectedBundle.json
@@ -5833,7 +5833,7 @@
               {
                 "url": "statusReason",
                 "valueCodeableConcept": {
-                  "text": "zzzzzss zzzzzss "
+                  "text": "zzzzzss"
                 }
               }
             ]
@@ -6219,7 +6219,7 @@
               {
                 "url": "statusReason",
                 "valueCodeableConcept": {
-                  "text": "Prescribing Error Prescribing Error "
+                  "text": "Prescribing Error"
                 }
               }
             ]
@@ -6760,7 +6760,7 @@
               {
                 "url": "statusReason",
                 "valueCodeableConcept": {
-                  "text": "Patient no longer requires these Patient no longer requires these "
+                  "text": "Patient no longer requires these"
                 }
               }
             ]
@@ -7229,7 +7229,7 @@
               {
                 "url": "statusReason",
                 "valueCodeableConcept": {
-                  "text": "Clinical Contra-indication Clinical Contra-indication "
+                  "text": "Clinical Contra-indication"
                 }
               }
             ]
@@ -12094,7 +12094,7 @@
               {
                 "url": "statusReason",
                 "valueCodeableConcept": {
-                  "text": "Allergy Allergy "
+                  "text": "Allergy"
                 }
               }
             ]
@@ -12475,7 +12475,7 @@
               {
                 "url": "statusReason",
                 "valueCodeableConcept": {
-                  "text": "Adverse reaction to Central Nervous System Drugs (allergy) Adverse reaction to Central Nervous System Drugs (allergy) "
+                  "text": "Adverse reaction to Central Nervous System Drugs (allergy)"
                 }
               }
             ]
@@ -12944,7 +12944,7 @@
               {
                 "url": "statusReason",
                 "valueCodeableConcept": {
-                  "text": "Alergy Alergy "
+                  "text": "Alergy"
                 }
               }
             ]
@@ -13861,7 +13861,7 @@
               {
                 "url": "statusReason",
                 "valueCodeableConcept": {
-                  "text": "kjhkjkjhjkjkj kjhkjkjhjkjkj "
+                  "text": "kjhkjkjhjkjkj"
                 }
               }
             ]
@@ -14384,7 +14384,7 @@
               {
                 "url": "statusReason",
                 "valueCodeableConcept": {
-                  "text": "Adverse reaction to Prednisolone (Fat, John said) Adverse reaction to Prednisolone (Fat, John said) "
+                  "text": "Adverse reaction to Prednisolone (Fat, John said)"
                 }
               }
             ]
@@ -20772,7 +20772,7 @@
               {
                 "url": "statusReason",
                 "valueCodeableConcept": {
-                  "text": "Clinical Grounds Clinical Grounds "
+                  "text": "Clinical Grounds"
                 }
               }
             ]
@@ -23447,7 +23447,7 @@
               {
                 "url": "statusReason",
                 "valueCodeableConcept": {
-                  "text": "Prescribing Error Prescribing Error "
+                  "text": "Prescribing Error"
                 }
               }
             ]
@@ -24901,7 +24901,7 @@
               {
                 "url": "statusReason",
                 "valueCodeableConcept": {
-                  "text": "Change to Medication Treatment Regime Change to Medication Treatment Regime "
+                  "text": "Change to Medication Treatment Regime"
                 }
               }
             ]
@@ -25336,7 +25336,7 @@
               {
                 "url": "statusReason",
                 "valueCodeableConcept": {
-                  "text": "some reason some reason "
+                  "text": "some reason"
                 }
               }
             ]
@@ -26314,7 +26314,7 @@
               {
                 "url": "statusReason",
                 "valueCodeableConcept": {
-                  "text": "Recreate 22047 Recreate 22047 "
+                  "text": "Recreate 22047"
                 }
               }
             ]
@@ -26691,7 +26691,7 @@
               {
                 "url": "statusReason",
                 "valueCodeableConcept": {
-                  "text": "End course for acute post G -> T switch for 22047 End course for acute post G -> T switch for 22047 "
+                  "text": "End course for acute post G -> T switch for 22047"
                 }
               }
             ]

--- a/gp2gp-translator/src/main/java/uk/nhs/adaptors/pss/translator/mapper/medication/MedicationRequestPlanMapper.java
+++ b/gp2gp-translator/src/main/java/uk/nhs/adaptors/pss/translator/mapper/medication/MedicationRequestPlanMapper.java
@@ -190,14 +190,7 @@ public class MedicationRequestPlanMapper {
             .filter(StringUtils::isNotBlank)
             .collect(Collectors.joining(", "));
 
-        String displayName = discontinue.getCode().getDisplayName();
-        String altText = displayName != null ? displayName : discontinue.getCode().getOriginalText();
-
-        if (altText == null) {
-            altText = MISSING_REASON_STRING;
-        }
-
-        return pertinentInfo.isEmpty() ? altText : pertinentInfo;
+        return pertinentInfo.isEmpty() ? MISSING_REASON_STRING : pertinentInfo;
     }
 
     private Optional<Reference> extractPriorPrescription(RCMRMT030101UK04Authorise supplyAuthorise) {

--- a/gp2gp-translator/src/main/java/uk/nhs/adaptors/pss/translator/mapper/medication/MedicationRequestPlanMapper.java
+++ b/gp2gp-translator/src/main/java/uk/nhs/adaptors/pss/translator/mapper/medication/MedicationRequestPlanMapper.java
@@ -1,6 +1,7 @@
 package uk.nhs.adaptors.pss.translator.mapper.medication;
 
 import static org.hl7.fhir.dstu3.model.MedicationRequest.MedicationRequestIntent.PLAN;
+import static org.hl7.fhir.dstu3.model.MedicationRequest.MedicationRequestStatus.ACTIVE;
 import static org.hl7.fhir.dstu3.model.MedicationRequest.MedicationRequestStatus.COMPLETED;
 import static org.hl7.fhir.dstu3.model.MedicationRequest.MedicationRequestStatus.STOPPED;
 
@@ -225,7 +226,7 @@ public class MedicationRequestPlanMapper {
             && COMPLETE.equals(supplyAuthorise.getStatusCode().getCode())) {
             return COMPLETED;
         } else {
-            return MedicationRequest.MedicationRequestStatus.ACTIVE;
+            return ACTIVE;
         }
     }
 

--- a/gp2gp-translator/src/test/java/uk/nhs/adaptors/pss/translator/mapper/medication/MedicationRequestPlanMapperTest.java
+++ b/gp2gp-translator/src/test/java/uk/nhs/adaptors/pss/translator/mapper/medication/MedicationRequestPlanMapperTest.java
@@ -154,6 +154,44 @@ public class MedicationRequestPlanMapperTest {
         assertThat(expiryDate.size()).isEqualTo(0);
     }
 
+    @Test
+    public void When_MappingDiscontinue_With_PertinentInformation_Expect_StatusReasonAdded() {
+        var ehrExtract = unmarshallEhrExtract("ehrExtract2.xml");
+        Optional<RCMRMT030101UK04MedicationStatement> medicationStatement = extractMedicationStatement(ehrExtract);
+        Optional<RCMRMT030101UK04Authorise> supplyAuthorise = extractSupplyAuthorise(medicationStatement.orElseThrow());
+
+        var medicationRequest =
+            medicationRequestPlanMapper.mapToPlanMedicationRequest(ehrExtract, medicationStatement.get(), supplyAuthorise.orElseThrow(),
+                PRACTISE_CODE);
+
+        var statusExt = medicationRequest.getExtensionsByUrl(MEDICATION_STATUS_REASON_URL);
+        assertThat(statusExt.size()).isEqualTo(1);
+
+        var statusReasonExt = statusExt.get(0).getExtensionsByUrl("statusReason");
+        assertThat(statusReasonExt.size()).isEqualTo(1);
+
+        var statusReason = (CodeableConcept) statusReasonExt.get(0).getValue();
+
+        assertThat(statusReason.getText()).isEqualTo("Patient no longer requires these");
+    }
+
+    @Test
+    public void When_MappingDiscontinue_With_MissingPertinentInformation_Expect_StatusReasonNotAdded() {
+        var ehrExtract = unmarshallEhrExtract("ehrExtract7.xml");
+        Optional<RCMRMT030101UK04MedicationStatement> medicationStatement = extractMedicationStatement(ehrExtract);
+        Optional<RCMRMT030101UK04Authorise> supplyAuthorise = extractSupplyAuthorise(medicationStatement.orElseThrow());
+
+        var medicationRequest =
+            medicationRequestPlanMapper.mapToPlanMedicationRequest(ehrExtract, medicationStatement.get(), supplyAuthorise.orElseThrow(),
+                PRACTISE_CODE);
+
+        var statusExt = medicationRequest.getExtensionsByUrl(MEDICATION_STATUS_REASON_URL);
+        assertThat(statusExt.size()).isEqualTo(1);
+
+        var statusReasonExt = statusExt.get(0).getExtensionsByUrl("statusReason");
+        assertThat(statusReasonExt.size()).isEqualTo(0);
+    }
+
     private Optional<RCMRMT030101UK04Authorise> extractSupplyAuthorise(RCMRMT030101UK04MedicationStatement medicationStatement) {
         return medicationStatement
             .getComponent()

--- a/gp2gp-translator/src/test/java/uk/nhs/adaptors/pss/translator/mapper/medication/MedicationRequestPlanMapperTest.java
+++ b/gp2gp-translator/src/test/java/uk/nhs/adaptors/pss/translator/mapper/medication/MedicationRequestPlanMapperTest.java
@@ -176,7 +176,7 @@ public class MedicationRequestPlanMapperTest {
     }
 
     @Test
-    public void When_MappingDiscontinue_With_MissingPertinentInformation_Expect_StatusReasonNotAdded() {
+    public void When_MappingDiscontinue_With_MissingPertinentInformationAndCodeDisplayPresent_Expect_DisplayAddedAsReason() {
         var ehrExtract = unmarshallEhrExtract("ehrExtract7.xml");
         Optional<RCMRMT030101UK04MedicationStatement> medicationStatement = extractMedicationStatement(ehrExtract);
         Optional<RCMRMT030101UK04Authorise> supplyAuthorise = extractSupplyAuthorise(medicationStatement.orElseThrow());
@@ -189,7 +189,50 @@ public class MedicationRequestPlanMapperTest {
         assertThat(statusExt.size()).isEqualTo(1);
 
         var statusReasonExt = statusExt.get(0).getExtensionsByUrl("statusReason");
-        assertThat(statusReasonExt.size()).isEqualTo(0);
+        assertThat(statusReasonExt.size()).isEqualTo(1);
+
+        var statusReason = (CodeableConcept) statusReasonExt.get(0).getValue();
+        assertThat(statusReason.getText()).isEqualTo("Medication Course Ended");
+    }
+
+    @Test
+    public void When_MappingDiscontinue_With_MissingPertinentInformationAndCodeDisplay_Expect_OriginalTextAddedAsReason() {
+        var ehrExtract = unmarshallEhrExtract("ehrExtract8.xml");
+        Optional<RCMRMT030101UK04MedicationStatement> medicationStatement = extractMedicationStatement(ehrExtract);
+        Optional<RCMRMT030101UK04Authorise> supplyAuthorise = extractSupplyAuthorise(medicationStatement.orElseThrow());
+
+        var medicationRequest =
+            medicationRequestPlanMapper.mapToPlanMedicationRequest(ehrExtract, medicationStatement.get(), supplyAuthorise.orElseThrow(),
+                PRACTISE_CODE);
+
+        var statusExt = medicationRequest.getExtensionsByUrl(MEDICATION_STATUS_REASON_URL);
+        assertThat(statusExt.size()).isEqualTo(1);
+
+        var statusReasonExt = statusExt.get(0).getExtensionsByUrl("statusReason");
+        assertThat(statusReasonExt.size()).isEqualTo(1);
+
+        var statusReason = (CodeableConcept) statusReasonExt.get(0).getValue();
+        assertThat(statusReason.getText()).isEqualTo("Ended");
+    }
+
+    @Test
+    public void When_MappingDiscontinue_With_MissingPertinentInformationAndCodeDisplayAndOriginalText_Expect_DefaultTextAddedAsReason() {
+        var ehrExtract = unmarshallEhrExtract("ehrExtract9.xml");
+        Optional<RCMRMT030101UK04MedicationStatement> medicationStatement = extractMedicationStatement(ehrExtract);
+        Optional<RCMRMT030101UK04Authorise> supplyAuthorise = extractSupplyAuthorise(medicationStatement.orElseThrow());
+
+        var medicationRequest =
+            medicationRequestPlanMapper.mapToPlanMedicationRequest(ehrExtract, medicationStatement.get(), supplyAuthorise.orElseThrow(),
+                PRACTISE_CODE);
+
+        var statusExt = medicationRequest.getExtensionsByUrl(MEDICATION_STATUS_REASON_URL);
+        assertThat(statusExt.size()).isEqualTo(1);
+
+        var statusReasonExt = statusExt.get(0).getExtensionsByUrl("statusReason");
+        assertThat(statusReasonExt.size()).isEqualTo(1);
+
+        var statusReason = (CodeableConcept) statusReasonExt.get(0).getValue();
+        assertThat(statusReason.getText()).isEqualTo("No information available");
     }
 
     private Optional<RCMRMT030101UK04Authorise> extractSupplyAuthorise(RCMRMT030101UK04MedicationStatement medicationStatement) {

--- a/gp2gp-translator/src/test/java/uk/nhs/adaptors/pss/translator/mapper/medication/MedicationRequestPlanMapperTest.java
+++ b/gp2gp-translator/src/test/java/uk/nhs/adaptors/pss/translator/mapper/medication/MedicationRequestPlanMapperTest.java
@@ -57,6 +57,7 @@ public class MedicationRequestPlanMapperTest {
         "https://fhir.nhs.uk/STU3/StructureDefinition/Extension-CareConnect-GPC-MedicationStatusReason-1";
     private static final String PRESCRIPTION_TYPE_URL =
         "https://fhir.nhs.uk/STU3/StructureDefinition/Extension-CareConnect-GPC-PrescriptionType-1";
+    private static final String DEFAULT_STATUS_REASON = "No information available";
 
     private static final int ONE = 1;
     private static final int TWO = 2;
@@ -176,7 +177,7 @@ public class MedicationRequestPlanMapperTest {
     }
 
     @Test
-    public void When_MappingDiscontinue_With_MissingPertinentInformationAndCodeDisplayPresent_Expect_DisplayAddedAsReason() {
+    public void When_MappingDiscontinue_With_MissingPertinentInformationAndCodeDisplayPresent_Expect_DefaultTextAddedAsReason() {
         var ehrExtract = unmarshallEhrExtract("ehrExtract7.xml");
         Optional<RCMRMT030101UK04MedicationStatement> medicationStatement = extractMedicationStatement(ehrExtract);
         Optional<RCMRMT030101UK04Authorise> supplyAuthorise = extractSupplyAuthorise(medicationStatement.orElseThrow());
@@ -192,11 +193,11 @@ public class MedicationRequestPlanMapperTest {
         assertThat(statusReasonExt.size()).isEqualTo(1);
 
         var statusReason = (CodeableConcept) statusReasonExt.get(0).getValue();
-        assertThat(statusReason.getText()).isEqualTo("Medication Course Ended");
+        assertThat(statusReason.getText()).isEqualTo(DEFAULT_STATUS_REASON);
     }
 
     @Test
-    public void When_MappingDiscontinue_With_MissingPertinentInformationAndCodeDisplay_Expect_OriginalTextAddedAsReason() {
+    public void When_MappingDiscontinue_With_MissingPertinentInformationAndCodeDisplay_Expect_DefaultTextAddedAsReason() {
         var ehrExtract = unmarshallEhrExtract("ehrExtract8.xml");
         Optional<RCMRMT030101UK04MedicationStatement> medicationStatement = extractMedicationStatement(ehrExtract);
         Optional<RCMRMT030101UK04Authorise> supplyAuthorise = extractSupplyAuthorise(medicationStatement.orElseThrow());
@@ -212,11 +213,11 @@ public class MedicationRequestPlanMapperTest {
         assertThat(statusReasonExt.size()).isEqualTo(1);
 
         var statusReason = (CodeableConcept) statusReasonExt.get(0).getValue();
-        assertThat(statusReason.getText()).isEqualTo("Ended");
+        assertThat(statusReason.getText()).isEqualTo(DEFAULT_STATUS_REASON);
     }
 
     @Test
-    public void When_MappingDiscontinue_With_MissingPertinentInformationAndCodeDisplayAndOriginalText_Expect_DefaultTextAddedAsReason() {
+    public void When_MappingDiscontinue_With_MissingPertinentInformation_Expect_DefaultTextAddedAsReason() {
         var ehrExtract = unmarshallEhrExtract("ehrExtract9.xml");
         Optional<RCMRMT030101UK04MedicationStatement> medicationStatement = extractMedicationStatement(ehrExtract);
         Optional<RCMRMT030101UK04Authorise> supplyAuthorise = extractSupplyAuthorise(medicationStatement.orElseThrow());
@@ -232,7 +233,7 @@ public class MedicationRequestPlanMapperTest {
         assertThat(statusReasonExt.size()).isEqualTo(1);
 
         var statusReason = (CodeableConcept) statusReasonExt.get(0).getValue();
-        assertThat(statusReason.getText()).isEqualTo("No information available");
+        assertThat(statusReason.getText()).isEqualTo(DEFAULT_STATUS_REASON);
     }
 
     private Optional<RCMRMT030101UK04Authorise> extractSupplyAuthorise(RCMRMT030101UK04MedicationStatement medicationStatement) {

--- a/gp2gp-translator/src/test/resources/xml/MedicationStatement/ehrExtract10.xml
+++ b/gp2gp-translator/src/test/resources/xml/MedicationStatement/ehrExtract10.xml
@@ -1,0 +1,97 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<EhrExtract xmlns="urn:hl7-org:v3" classCode="EXTRACT" moodCode="EVN">
+    <availabilityTime value="20100115"/>
+    <component typeCode="COMP">
+        <ehrFolder classCode="FOLDER" moodCode="EVN">
+            <component typeCode="COMP">
+                <ehrComposition classCode="COMPOSITION" moodCode="EVN">
+                    <component typeCode="COMP">
+                        <MedicationStatement xmlns="urn:hl7-org:v3" classCode="SBADM" moodCode="INT">
+                            <id root="B4D70A6D-2EE4-41B6-B1FB-F9F0AD84C503"/>
+                            <statusCode code="ACTIVE"/>
+                            <effectiveTime>
+                                <high value="20060426"/>
+                                <center nullFlavor="NI"/>
+                            </effectiveTime>
+                            <availabilityTime value="20100115"/>
+                            <consumable typeCode="CSM">
+                                <manufacturedProduct classCode="MANU">
+                                    <manufacturedMaterial classCode="MMAT" determinerCode="KIND">
+                                        <code code="RACA57NEMIS" codeSystem="2.16.840.1.113883.2.1.6.9"
+                                              displayName="Ramipril 10mg capsules">
+                                            <translation code="318906001" codeSystem="2.16.840.1.113883.2.1.3.2.4.15"
+                                                         displayName="Ramipril 10mg capsules"/>
+                                        </code>
+                                        <quantity value="28" unit="1">
+                                            <translation value="28">
+                                                <originalText>capsule</originalText>
+                                            </translation>
+                                        </quantity>
+                                    </manufacturedMaterial>
+                                </manufacturedProduct>
+                            </consumable>
+                            <component typeCode="COMP">
+                                <ehrSupplyAuthorise classCode="SPLY" moodCode="INT">
+                                    <id root="TEST_ID"/>
+                                    <code code="9bG0.00" codeSystem="2.16.840.1.113883.2.1.6.2"
+                                          displayName="NHS prescription"/>
+                                    <statusCode code="ACTIVE"/>
+                                    <effectiveTime>
+                                        <high value="20060427"/>
+                                        <center nullFlavor="NI"/>
+                                    </effectiveTime>
+                                    <availabilityTime value="20100114"/>
+                                    <repeatNumber value="6"/>
+                                    <quantity value="28" unit="1">
+                                        <translation value="28">
+                                            <originalText>capsule</originalText>
+                                        </translation>
+                                    </quantity>
+                                    <predecessor typeCode="SUCC">
+                                        <priorMedicationRef classCode="SBADM" moodCode="INT">
+                                            <id root="TEST_ID"/>
+                                        </priorMedicationRef>
+                                    </predecessor>
+                                    <pertinentInformation typeCode="PERT">
+                                        <pertinentSupplyAnnotation classCode="OBS" moodCode="EVN">
+                                            <text>Pharmacy Text: Repeat Dispensing Pharmacy Note. 1</text>
+                                        </pertinentSupplyAnnotation>
+                                    </pertinentInformation>
+                                    <pertinentInformation typeCode="PERT">
+                                        <pertinentSupplyAnnotation classCode="OBS" moodCode="EVN">
+                                            <text>Pharmacy Text: Repeat Dispensing Pharmacy Note. 2</text>
+                                        </pertinentSupplyAnnotation>
+                                    </pertinentInformation>
+                                </ehrSupplyAuthorise>
+                            </component>
+                            <component typeCode="COMP">
+                                <ehrSupplyPrescribe classCode="SPLY" moodCode="RQO">
+                                    <id root="9B4B797A-D674-4362-B666-2ADC8551EEDA"/>
+                                    <code code="394823007" displayName="NHS Prescription"
+                                          codeSystem="2.16.840.1.113883.2.1.3.2.4.15"/>
+                                    <statusCode code="COMPLETE"/>
+                                    <availabilityTime value="20060426"/>
+                                    <quantity value="1" unit="1">
+                                        <translation value="1">
+                                            <originalText>tablet(s)</originalText>
+                                        </translation>
+                                    </quantity>
+                                    <inFulfillmentOf typeCode="FLFS">
+                                        <priorMedicationRef moodCode="INT">
+                                            <id root="TEST_ID"/>
+                                        </priorMedicationRef>
+                                    </inFulfillmentOf>
+                                </ehrSupplyPrescribe>
+                            </component>
+                            <pertinentInformation typeCode="PERT">
+                                <pertinentMedicationDosage classCode="SBADM" moodCode="RMD">
+                                    <text>One To Be Taken Each Day</text>
+                                </pertinentMedicationDosage>
+                            </pertinentInformation>
+                        </MedicationStatement>
+                    </component>
+                </ehrComposition>
+            </component>
+        </ehrFolder>
+    </component>
+</EhrExtract>

--- a/gp2gp-translator/src/test/resources/xml/MedicationStatement/ehrExtract11.xml
+++ b/gp2gp-translator/src/test/resources/xml/MedicationStatement/ehrExtract11.xml
@@ -1,0 +1,97 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<EhrExtract xmlns="urn:hl7-org:v3" classCode="EXTRACT" moodCode="EVN">
+    <availabilityTime value="20100115"/>
+    <component typeCode="COMP">
+        <ehrFolder classCode="FOLDER" moodCode="EVN">
+            <component typeCode="COMP">
+                <ehrComposition classCode="COMPOSITION" moodCode="EVN">
+                    <component typeCode="COMP">
+                        <MedicationStatement xmlns="urn:hl7-org:v3" classCode="SBADM" moodCode="INT">
+                            <id root="B4D70A6D-2EE4-41B6-B1FB-F9F0AD84C503"/>
+                            <statusCode code="ACTIVE"/>
+                            <effectiveTime>
+                                <high value="20060426"/>
+                                <center nullFlavor="NI"/>
+                            </effectiveTime>
+                            <availabilityTime value="20100115"/>
+                            <consumable typeCode="CSM">
+                                <manufacturedProduct classCode="MANU">
+                                    <manufacturedMaterial classCode="MMAT" determinerCode="KIND">
+                                        <code code="RACA57NEMIS" codeSystem="2.16.840.1.113883.2.1.6.9"
+                                              displayName="Ramipril 10mg capsules">
+                                            <translation code="318906001" codeSystem="2.16.840.1.113883.2.1.3.2.4.15"
+                                                         displayName="Ramipril 10mg capsules"/>
+                                        </code>
+                                        <quantity value="28" unit="1">
+                                            <translation value="28">
+                                                <originalText>capsule</originalText>
+                                            </translation>
+                                        </quantity>
+                                    </manufacturedMaterial>
+                                </manufacturedProduct>
+                            </consumable>
+                            <component typeCode="COMP">
+                                <ehrSupplyAuthorise classCode="SPLY" moodCode="INT">
+                                    <id root="TEST_ID"/>
+                                    <code code="9bG0.00" codeSystem="2.16.840.1.113883.2.1.6.2"
+                                          displayName="NHS prescription"/>
+                                    <statusCode code="COMPLETE"/>
+                                    <effectiveTime>
+                                        <high value="20060427"/>
+                                        <center nullFlavor="NI"/>
+                                    </effectiveTime>
+                                    <availabilityTime value="20100114"/>
+                                    <repeatNumber value="6"/>
+                                    <quantity value="28" unit="1">
+                                        <translation value="28">
+                                            <originalText>capsule</originalText>
+                                        </translation>
+                                    </quantity>
+                                    <predecessor typeCode="SUCC">
+                                        <priorMedicationRef classCode="SBADM" moodCode="INT">
+                                            <id root="TEST_ID"/>
+                                        </priorMedicationRef>
+                                    </predecessor>
+                                    <pertinentInformation typeCode="PERT">
+                                        <pertinentSupplyAnnotation classCode="OBS" moodCode="EVN">
+                                            <text>Pharmacy Text: Repeat Dispensing Pharmacy Note. 1</text>
+                                        </pertinentSupplyAnnotation>
+                                    </pertinentInformation>
+                                    <pertinentInformation typeCode="PERT">
+                                        <pertinentSupplyAnnotation classCode="OBS" moodCode="EVN">
+                                            <text>Pharmacy Text: Repeat Dispensing Pharmacy Note. 2</text>
+                                        </pertinentSupplyAnnotation>
+                                    </pertinentInformation>
+                                </ehrSupplyAuthorise>
+                            </component>
+                            <component typeCode="COMP">
+                                <ehrSupplyPrescribe classCode="SPLY" moodCode="RQO">
+                                    <id root="9B4B797A-D674-4362-B666-2ADC8551EEDA"/>
+                                    <code code="394823007" displayName="NHS Prescription"
+                                          codeSystem="2.16.840.1.113883.2.1.3.2.4.15"/>
+                                    <statusCode code="COMPLETE"/>
+                                    <availabilityTime value="20060426"/>
+                                    <quantity value="1" unit="1">
+                                        <translation value="1">
+                                            <originalText>tablet(s)</originalText>
+                                        </translation>
+                                    </quantity>
+                                    <inFulfillmentOf typeCode="FLFS">
+                                        <priorMedicationRef moodCode="INT">
+                                            <id root="TEST_ID"/>
+                                        </priorMedicationRef>
+                                    </inFulfillmentOf>
+                                </ehrSupplyPrescribe>
+                            </component>
+                            <pertinentInformation typeCode="PERT">
+                                <pertinentMedicationDosage classCode="SBADM" moodCode="RMD">
+                                    <text>One To Be Taken Each Day</text>
+                                </pertinentMedicationDosage>
+                            </pertinentInformation>
+                        </MedicationStatement>
+                    </component>
+                </ehrComposition>
+            </component>
+        </ehrFolder>
+    </component>
+</EhrExtract>

--- a/gp2gp-translator/src/test/resources/xml/MedicationStatement/ehrExtract12.xml
+++ b/gp2gp-translator/src/test/resources/xml/MedicationStatement/ehrExtract12.xml
@@ -35,7 +35,7 @@
                                     <id root="TEST_ID"/>
                                     <code code="9bG0.00" codeSystem="2.16.840.1.113883.2.1.6.2"
                                           displayName="NHS prescription"/>
-                                    <statusCode code="COMPLETE"/>
+                                    <statusCode code="ACTIVE"/>
                                     <effectiveTime>
                                         <high value="20060427"/>
                                         <center nullFlavor="NI"/>

--- a/gp2gp-translator/src/test/resources/xml/MedicationStatement/ehrExtract12.xml
+++ b/gp2gp-translator/src/test/resources/xml/MedicationStatement/ehrExtract12.xml
@@ -1,0 +1,116 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<EhrExtract xmlns="urn:hl7-org:v3" classCode="EXTRACT" moodCode="EVN">
+    <availabilityTime value="20100115"/>
+    <component typeCode="COMP">
+        <ehrFolder classCode="FOLDER" moodCode="EVN">
+            <component typeCode="COMP">
+                <ehrComposition classCode="COMPOSITION" moodCode="EVN">
+                    <component typeCode="COMP">
+                        <MedicationStatement xmlns="urn:hl7-org:v3" classCode="SBADM" moodCode="INT">
+                            <id root="B4D70A6D-2EE4-41B6-B1FB-F9F0AD84C503"/>
+                            <statusCode code="ACTIVE"/>
+                            <effectiveTime>
+                                <high value="20060426"/>
+                                <center nullFlavor="NI"/>
+                            </effectiveTime>
+                            <availabilityTime value="20100115"/>
+                            <consumable typeCode="CSM">
+                                <manufacturedProduct classCode="MANU">
+                                    <manufacturedMaterial classCode="MMAT" determinerCode="KIND">
+                                        <code code="RACA57NEMIS" codeSystem="2.16.840.1.113883.2.1.6.9"
+                                              displayName="Ramipril 10mg capsules">
+                                            <translation code="318906001" codeSystem="2.16.840.1.113883.2.1.3.2.4.15"
+                                                         displayName="Ramipril 10mg capsules"/>
+                                        </code>
+                                        <quantity value="28" unit="1">
+                                            <translation value="28">
+                                                <originalText>capsule</originalText>
+                                            </translation>
+                                        </quantity>
+                                    </manufacturedMaterial>
+                                </manufacturedProduct>
+                            </consumable>
+                            <component typeCode="COMP">
+                                <ehrSupplyAuthorise classCode="SPLY" moodCode="INT">
+                                    <id root="TEST_ID"/>
+                                    <code code="9bG0.00" codeSystem="2.16.840.1.113883.2.1.6.2"
+                                          displayName="NHS prescription"/>
+                                    <statusCode code="COMPLETE"/>
+                                    <effectiveTime>
+                                        <high value="20060427"/>
+                                        <center nullFlavor="NI"/>
+                                    </effectiveTime>
+                                    <availabilityTime value="20100114"/>
+                                    <repeatNumber value="6"/>
+                                    <quantity value="28" unit="1">
+                                        <translation value="28">
+                                            <originalText>capsule</originalText>
+                                        </translation>
+                                    </quantity>
+                                    <predecessor typeCode="SUCC">
+                                        <priorMedicationRef classCode="SBADM" moodCode="INT">
+                                            <id root="TEST_ID"/>
+                                        </priorMedicationRef>
+                                    </predecessor>
+                                    <pertinentInformation typeCode="PERT">
+                                        <pertinentSupplyAnnotation classCode="OBS" moodCode="EVN">
+                                            <text>Pharmacy Text: Repeat Dispensing Pharmacy Note. 1</text>
+                                        </pertinentSupplyAnnotation>
+                                    </pertinentInformation>
+                                    <pertinentInformation typeCode="PERT">
+                                        <pertinentSupplyAnnotation classCode="OBS" moodCode="EVN">
+                                            <text>Pharmacy Text: Repeat Dispensing Pharmacy Note. 2</text>
+                                        </pertinentSupplyAnnotation>
+                                    </pertinentInformation>
+                                </ehrSupplyAuthorise>
+                            </component>
+                            <component typeCode="COMP">
+                                <ehrSupplyPrescribe classCode="SPLY" moodCode="RQO">
+                                    <id root="9B4B797A-D674-4362-B666-2ADC8551EEDA"/>
+                                    <code code="394823007" displayName="NHS Prescription"
+                                          codeSystem="2.16.840.1.113883.2.1.3.2.4.15"/>
+                                    <statusCode code="COMPLETE"/>
+                                    <availabilityTime value="20060426"/>
+                                    <quantity value="1" unit="1">
+                                        <translation value="1">
+                                            <originalText>tablet(s)</originalText>
+                                        </translation>
+                                    </quantity>
+                                    <inFulfillmentOf typeCode="FLFS">
+                                        <priorMedicationRef moodCode="INT">
+                                            <id root="TEST_ID"/>
+                                        </priorMedicationRef>
+                                    </inFulfillmentOf>
+                                </ehrSupplyPrescribe>
+                            </component>
+                            <component typeCode="COMP">
+                                <ehrSupplyDiscontinue classCode="SPLY" moodCode="RQO">
+                                    <id root="D0BF39CA-E656-4322-879F-83EE6E688053"/>
+                                    <code code="EMISDRUG_DISCONTINUATION" codeSystem="2.16.840.1.113883.2.1.6.3"
+                                          displayName="Medication Course Ended"/>
+                                    <statusCode code="COMPLETE"/>
+                                    <availabilityTime nullFlavor="UNK"/>
+                                    <reversalOf typeCode="REV">
+                                        <priorMedicationRef classCode="SBADM" moodCode="ORD">
+                                            <id root="TEST_ID"/>
+                                        </priorMedicationRef>
+                                    </reversalOf>
+                                    <pertinentInformation typeCode="PERT">
+                                        <pertinentSupplyAnnotation classCode="OBS" moodCode="EVN">
+                                            <text>Patient no longer requires these</text>
+                                        </pertinentSupplyAnnotation>
+                                    </pertinentInformation>
+                                </ehrSupplyDiscontinue>
+                            </component>
+                            <pertinentInformation typeCode="PERT">
+                                <pertinentMedicationDosage classCode="SBADM" moodCode="RMD">
+                                    <text>One To Be Taken Each Day</text>
+                                </pertinentMedicationDosage>
+                            </pertinentInformation>
+                        </MedicationStatement>
+                    </component>
+                </ehrComposition>
+            </component>
+        </ehrFolder>
+    </component>
+</EhrExtract>

--- a/gp2gp-translator/src/test/resources/xml/MedicationStatement/ehrExtract7.xml
+++ b/gp2gp-translator/src/test/resources/xml/MedicationStatement/ehrExtract7.xml
@@ -1,0 +1,111 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<EhrExtract xmlns="urn:hl7-org:v3" classCode="EXTRACT" moodCode="EVN">
+    <availabilityTime value="20100115"/>
+    <component typeCode="COMP">
+        <ehrFolder classCode="FOLDER" moodCode="EVN">
+            <component typeCode="COMP">
+                <ehrComposition classCode="COMPOSITION" moodCode="EVN">
+                    <component typeCode="COMP">
+                        <MedicationStatement xmlns="urn:hl7-org:v3" classCode="SBADM" moodCode="INT">
+                            <id root="B4D70A6D-2EE4-41B6-B1FB-F9F0AD84C503"/>
+                            <statusCode code="ACTIVE"/>
+                            <effectiveTime>
+                                <high value="20060426"/>
+                                <center nullFlavor="NI"/>
+                            </effectiveTime>
+                            <availabilityTime value="20100115"/>
+                            <consumable typeCode="CSM">
+                                <manufacturedProduct classCode="MANU">
+                                    <manufacturedMaterial classCode="MMAT" determinerCode="KIND">
+                                        <code code="RACA57NEMIS" codeSystem="2.16.840.1.113883.2.1.6.9"
+                                              displayName="Ramipril 10mg capsules">
+                                            <translation code="318906001" codeSystem="2.16.840.1.113883.2.1.3.2.4.15"
+                                                         displayName="Ramipril 10mg capsules"/>
+                                        </code>
+                                        <quantity value="28" unit="1">
+                                            <translation value="28">
+                                                <originalText>capsule</originalText>
+                                            </translation>
+                                        </quantity>
+                                    </manufacturedMaterial>
+                                </manufacturedProduct>
+                            </consumable>
+                            <component typeCode="COMP">
+                                <ehrSupplyAuthorise classCode="SPLY" moodCode="INT">
+                                    <id root="TEST_ID"/>
+                                    <code code="9bG0.00" codeSystem="2.16.840.1.113883.2.1.6.2"
+                                          displayName="NHS prescription"/>
+                                    <statusCode code="ACTIVE"/>
+                                    <effectiveTime>
+                                        <high value="20060427"/>
+                                        <center nullFlavor="NI"/>
+                                    </effectiveTime>
+                                    <availabilityTime value="20100114"/>
+                                    <repeatNumber value="6"/>
+                                    <quantity value="28" unit="1">
+                                        <translation value="28">
+                                            <originalText>capsule</originalText>
+                                        </translation>
+                                    </quantity>
+                                    <predecessor typeCode="SUCC">
+                                        <priorMedicationRef classCode="SBADM" moodCode="INT">
+                                            <id root="TEST_ID"/>
+                                        </priorMedicationRef>
+                                    </predecessor>
+                                    <pertinentInformation typeCode="PERT">
+                                        <pertinentSupplyAnnotation classCode="OBS" moodCode="EVN">
+                                            <text>Pharmacy Text: Repeat Dispensing Pharmacy Note. 1</text>
+                                        </pertinentSupplyAnnotation>
+                                    </pertinentInformation>
+                                    <pertinentInformation typeCode="PERT">
+                                        <pertinentSupplyAnnotation classCode="OBS" moodCode="EVN">
+                                            <text>Pharmacy Text: Repeat Dispensing Pharmacy Note. 2</text>
+                                        </pertinentSupplyAnnotation>
+                                    </pertinentInformation>
+                                </ehrSupplyAuthorise>
+                            </component>
+                            <component typeCode="COMP">
+                                <ehrSupplyPrescribe classCode="SPLY" moodCode="RQO">
+                                    <id root="9B4B797A-D674-4362-B666-2ADC8551EEDA"/>
+                                    <code code="394823007" displayName="NHS Prescription"
+                                          codeSystem="2.16.840.1.113883.2.1.3.2.4.15"/>
+                                    <statusCode code="COMPLETE"/>
+                                    <availabilityTime value="20060426"/>
+                                    <quantity value="1" unit="1">
+                                        <translation value="1">
+                                            <originalText>tablet(s)</originalText>
+                                        </translation>
+                                    </quantity>
+                                    <inFulfillmentOf typeCode="FLFS">
+                                        <priorMedicationRef moodCode="INT">
+                                            <id root="TEST_ID"/>
+                                        </priorMedicationRef>
+                                    </inFulfillmentOf>
+                                </ehrSupplyPrescribe>
+                            </component>
+                            <component typeCode="COMP">
+                                <ehrSupplyDiscontinue classCode="SPLY" moodCode="RQO">
+                                    <id root="D0BF39CA-E656-4322-879F-83EE6E688053"/>
+                                    <code code="EMISDRUG_DISCONTINUATION" codeSystem="2.16.840.1.113883.2.1.6.3"
+                                          displayName="Medication Course Ended"/>
+                                    <statusCode code="COMPLETE"/>
+                                    <availabilityTime value="20060426"/>
+                                    <reversalOf typeCode="REV">
+                                        <priorMedicationRef classCode="SBADM" moodCode="ORD">
+                                            <id root="TEST_ID"/>
+                                        </priorMedicationRef>
+                                    </reversalOf>
+                                </ehrSupplyDiscontinue>
+                            </component>
+                            <pertinentInformation typeCode="PERT">
+                                <pertinentMedicationDosage classCode="SBADM" moodCode="RMD">
+                                    <text>One To Be Taken Each Day</text>
+                                </pertinentMedicationDosage>
+                            </pertinentInformation>
+                        </MedicationStatement>
+                    </component>
+                </ehrComposition>
+            </component>
+        </ehrFolder>
+    </component>
+</EhrExtract>

--- a/gp2gp-translator/src/test/resources/xml/MedicationStatement/ehrExtract8.xml
+++ b/gp2gp-translator/src/test/resources/xml/MedicationStatement/ehrExtract8.xml
@@ -1,0 +1,112 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<EhrExtract xmlns="urn:hl7-org:v3" classCode="EXTRACT" moodCode="EVN">
+    <availabilityTime value="20100115"/>
+    <component typeCode="COMP">
+        <ehrFolder classCode="FOLDER" moodCode="EVN">
+            <component typeCode="COMP">
+                <ehrComposition classCode="COMPOSITION" moodCode="EVN">
+                    <component typeCode="COMP">
+                        <MedicationStatement xmlns="urn:hl7-org:v3" classCode="SBADM" moodCode="INT">
+                            <id root="B4D70A6D-2EE4-41B6-B1FB-F9F0AD84C503"/>
+                            <statusCode code="ACTIVE"/>
+                            <effectiveTime>
+                                <high value="20060426"/>
+                                <center nullFlavor="NI"/>
+                            </effectiveTime>
+                            <availabilityTime value="20100115"/>
+                            <consumable typeCode="CSM">
+                                <manufacturedProduct classCode="MANU">
+                                    <manufacturedMaterial classCode="MMAT" determinerCode="KIND">
+                                        <code code="RACA57NEMIS" codeSystem="2.16.840.1.113883.2.1.6.9"
+                                              displayName="Ramipril 10mg capsules">
+                                            <translation code="318906001" codeSystem="2.16.840.1.113883.2.1.3.2.4.15"
+                                                         displayName="Ramipril 10mg capsules"/>
+                                        </code>
+                                        <quantity value="28" unit="1">
+                                            <translation value="28">
+                                                <originalText>capsule</originalText>
+                                            </translation>
+                                        </quantity>
+                                    </manufacturedMaterial>
+                                </manufacturedProduct>
+                            </consumable>
+                            <component typeCode="COMP">
+                                <ehrSupplyAuthorise classCode="SPLY" moodCode="INT">
+                                    <id root="TEST_ID"/>
+                                    <code code="9bG0.00" codeSystem="2.16.840.1.113883.2.1.6.2"
+                                          displayName="NHS prescription"/>
+                                    <statusCode code="ACTIVE"/>
+                                    <effectiveTime>
+                                        <high value="20060427"/>
+                                        <center nullFlavor="NI"/>
+                                    </effectiveTime>
+                                    <availabilityTime value="20100114"/>
+                                    <repeatNumber value="6"/>
+                                    <quantity value="28" unit="1">
+                                        <translation value="28">
+                                            <originalText>capsule</originalText>
+                                        </translation>
+                                    </quantity>
+                                    <predecessor typeCode="SUCC">
+                                        <priorMedicationRef classCode="SBADM" moodCode="INT">
+                                            <id root="TEST_ID"/>
+                                        </priorMedicationRef>
+                                    </predecessor>
+                                    <pertinentInformation typeCode="PERT">
+                                        <pertinentSupplyAnnotation classCode="OBS" moodCode="EVN">
+                                            <text>Pharmacy Text: Repeat Dispensing Pharmacy Note. 1</text>
+                                        </pertinentSupplyAnnotation>
+                                    </pertinentInformation>
+                                    <pertinentInformation typeCode="PERT">
+                                        <pertinentSupplyAnnotation classCode="OBS" moodCode="EVN">
+                                            <text>Pharmacy Text: Repeat Dispensing Pharmacy Note. 2</text>
+                                        </pertinentSupplyAnnotation>
+                                    </pertinentInformation>
+                                </ehrSupplyAuthorise>
+                            </component>
+                            <component typeCode="COMP">
+                                <ehrSupplyPrescribe classCode="SPLY" moodCode="RQO">
+                                    <id root="9B4B797A-D674-4362-B666-2ADC8551EEDA"/>
+                                    <code code="394823007" displayName="NHS Prescription"
+                                          codeSystem="2.16.840.1.113883.2.1.3.2.4.15"/>
+                                    <statusCode code="COMPLETE"/>
+                                    <availabilityTime value="20060426"/>
+                                    <quantity value="1" unit="1">
+                                        <translation value="1">
+                                            <originalText>tablet(s)</originalText>
+                                        </translation>
+                                    </quantity>
+                                    <inFulfillmentOf typeCode="FLFS">
+                                        <priorMedicationRef moodCode="INT">
+                                            <id root="TEST_ID"/>
+                                        </priorMedicationRef>
+                                    </inFulfillmentOf>
+                                </ehrSupplyPrescribe>
+                            </component>
+                            <component typeCode="COMP">
+                                <ehrSupplyDiscontinue classCode="SPLY" moodCode="RQO">
+                                    <id root="D0BF39CA-E656-4322-879F-83EE6E688053"/>
+                                    <code code="EMISDRUG_DISCONTINUATION" codeSystem="2.16.840.1.113883.2.1.6.3">
+                                        <originalText>Ended</originalText>
+                                    </code>
+                                    <statusCode code="COMPLETE"/>
+                                    <availabilityTime value="20060426"/>
+                                    <reversalOf typeCode="REV">
+                                        <priorMedicationRef classCode="SBADM" moodCode="ORD">
+                                            <id root="TEST_ID"/>
+                                        </priorMedicationRef>
+                                    </reversalOf>
+                                </ehrSupplyDiscontinue>
+                            </component>
+                            <pertinentInformation typeCode="PERT">
+                                <pertinentMedicationDosage classCode="SBADM" moodCode="RMD">
+                                    <text>One To Be Taken Each Day</text>
+                                </pertinentMedicationDosage>
+                            </pertinentInformation>
+                        </MedicationStatement>
+                    </component>
+                </ehrComposition>
+            </component>
+        </ehrFolder>
+    </component>
+</EhrExtract>

--- a/gp2gp-translator/src/test/resources/xml/MedicationStatement/ehrExtract9.xml
+++ b/gp2gp-translator/src/test/resources/xml/MedicationStatement/ehrExtract9.xml
@@ -1,0 +1,110 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<EhrExtract xmlns="urn:hl7-org:v3" classCode="EXTRACT" moodCode="EVN">
+    <availabilityTime value="20100115"/>
+    <component typeCode="COMP">
+        <ehrFolder classCode="FOLDER" moodCode="EVN">
+            <component typeCode="COMP">
+                <ehrComposition classCode="COMPOSITION" moodCode="EVN">
+                    <component typeCode="COMP">
+                        <MedicationStatement xmlns="urn:hl7-org:v3" classCode="SBADM" moodCode="INT">
+                            <id root="B4D70A6D-2EE4-41B6-B1FB-F9F0AD84C503"/>
+                            <statusCode code="ACTIVE"/>
+                            <effectiveTime>
+                                <high value="20060426"/>
+                                <center nullFlavor="NI"/>
+                            </effectiveTime>
+                            <availabilityTime value="20100115"/>
+                            <consumable typeCode="CSM">
+                                <manufacturedProduct classCode="MANU">
+                                    <manufacturedMaterial classCode="MMAT" determinerCode="KIND">
+                                        <code code="RACA57NEMIS" codeSystem="2.16.840.1.113883.2.1.6.9"
+                                              displayName="Ramipril 10mg capsules">
+                                            <translation code="318906001" codeSystem="2.16.840.1.113883.2.1.3.2.4.15"
+                                                         displayName="Ramipril 10mg capsules"/>
+                                        </code>
+                                        <quantity value="28" unit="1">
+                                            <translation value="28">
+                                                <originalText>capsule</originalText>
+                                            </translation>
+                                        </quantity>
+                                    </manufacturedMaterial>
+                                </manufacturedProduct>
+                            </consumable>
+                            <component typeCode="COMP">
+                                <ehrSupplyAuthorise classCode="SPLY" moodCode="INT">
+                                    <id root="TEST_ID"/>
+                                    <code code="9bG0.00" codeSystem="2.16.840.1.113883.2.1.6.2"
+                                          displayName="NHS prescription"/>
+                                    <statusCode code="ACTIVE"/>
+                                    <effectiveTime>
+                                        <high value="20060427"/>
+                                        <center nullFlavor="NI"/>
+                                    </effectiveTime>
+                                    <availabilityTime value="20100114"/>
+                                    <repeatNumber value="6"/>
+                                    <quantity value="28" unit="1">
+                                        <translation value="28">
+                                            <originalText>capsule</originalText>
+                                        </translation>
+                                    </quantity>
+                                    <predecessor typeCode="SUCC">
+                                        <priorMedicationRef classCode="SBADM" moodCode="INT">
+                                            <id root="TEST_ID"/>
+                                        </priorMedicationRef>
+                                    </predecessor>
+                                    <pertinentInformation typeCode="PERT">
+                                        <pertinentSupplyAnnotation classCode="OBS" moodCode="EVN">
+                                            <text>Pharmacy Text: Repeat Dispensing Pharmacy Note. 1</text>
+                                        </pertinentSupplyAnnotation>
+                                    </pertinentInformation>
+                                    <pertinentInformation typeCode="PERT">
+                                        <pertinentSupplyAnnotation classCode="OBS" moodCode="EVN">
+                                            <text>Pharmacy Text: Repeat Dispensing Pharmacy Note. 2</text>
+                                        </pertinentSupplyAnnotation>
+                                    </pertinentInformation>
+                                </ehrSupplyAuthorise>
+                            </component>
+                            <component typeCode="COMP">
+                                <ehrSupplyPrescribe classCode="SPLY" moodCode="RQO">
+                                    <id root="9B4B797A-D674-4362-B666-2ADC8551EEDA"/>
+                                    <code code="394823007" displayName="NHS Prescription"
+                                          codeSystem="2.16.840.1.113883.2.1.3.2.4.15"/>
+                                    <statusCode code="COMPLETE"/>
+                                    <availabilityTime value="20060426"/>
+                                    <quantity value="1" unit="1">
+                                        <translation value="1">
+                                            <originalText>tablet(s)</originalText>
+                                        </translation>
+                                    </quantity>
+                                    <inFulfillmentOf typeCode="FLFS">
+                                        <priorMedicationRef moodCode="INT">
+                                            <id root="TEST_ID"/>
+                                        </priorMedicationRef>
+                                    </inFulfillmentOf>
+                                </ehrSupplyPrescribe>
+                            </component>
+                            <component typeCode="COMP">
+                                <ehrSupplyDiscontinue classCode="SPLY" moodCode="RQO">
+                                    <id root="D0BF39CA-E656-4322-879F-83EE6E688053"/>
+                                    <code code="EMISDRUG_DISCONTINUATION" codeSystem="2.16.840.1.113883.2.1.6.3"/>
+                                    <statusCode code="COMPLETE"/>
+                                    <availabilityTime value="20060426"/>
+                                    <reversalOf typeCode="REV">
+                                        <priorMedicationRef classCode="SBADM" moodCode="ORD">
+                                            <id root="TEST_ID"/>
+                                        </priorMedicationRef>
+                                    </reversalOf>
+                                </ehrSupplyDiscontinue>
+                            </component>
+                            <pertinentInformation typeCode="PERT">
+                                <pertinentMedicationDosage classCode="SBADM" moodCode="RMD">
+                                    <text>One To Be Taken Each Day</text>
+                                </pertinentMedicationDosage>
+                            </pertinentInformation>
+                        </MedicationStatement>
+                    </component>
+                </ehrComposition>
+            </component>
+        </ehrFolder>
+    </component>
+</EhrExtract>


### PR DESCRIPTION
**Description**

We were expecting the term Expired to be here without the “True“ prefixing it, please investigate, confirm the logic with Martin Hillyard and fix if required following the discussion. 

**Investigation**

There was a coding error that inserted the Boolean value. However, the string itself was constructed from the discontinue's pertinent annotation, code and availability time. After discussion with Martin, it was decided a better approach was to use the pertinent information or a default string of "No information available", as per the GP Connect spec.

*Additional changes were identified as a result of the investigation:*

- If a discontinue request is present and it's possible to map the status reason extension, the status of the medication request should be `stopped`.  
- If the status changed date is unknown, then the status should be `completed` and the status reason extension omitted.       