### PR TITLE
NIAD-2489 Mapping Bug PWTP7: Document Reference does not have url or length parameters.

### DIFF
--- a/db-connector/changelog/migration/12-add-processedlength-column-to-patient_attachment-log-table.xml
+++ b/db-connector/changelog/migration/12-add-processedlength-column-to-patient_attachment-log-table.xml
@@ -11,9 +11,7 @@
 	http://www.liquibase.org/xml/ns/pro/liquibase-pro-4.1.xsd">
     <changeSet id="12" author="mwheeler">
         <addColumn schemaName="public" tableName="patient_attachment_log">
-            <column name="post_processed_length_num" type="int4" defaultValue="0">
-                <constraints nullable="false" unique="true"/>
-            </column>
+            <column name="post_processed_length_num" type="int4" defaultValue="0" />
         </addColumn>
     </changeSet>
 </databaseChangeLog>

--- a/db-connector/changelog/migration/12-add-processedlength-column-to-patient_attachment-log-table.xml
+++ b/db-connector/changelog/migration/12-add-processedlength-column-to-patient_attachment-log-table.xml
@@ -1,0 +1,19 @@
+<databaseChangeLog
+        xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xmlns:ext="http://www.liquibase.org/xml/ns/dbchangelog-ext"
+        xmlns:pro="http://www.liquibase.org/xml/ns/pro"
+        xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+	http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-4.1.xsd
+	http://www.liquibase.org/xml/ns/dbchangelog-ext
+	http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-ext.xsd
+    http://www.liquibase.org/xml/ns/pro
+	http://www.liquibase.org/xml/ns/pro/liquibase-pro-4.1.xsd">
+    <changeSet id="12" author="mwheeler">
+        <addColumn schemaName="public" tableName="patient_attachment_log">
+            <column name="post_processed_length_num" type="int4" defaultValue="0">
+                <constraints nullable="false" unique="true"/>
+            </column>
+        </addColumn>
+    </changeSet>
+</databaseChangeLog>

--- a/db-connector/src/main/java/uk/nhs/adaptors/connector/dao/PatientAttachmentLogDao.java
+++ b/db-connector/src/main/java/uk/nhs/adaptors/connector/dao/PatientAttachmentLogDao.java
@@ -27,7 +27,7 @@ public interface PatientAttachmentLogDao {
         @Bind() Boolean uploaded,
         @Bind() Integer orderNum,
         @Bind() Integer lengthNum,
-        @Bind() Integer postProcessLengthNum
+        @Bind() Integer postProcessedLengthNum
     );
 
     @SqlUpdate("delete_patient_attachment_log")

--- a/db-connector/src/main/java/uk/nhs/adaptors/connector/dao/PatientAttachmentLogDao.java
+++ b/db-connector/src/main/java/uk/nhs/adaptors/connector/dao/PatientAttachmentLogDao.java
@@ -26,7 +26,8 @@ public interface PatientAttachmentLogDao {
         @Bind() Boolean skeleton,
         @Bind() Boolean uploaded,
         @Bind() Integer orderNum,
-        @Bind() Integer lengthNum
+        @Bind() Integer lengthNum,
+        @Bind() Integer postProcessLengthNum
     );
 
     @SqlUpdate("delete_patient_attachment_log")
@@ -64,7 +65,8 @@ public interface PatientAttachmentLogDao {
         @Bind() Boolean skeleton,
         @Bind() Boolean uploaded,
         @Bind() Integer lengthNum,
-        @Bind() Integer orderNum
+        @Bind() Integer orderNum,
+        @Bind() Integer postProcessedLengthNum
     );
 
     @SqlQuery("count_attachments_for_migration_id")

--- a/db-connector/src/main/java/uk/nhs/adaptors/connector/mapper/PatientAttachmentLogRowMapper.java
+++ b/db-connector/src/main/java/uk/nhs/adaptors/connector/mapper/PatientAttachmentLogRowMapper.java
@@ -28,6 +28,7 @@ public class PatientAttachmentLogRowMapper implements RowMapper<PatientAttachmen
             .lengthNum(rs.getInt("length_num"))
             .orderNum(rs.getInt("order_num"))
             .deleted((rs.getBoolean("deleted")))
+                .postProcessedLengthNum(rs.getInt("post_processed_length_num"))
             .build();
     }
 }

--- a/db-connector/src/main/java/uk/nhs/adaptors/connector/mapper/PatientAttachmentLogRowMapper.java
+++ b/db-connector/src/main/java/uk/nhs/adaptors/connector/mapper/PatientAttachmentLogRowMapper.java
@@ -28,7 +28,7 @@ public class PatientAttachmentLogRowMapper implements RowMapper<PatientAttachmen
             .lengthNum(rs.getInt("length_num"))
             .orderNum(rs.getInt("order_num"))
             .deleted((rs.getBoolean("deleted")))
-                .postProcessedLengthNum(rs.getInt("post_processed_length_num"))
+            .postProcessedLengthNum(rs.getInt("post_processed_length_num"))
             .build();
     }
 }

--- a/db-connector/src/main/java/uk/nhs/adaptors/connector/model/PatientAttachmentLog.java
+++ b/db-connector/src/main/java/uk/nhs/adaptors/connector/model/PatientAttachmentLog.java
@@ -26,4 +26,5 @@ public class PatientAttachmentLog {
     private Integer patientMigrationReqId;
     private Integer orderNum;
     private Boolean deleted;
+    private Integer postProcessedLengthNum;
 }

--- a/db-connector/src/main/java/uk/nhs/adaptors/connector/service/PatientAttachmentLogService.java
+++ b/db-connector/src/main/java/uk/nhs/adaptors/connector/service/PatientAttachmentLogService.java
@@ -41,7 +41,8 @@ public class PatientAttachmentLogService {
             attachmentLogInput.getSkeleton(),
             attachmentLogInput.getUploaded(),
             attachmentLogInput.getOrderNum(),
-            attachmentLogInput.getLengthNum()
+            attachmentLogInput.getLengthNum(),
+            attachmentLogInput.getPostProcessedLengthNum()
         );
         LOGGER.debug("Created migration log mid=[{}] for patient migration request id=[{}]", mid, filename);
     }
@@ -102,7 +103,9 @@ public class PatientAttachmentLogService {
             attachmentLogInput.getSkeleton(),
             attachmentLogInput.getUploaded(),
             attachmentLogInput.getLengthNum(),
-            attachmentLogInput.getOrderNum()
+            attachmentLogInput.getOrderNum(),
+            attachmentLogInput.getPostProcessedLengthNum()
+
         );
         LOGGER.debug("Updated migration log mid=[{}]", mid);
     }

--- a/db-connector/src/main/resources/uk/nhs/adaptors/connector/dao/PatientAttachmentLogDao/insert_patient_attachment_log.sql
+++ b/db-connector/src/main/resources/uk/nhs/adaptors/connector/dao/PatientAttachmentLogDao/insert_patient_attachment_log.sql
@@ -10,7 +10,8 @@ INSERT INTO patient_attachment_log(
                                    skeleton,
                                    uploaded,
                                    order_num,
-                                   length_num
+                                   length_num,
+                                   post_processed_length_num
                                    )
 VALUES (
         :mid,
@@ -24,5 +25,6 @@ VALUES (
         :skeleton,
         COALESCE(:uploaded, false),
         COALESCE(:orderNum, 0),
-        :lengthNum
+        :lengthNum,
+        :postProcessedLengthNum
         );

--- a/db-connector/src/main/resources/uk/nhs/adaptors/connector/dao/PatientAttachmentLogDao/update_patient_attachment_log.sql
+++ b/db-connector/src/main/resources/uk/nhs/adaptors/connector/dao/PatientAttachmentLogDao/update_patient_attachment_log.sql
@@ -8,6 +8,7 @@ SET
     skeleton = COALESCE(:skeleton, PAL.skeleton),
     uploaded = COALESCE(:uploaded, PAL.uploaded),
     length_num = COALESCE(:lengthNum, PAL.length_num),
-    order_num = COALESCE(:orderNum, PAL.order_num)
+    order_num = COALESCE(:orderNum, PAL.order_num),
+    post_processed_length_num = COALESCE(:postProcessedLengthNum, PAL.post_processed_length_num)
 FROM patient_migration_request AS PMR
 WHERE PMR.conversation_id = :conversationId AND PAL.mid = :mid

--- a/gp2gp-translator/src/integrationTest/resources/e2e-mapping/output-json/PWTP7_vis-output.json
+++ b/gp2gp-translator/src/integrationTest/resources/e2e-mapping/output-json/PWTP7_vis-output.json
@@ -2726,7 +2726,6 @@
         "attachment": {
           "contentType": "text/plain",
           "url": "file://localhost/0FA498E2-DBC9-4A45-92BF-03A31844F490_Test_att_txt.txt",
-          "size": 0,
           "title": "0FA498E2-DBC9-4A45-92BF-03A31844F490_Test_att_txt.txt"
         }
       } ],
@@ -2772,7 +2771,6 @@
         "attachment": {
           "contentType": "application/msword",
           "url": "file://localhost/95B3D82A-BA16-4771-B2A4-03F9C0CCF87F_Test_att_doc.doc",
-          "size": 0,
           "title": "95B3D82A-BA16-4771-B2A4-03F9C0CCF87F_Test_att_doc.doc"
         }
       } ],
@@ -2818,7 +2816,6 @@
         "attachment": {
           "contentType": "GP2GP generated placeholder. Original document not available. See notes for details",
           "url": "file://localhost/3E12AB25-9A18-4239-93A6-2592F6DA9289_Test_att_bmp.bmp",
-          "size": 0,
           "title": "3E12AB25-9A18-4239-93A6-2592F6DA9289_Test_att_bmp.bmp"
         }
       } ],
@@ -2864,7 +2861,6 @@
         "attachment": {
           "contentType": "GP2GP generated placeholder. Original document not available. See notes for details",
           "url": "file://localhost/3AE27487-78D3-43CF-8356-3BF156F9B479_Test_att_gif.GIF",
-          "size": 0,
           "title": "3AE27487-78D3-43CF-8356-3BF156F9B479_Test_att_gif.GIF"
         }
       } ],
@@ -2910,7 +2906,6 @@
         "attachment": {
           "contentType": "GP2GP generated placeholder. Original document not available. See notes for details",
           "url": "file://localhost/F4AC3D0F-06D5-4A2C-8686-17B23A46F0A7_Test_att_jpg.JPG",
-          "size": 0,
           "title": "F4AC3D0F-06D5-4A2C-8686-17B23A46F0A7_Test_att_jpg.JPG"
         }
       } ],
@@ -2956,7 +2951,6 @@
         "attachment": {
           "contentType": "text/plain",
           "url": "file://localhost/997CDD95-120C-4B48-99FF-D73170F275AB_Fix%20for%20Consultation%20Place%20of%20Procedure.txt",
-          "size": 0,
           "title": "997CDD95-120C-4B48-99FF-D73170F275AB_Fix%20for%20Consultation%20Place%20of%20Procedure.txt"
         }
       } ],
@@ -3002,7 +2996,6 @@
         "attachment": {
           "contentType": "text/rtf",
           "url": "file://localhost/2AD22965-C1CE-4AC0-A013-64806E23AEFD_tmpATT_1.rtf",
-          "size": 0,
           "title": "2AD22965-C1CE-4AC0-A013-64806E23AEFD_tmpATT_1.rtf"
         }
       } ],

--- a/gp2gp-translator/src/integrationTest/resources/e2e-mapping/output-json/PWTP7_vis-output.json
+++ b/gp2gp-translator/src/integrationTest/resources/e2e-mapping/output-json/PWTP7_vis-output.json
@@ -2726,6 +2726,7 @@
         "attachment": {
           "contentType": "text/plain",
           "url": "file://localhost/0FA498E2-DBC9-4A45-92BF-03A31844F490_Test_att_txt.txt",
+          "size": 0,
           "title": "0FA498E2-DBC9-4A45-92BF-03A31844F490_Test_att_txt.txt"
         }
       } ],
@@ -2771,6 +2772,7 @@
         "attachment": {
           "contentType": "application/msword",
           "url": "file://localhost/95B3D82A-BA16-4771-B2A4-03F9C0CCF87F_Test_att_doc.doc",
+          "size": 0,
           "title": "95B3D82A-BA16-4771-B2A4-03F9C0CCF87F_Test_att_doc.doc"
         }
       } ],
@@ -2816,6 +2818,7 @@
         "attachment": {
           "contentType": "GP2GP generated placeholder. Original document not available. See notes for details",
           "url": "file://localhost/3E12AB25-9A18-4239-93A6-2592F6DA9289_Test_att_bmp.bmp",
+          "size": 0,
           "title": "3E12AB25-9A18-4239-93A6-2592F6DA9289_Test_att_bmp.bmp"
         }
       } ],
@@ -2861,6 +2864,7 @@
         "attachment": {
           "contentType": "GP2GP generated placeholder. Original document not available. See notes for details",
           "url": "file://localhost/3AE27487-78D3-43CF-8356-3BF156F9B479_Test_att_gif.GIF",
+          "size": 0,
           "title": "3AE27487-78D3-43CF-8356-3BF156F9B479_Test_att_gif.GIF"
         }
       } ],
@@ -2906,6 +2910,7 @@
         "attachment": {
           "contentType": "GP2GP generated placeholder. Original document not available. See notes for details",
           "url": "file://localhost/F4AC3D0F-06D5-4A2C-8686-17B23A46F0A7_Test_att_jpg.JPG",
+          "size": 0,
           "title": "F4AC3D0F-06D5-4A2C-8686-17B23A46F0A7_Test_att_jpg.JPG"
         }
       } ],
@@ -2951,6 +2956,7 @@
         "attachment": {
           "contentType": "text/plain",
           "url": "file://localhost/997CDD95-120C-4B48-99FF-D73170F275AB_Fix%20for%20Consultation%20Place%20of%20Procedure.txt",
+          "size": 0,
           "title": "997CDD95-120C-4B48-99FF-D73170F275AB_Fix%20for%20Consultation%20Place%20of%20Procedure.txt"
         }
       } ],
@@ -2996,6 +3002,7 @@
         "attachment": {
           "contentType": "text/rtf",
           "url": "file://localhost/2AD22965-C1CE-4AC0-A013-64806E23AEFD_tmpATT_1.rtf",
+          "size": 0,
           "title": "2AD22965-C1CE-4AC0-A013-64806E23AEFD_tmpATT_1.rtf"
         }
       } ],

--- a/gp2gp-translator/src/integrationTest/resources/json/LargeMessage/expectedBundleScenario1.json
+++ b/gp2gp-translator/src/integrationTest/resources/json/LargeMessage/expectedBundleScenario1.json
@@ -504,12 +504,13 @@
       "custodian": {
         "reference": "Organization/364fda08-aef3-414a-abdd-cb64152ee2d5"
       },
-      "description": "text/plain\nb6ae6bbd-53b8-4d76-b611-fdbad81eb3c6_277F29F1-FEAB-4D38-8266-FEB7A1E6227D_LICENSE.txt",
+      "description": "text/plain",
       "content": [ {
         "attachment": {
           "contentType": "text/plain",
           "url": "b6ae6bbd-53b8-4d76-b611-fdbad81eb3c6_277F29F1-FEAB-4D38-8266-FEB7A1E6227D_LICENSE.txt",
-          "title": "b6ae6bbd-53b8-4d76-b611-fdbad81eb3c6_277F29F1-FEAB-4D38-8266-FEB7A1E6227D_LICENSE.txt"
+          "title": "b6ae6bbd-53b8-4d76-b611-fdbad81eb3c6_277F29F1-FEAB-4D38-8266-FEB7A1E6227D_LICENSE.txt",
+          "size": 15416
         }
       } ],
       "context": {

--- a/gp2gp-translator/src/integrationTest/resources/json/LargeMessage/expectedBundleScenario2.json
+++ b/gp2gp-translator/src/integrationTest/resources/json/LargeMessage/expectedBundleScenario2.json
@@ -509,7 +509,8 @@
         "attachment": {
           "contentType": "application/binary",
           "url": "517146eb-229c-42d3-9e1b-bf86757775e5_898A1474-F39B-491F-AEFF-315E884C26EA.txt",
-          "title": "517146eb-229c-42d3-9e1b-bf86757775e5_898A1474-F39B-491F-AEFF-315E884C26EA.txt"
+          "title": "517146eb-229c-42d3-9e1b-bf86757775e5_898A1474-F39B-491F-AEFF-315E884C26EA.txt",
+          "size": 611
         }
       } ],
       "context": {

--- a/gp2gp-translator/src/integrationTest/resources/json/LargeMessage/expectedBundleScenario3.json
+++ b/gp2gp-translator/src/integrationTest/resources/json/LargeMessage/expectedBundleScenario3.json
@@ -509,7 +509,8 @@
         "attachment": {
           "contentType": "video/mpeg",
           "url": "1459976e-bb80-4335-b94e-89dadba685fe_8681AF4F-E577-4C8D-A2CE-43CABE3D5FB4_sample_mpeg4.mp4",
-          "title": "1459976e-bb80-4335-b94e-89dadba685fe_8681AF4F-E577-4C8D-A2CE-43CABE3D5FB4_sample_mpeg4.mp4"
+          "title": "1459976e-bb80-4335-b94e-89dadba685fe_8681AF4F-E577-4C8D-A2CE-43CABE3D5FB4_sample_mpeg4.mp4",
+          "size": 327708
         }
       } ],
       "context": {

--- a/gp2gp-translator/src/integrationTest/resources/json/LargeMessage/expectedBundleScenario4.json
+++ b/gp2gp-translator/src/integrationTest/resources/json/LargeMessage/expectedBundleScenario4.json
@@ -509,7 +509,8 @@
         "attachment": {
           "contentType": "text/plain",
           "url": "5739c03e-af1c-4490-8439-15d24bb66801_7CCB6A77-360E-434E-8CF4-97C7C2B47D70_book.txt",
-          "title": "5739c03e-af1c-4490-8439-15d24bb66801_7CCB6A77-360E-434E-8CF4-97C7C2B47D70_book.txt"
+          "title": "5739c03e-af1c-4490-8439-15d24bb66801_7CCB6A77-360E-434E-8CF4-97C7C2B47D70_book.txt",
+          "size": 1695240
         }
       } ],
       "context": {

--- a/gp2gp-translator/src/integrationTest/resources/json/LargeMessage/expectedBundleScenario6.json
+++ b/gp2gp-translator/src/integrationTest/resources/json/LargeMessage/expectedBundleScenario6.json
@@ -733,7 +733,8 @@
         "attachment": {
           "contentType": "image/tiff",
           "url": "17f220bd-8793-44fc-a518-a50da34c8ed1_588210BB-401D-41F9-84D2-978697CEEFE5_00011000.tif",
-          "title": "17f220bd-8793-44fc-a518-a50da34c8ed1_588210BB-401D-41F9-84D2-978697CEEFE5_00011000.tif"
+          "title": "17f220bd-8793-44fc-a518-a50da34c8ed1_588210BB-401D-41F9-84D2-978697CEEFE5_00011000.tif",
+          "size": 36504
         }
       } ],
       "context": {

--- a/gp2gp-translator/src/integrationTest/resources/json/LargeMessage/expectedBundleScenario8.json
+++ b/gp2gp-translator/src/integrationTest/resources/json/LargeMessage/expectedBundleScenario8.json
@@ -509,7 +509,8 @@
         "attachment": {
           "contentType": "text/plain",
           "url": "47ccb416-abc0-4479-bbe8-9016c06917b1_7CCB6A77-360E-434E-8CF4-97C7C2B47D70_book.txt",
-          "title": "47ccb416-abc0-4479-bbe8-9016c06917b1_7CCB6A77-360E-434E-8CF4-97C7C2B47D70_book.txt"
+          "title": "47ccb416-abc0-4479-bbe8-9016c06917b1_7CCB6A77-360E-434E-8CF4-97C7C2B47D70_book.txt",
+          "size": 2152228
         }
       } ],
       "context": {

--- a/gp2gp-translator/src/integrationTest/resources/json/LargeMessage/expectedBundleScenario9.json
+++ b/gp2gp-translator/src/integrationTest/resources/json/LargeMessage/expectedBundleScenario9.json
@@ -509,7 +509,8 @@
         "attachment": {
           "contentType": "text/plain",
           "url": "1e448cdc-c03f-428b-be48-61117d70b963_7CCB6A77-360E-434E-8CF4-97C7C2B47D70_book.txt",
-          "title": "1e448cdc-c03f-428b-be48-61117d70b963_7CCB6A77-360E-434E-8CF4-97C7C2B47D70_book.txt"
+          "title": "1e448cdc-c03f-428b-be48-61117d70b963_7CCB6A77-360E-434E-8CF4-97C7C2B47D70_book.txt",
+          "size": 2152228
         }
       } ],
       "context": {

--- a/gp2gp-translator/src/main/java/uk/nhs/adaptors/pss/translator/mapper/DocumentReferenceMapper.java
+++ b/gp2gp-translator/src/main/java/uk/nhs/adaptors/pss/translator/mapper/DocumentReferenceMapper.java
@@ -170,7 +170,7 @@ public class DocumentReferenceMapper extends AbstractMapper<DocumentReference> {
                 attachment.setUrl(referenceToExternalDocument.getText().getReference().getValue());
                 attachment.setTitle(buildFileName(referenceToExternalDocument.getText().getReference().getValue()));
 
-                if(attachmentSize != null) {
+                if (attachmentSize != null) {
                     attachment.setSize(attachmentSize);
                 }
 
@@ -211,13 +211,13 @@ public class DocumentReferenceMapper extends AbstractMapper<DocumentReference> {
 
     private Integer getAttachmentSize(List<PatientAttachmentLog> patientAttachmentLogs, String filename) {
 
-        if(patientAttachmentLogs != null && !patientAttachmentLogs.isEmpty()) {
+        if (patientAttachmentLogs != null && !patientAttachmentLogs.isEmpty()) {
             var attachmentSize = patientAttachmentLogs.stream()
                     .filter(patientAttachmentLog -> filename.contains(patientAttachmentLog.getFilename()))
                     .findFirst()
                     .map(PatientAttachmentLog::getPostProcessedLengthNum);
 
-            if(attachmentSize.isPresent()) {
+            if (attachmentSize.isPresent()) {
                 return attachmentSize.get();
             }
         }

--- a/gp2gp-translator/src/main/java/uk/nhs/adaptors/pss/translator/service/BundleMapperService.java
+++ b/gp2gp-translator/src/main/java/uk/nhs/adaptors/pss/translator/service/BundleMapperService.java
@@ -28,6 +28,7 @@ import org.springframework.stereotype.Service;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import uk.nhs.adaptors.connector.model.PatientAttachmentLog;
 import uk.nhs.adaptors.pss.translator.exception.BundleMappingException;
 import uk.nhs.adaptors.pss.translator.generator.BundleGenerator;
 import uk.nhs.adaptors.pss.translator.mapper.AgentDirectoryMapper;
@@ -83,7 +84,7 @@ public class BundleMapperService {
     private final SpecimenMapper specimenMapper;
     private final SpecimenCompoundsMapper specimenCompoundsMapper;
 
-    public Bundle mapToBundle(RCMRIN030000UK06Message xmlMessage, String losingPracticeOdsCode) throws BundleMappingException {
+    public Bundle mapToBundle(RCMRIN030000UK06Message xmlMessage, String losingPracticeOdsCode, List<PatientAttachmentLog> attachments) throws BundleMappingException {
 
         try {
 
@@ -131,7 +132,7 @@ public class BundleMapperService {
             var observationComments = observationCommentMapper.mapResources(ehrExtract, patient, encounters, losingPracticeOdsCode);
             addEntries(bundle, observationComments);
 
-            var documentReferences = documentReferenceMapper.mapResources(ehrExtract, patient, encounters, authorOrg);
+            var documentReferences = documentReferenceMapper.mapResources(ehrExtract, patient, encounters, authorOrg, attachments);
             addEntries(bundle, documentReferences);
 
             var templates = templateMapper.mapResources(ehrExtract, patient, encounters, losingPracticeOdsCode);

--- a/gp2gp-translator/src/main/java/uk/nhs/adaptors/pss/translator/service/BundleMapperService.java
+++ b/gp2gp-translator/src/main/java/uk/nhs/adaptors/pss/translator/service/BundleMapperService.java
@@ -84,8 +84,8 @@ public class BundleMapperService {
     private final SpecimenMapper specimenMapper;
     private final SpecimenCompoundsMapper specimenCompoundsMapper;
 
-    public Bundle mapToBundle(RCMRIN030000UK06Message xmlMessage, String losingPracticeOdsCode, List<PatientAttachmentLog> attachments) throws BundleMappingException {
-
+    public Bundle mapToBundle(RCMRIN030000UK06Message xmlMessage, String losingPracticeOdsCode,
+                              List<PatientAttachmentLog> attachments) throws BundleMappingException {
         try {
 
             Bundle bundle = generator.generateBundle();

--- a/gp2gp-translator/src/main/java/uk/nhs/adaptors/pss/translator/service/InboundMessageMergingService.java
+++ b/gp2gp-translator/src/main/java/uk/nhs/adaptors/pss/translator/service/InboundMessageMergingService.java
@@ -103,7 +103,9 @@ public class InboundMessageMergingService {
             inboundMessage.setPayload(newPayloadStr);
             payload = unmarshallString(inboundMessage.getPayload(), RCMRIN030000UK06Message.class);
 
-            var bundle = bundleMapperService.mapToBundle(payload, migrationRequest.getLosingPracticeOdsCode());
+            var attachments = patientAttachmentLogService.findAttachmentLogs(conversationId);
+
+            var bundle = bundleMapperService.mapToBundle(payload, migrationRequest.getLosingPracticeOdsCode(), attachments);
             migrationStatusLogService.updatePatientMigrationRequestAndAddMigrationStatusLog(
                     conversationId,
                     fhirParser.encodeToJson(bundle),

--- a/gp2gp-translator/src/main/java/uk/nhs/adaptors/pss/translator/task/COPCMessageHandler.java
+++ b/gp2gp-translator/src/main/java/uk/nhs/adaptors/pss/translator/task/COPCMessageHandler.java
@@ -7,9 +7,10 @@ import static uk.nhs.adaptors.pss.translator.util.XmlUnmarshallUtil.unmarshallSt
 
 import java.text.ParseException;
 import java.util.ArrayList;
-import java.util.Arrays;
+import java.util.Collections;
 import java.util.Comparator;
 import java.util.List;
+import java.util.stream.Collectors;
 
 import javax.xml.bind.JAXBException;
 import javax.xml.bind.ValidationException;
@@ -94,6 +95,12 @@ public class COPCMessageHandler {
                 } else {
                     storeCOPCAttachment(patientAttachmentLog, inboundMessage, conversationId);
                     patientAttachmentLog.setUploaded(true);
+
+                    var size = (Integer) inboundMessage.getAttachments()
+                            .stream()
+                            .mapToInt(a -> a.getPayload().length()).sum();
+
+                    patientAttachmentLog.setPostProcessedLengthNum(size);
                     patientAttachmentLogService.updateAttachmentLog(patientAttachmentLog, conversationId);
                 }
             }
@@ -132,7 +139,7 @@ public class COPCMessageHandler {
         }
 
         var conversationAttachmentLogs = patientAttachmentLogService.findAttachmentLogs(conversationId);
-        // if a message has arrived early, it will not have a parent ID so we can cancel early.
+        // if a message has arrived early, it will not have a parent ID, so we can cancel early.
         // However, an index created by the ehr message will also have no parent id
         // Logic below manages that case to make sure index COPC messages trigger the merge check
         var indexMidReference = currentAttachmentLog.getMid();
@@ -146,7 +153,7 @@ public class COPCMessageHandler {
             if (childFragments.isEmpty()) {
                 return;
             } else {
-                // otherwise lets select the first child fragment to run the process as normal
+                // otherwise let's select the first child fragment to run the process as normal
                 currentAttachmentLog = childFragments.get(0);
             }
         }
@@ -181,10 +188,15 @@ public class COPCMessageHandler {
 
             // if we have been given a file length, validate it
             var canCheckAttachmentLength = parentLogFile.getLengthNum() > 0;
+
             if (canCheckAttachmentLength) {
                 if (payload.length() != parentLogFile.getLengthNum()) {
                     throw new ExternalAttachmentProcessingException("Illegal file length detected");
                 }
+            }
+
+            if (payload != null) {
+                parentLogFile.setPostProcessedLengthNum(payload.length());
             }
 
             var mergedLargeAttachment = createNewLargeAttachmentInList(parentLogFile, payload);
@@ -193,7 +205,9 @@ public class COPCMessageHandler {
             var updatedLog = PatientAttachmentLog.builder()
                 .mid(parentLogFile.getMid())
                 .uploaded(true)
+                .postProcessedLengthNum(parentLogFile.getPostProcessedLengthNum())
                 .build();
+
             patientAttachmentLogService.updateAttachmentLog(updatedLog, conversationId);
 
             attachmentLogFragments.forEach((PatientAttachmentLog log) -> {
@@ -213,15 +227,15 @@ public class COPCMessageHandler {
                 + "OriginalBase64=" + largeFileLog.getBase64().toString() + " "
                 + "Length=" + largeFileLog.getLengthNum();
 
-        return Arrays.asList(
-            InboundMessage.Attachment.builder()
-                .payload(payload)
-                .isBase64(largeFileLog
-                    .getBase64()
-                    .toString())
-                .contentType(largeFileLog.getContentType())
-                .description(fileDescription)
-                .build()
+        return Collections.singletonList(
+                InboundMessage.Attachment.builder()
+                        .payload(payload)
+                        .isBase64(largeFileLog
+                                .getBase64()
+                                .toString())
+                        .contentType(largeFileLog.getContentType())
+                        .description(fileDescription)
+                        .build()
         );
     }
 
@@ -234,9 +248,12 @@ public class COPCMessageHandler {
         UnsupportedFileTypeException {
         String fragmentMid = getFragmentMidId(ebXmlDocument);
         String fileName = getFileNameForFragment(inboundMessage, payload);
+        var attachment = inboundMessage.getAttachments().get(0);
+        var postProcessedLength = inboundMessage.getAttachments().get(0).getPayload().length();
 
-        PatientAttachmentLog fragmentAttachmentLog
-            = buildFragmentAttachmentLog(fragmentMid, fileName, inboundMessage.getAttachments().get(0).getContentType(), patientId);
+        PatientAttachmentLog fragmentAttachmentLog = buildFragmentAttachmentLog(fragmentMid, fileName,
+                attachment.getContentType(), patientId, postProcessedLength);
+
         storeCOPCAttachment(fragmentAttachmentLog, inboundMessage, conversationId);
         fragmentAttachmentLog.setUploaded(true);
 
@@ -261,7 +278,8 @@ public class COPCMessageHandler {
                 List.of(inboundMessage.getAttachments().get(0).getPayload()),
                 conversationId
             );
-            attachmentHandlerService.storeAttachments(attachment, conversationId);
+
+          attachmentHandlerService.storeAttachments(attachment, conversationId);
         }
 
     }
@@ -289,12 +307,14 @@ public class COPCMessageHandler {
         }
     }
 
-    private PatientAttachmentLog buildFragmentAttachmentLog(String fragmentMid, String fileName, String contentType, int patientId) {
+    private PatientAttachmentLog buildFragmentAttachmentLog(
+            String fragmentMid, String fileName, String contentType, int patientId, int postProcessedLength) {
         return PatientAttachmentLog.builder()
             .mid(fragmentMid)
             .filename(fileName)
             .contentType(contentType)
             .patientMigrationReqId(patientId)
+            .postProcessedLengthNum(postProcessedLength)
             .build();
     }
 
@@ -318,8 +338,8 @@ public class COPCMessageHandler {
         PatientAttachmentLog parentAttachmentLog, String conversationId, InboundMessage message) throws ParseException, SAXException,
         ValidationException, InlineAttachmentProcessingException {
 
-        List<EbxmlReference> attachmentReferenceDescription = new ArrayList<>();
-        attachmentReferenceDescription.addAll(xmlParseUtilService.getEbxmlAttachmentsData(message));
+        List<EbxmlReference> attachmentReferenceDescription = new ArrayList<>(
+                xmlParseUtilService.getEbxmlAttachmentsData(message));
 
         // first item is always the message payload reference so skip it
         for (var index = 1; index < attachmentReferenceDescription.size(); index++) {

--- a/gp2gp-translator/src/main/java/uk/nhs/adaptors/pss/translator/task/COPCMessageHandler.java
+++ b/gp2gp-translator/src/main/java/uk/nhs/adaptors/pss/translator/task/COPCMessageHandler.java
@@ -10,7 +10,6 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Comparator;
 import java.util.List;
-import java.util.stream.Collectors;
 
 import javax.xml.bind.JAXBException;
 import javax.xml.bind.ValidationException;
@@ -279,9 +278,8 @@ public class COPCMessageHandler {
                 conversationId
             );
 
-          attachmentHandlerService.storeAttachments(attachment, conversationId);
+            attachmentHandlerService.storeAttachments(attachment, conversationId);
         }
-
     }
 
     private boolean checkIfFileTypeSupported(String fileType) {

--- a/gp2gp-translator/src/test/java/uk/nhs/adaptors/pss/translator/mapper/DocumentReferenceTest.java
+++ b/gp2gp-translator/src/test/java/uk/nhs/adaptors/pss/translator/mapper/DocumentReferenceTest.java
@@ -8,6 +8,8 @@ import static org.springframework.util.ResourceUtils.getFile;
 
 import static uk.nhs.adaptors.pss.translator.util.XmlUnmarshallUtil.unmarshallFile;
 
+import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 
 import org.hl7.fhir.dstu3.model.CodeableConcept;
@@ -26,6 +28,7 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 import lombok.SneakyThrows;
+import uk.nhs.adaptors.connector.model.PatientAttachmentLog;
 
 @ExtendWith(MockitoExtension.class)
 public class DocumentReferenceTest {
@@ -37,12 +40,13 @@ public class DocumentReferenceTest {
     private static final String NARRATIVE_STATEMENT_TYPE = "Record Attachment";
     private static final String FILENAME = "31B75ED0-6E88-11EA-9384-E83935108FD5_patient-attachment.txt";
     private static final String URL = "file://localhost/31B75ED0-6E88-11EA-9384-E83935108FD5_patient-attachment.txt";
+    private static final Integer ATTACHMENT_SIZE = 128000;
     private static final String CONTENT_TYPE = "text/plain";
     private static final String ENCOUNTER_ID = "62A39454-299F-432E-993E-5A6232B4E099";
     private static final String PATIENT_ID = "45329454-299F-432E-993E-5A6232B4E099";
     private static final Organization AUTHOR_ORG = new Organization().addIdentifier(new Identifier().setValue("TESTPRACTISECODE"));
     private static final String PLACEHOLDER = "GP2GP generated placeholder. Original document not available. See notes for details";
-    private static final int THREE = 3;
+    private static final Integer EXPECTED_DOCUMENT_REFERENCE_COUNT = 3;
 
     @InjectMocks
     private DocumentReferenceMapper documentReferenceMapper;
@@ -59,7 +63,7 @@ public class DocumentReferenceTest {
     public void mapNarrativeStatementToDocumentReferenceWithValidData() {
         var ehrExtract = unmarshallEhrExtract("narrative_statement_has_referred_to_external_document.xml");
         List<DocumentReference> documentReferences = documentReferenceMapper.mapResources(ehrExtract, createPatient(),
-            getEncounterList(), AUTHOR_ORG);
+            getEncounterList(), AUTHOR_ORG, createAttachmentList());
         var documentReference = documentReferences.get(0);
 
         assertFullValidData(documentReference);
@@ -69,7 +73,7 @@ public class DocumentReferenceTest {
     public void mapNarrativeStatementToDocumentReferenceWithOptionalData() {
         var ehrExtract = unmarshallEhrExtract("narrative_statement_has_referred_to_external_document_with_optional_data.xml");
         List<DocumentReference> documentReferences = documentReferenceMapper.mapResources(ehrExtract, createPatient(),
-            getEncounterList(), AUTHOR_ORG);
+            getEncounterList(), AUTHOR_ORG, createAttachmentList());
         var documentReference = documentReferences.get(0);
 
         assertOptionalValidData(documentReference);
@@ -79,16 +83,16 @@ public class DocumentReferenceTest {
     public void mapMultpleNarrativeStatementToDocumentReference() {
         var ehrExtract = unmarshallEhrExtract("multiple_narrative_statements_has_referred_to_external_document.xml");
         List<DocumentReference> documentReferences = documentReferenceMapper.mapResources(ehrExtract, createPatient(),
-            getEncounterList(), AUTHOR_ORG);
+            getEncounterList(), AUTHOR_ORG, createAttachmentList());
 
-        assertThat(documentReferences.size()).isEqualTo(THREE);
+        assertThat(documentReferences.size()).isEqualTo(EXPECTED_DOCUMENT_REFERENCE_COUNT);
     }
 
     @Test
     public void mapNarrativeStatementToDocumentReferenceWithAttachments() {
         var ehrExtract = unmarshallEhrExtract("narrative_statement_has_referred_to_external_document.xml");
         List<DocumentReference> documentReferences = documentReferenceMapper.mapResources(ehrExtract, createPatient(),
-            getEncounterList(), AUTHOR_ORG);
+            getEncounterList(), AUTHOR_ORG, createAttachmentList());
         var documentReference = documentReferences.get(0);
 
         assertAttachmentData(documentReference);
@@ -98,7 +102,7 @@ public class DocumentReferenceTest {
     public void mapNarrativeStatementToDocumentReferenceWithAbsentAttachment() {
         var ehrExtract = unmarshallEhrExtract("narrative_statement_has_referred_to_external_document_with_absent_attachment.xml");
         List<DocumentReference> documentReferences = documentReferenceMapper.mapResources(ehrExtract, createPatient(),
-            getEncounterList(), AUTHOR_ORG);
+            getEncounterList(), AUTHOR_ORG, new ArrayList<>());
         var documentReference = documentReferences.get(0);
 
         assertDocumentReferenceWithAbsentAttachment(documentReference);
@@ -108,7 +112,7 @@ public class DocumentReferenceTest {
     public void mapNarrativeStatementToDocumentReferenceWithInvalidEncounterReference() {
         var ehrExtract = unmarshallEhrExtract("narrative_statement_with_invalid_encounter.xml");
         List<DocumentReference> documentReferences = documentReferenceMapper.mapResources(ehrExtract, createPatient(),
-            getEncounterList(), AUTHOR_ORG);
+            getEncounterList(), AUTHOR_ORG, createAttachmentList());
         var documentReference = documentReferences.get(0);
 
         assertDocumentReferenceWithInvalidEncounter(documentReference);
@@ -117,8 +121,9 @@ public class DocumentReferenceTest {
     @Test
     public void mapNestedNarrativeStatement() {
         var ehrExtract = unmarshallEhrExtract("nested_narrative_statements.xml");
+
         List<DocumentReference> documentReferences = documentReferenceMapper.mapResources(ehrExtract, createPatient(),
-            getEncounterList(), AUTHOR_ORG);
+            getEncounterList(), AUTHOR_ORG, createAttachmentList());
         var documentReference = documentReferences.get(0);
 
         assertDocumentReferenceMappedFromNestedNarrativeStatement(documentReference);
@@ -137,6 +142,7 @@ public class DocumentReferenceTest {
         assertThat(documentReference.getSubject().getResource()).isNotNull();
         assertThat(documentReference.getSubject().getResource().getIdElement().getValue()).isEqualTo(PATIENT_ID);
         assertThat(documentReference.getContext().getEncounter().getResource().getIdElement().getValue()).isEqualTo(ENCOUNTER_ID);
+        assertAttachmentData(documentReference);
     }
 
     private void assertFullValidData(DocumentReference documentReference) {
@@ -152,6 +158,7 @@ public class DocumentReferenceTest {
         assertThat(documentReference.getSubject().getResource()).isNotNull();
         assertThat(documentReference.getSubject().getResource().getIdElement().getValue()).isEqualTo(PATIENT_ID);
         assertThat(documentReference.getContext().getEncounter().getResource().getIdElement().getValue()).isEqualTo(ENCOUNTER_ID);
+        assertAttachmentData(documentReference);
     }
 
     private void assertOptionalValidData(DocumentReference documentReference) {
@@ -170,12 +177,14 @@ public class DocumentReferenceTest {
         assertThat(documentReference.getContent().get(0).getAttachment().getTitle()).isEqualTo(FILENAME);
         assertThat(documentReference.getContent().get(0).getAttachment().getUrl()).isEqualTo(URL);
         assertThat(documentReference.getContent().get(0).getAttachment().getContentType()).isEqualTo(CONTENT_TYPE);
+        assertThat(documentReference.getContent().get(0).getAttachment().getSize()).isEqualTo(ATTACHMENT_SIZE);
     }
 
     private void assertDocumentReferenceWithAbsentAttachment(DocumentReference documentReference) {
         assertThat(documentReference.getId()).isEqualTo(NARRATIVE_STATEMENT_ROOT_ID);
         assertThat(documentReference.getContent().get(0).getAttachment().getTitle()).isEqualTo(PLACEHOLDER);
         assertThat(documentReference.getContent().get(0).getAttachment().getUrl()).isNull();
+        assertThat(documentReference.getContent().get(0).getAttachment().hasSize()).isFalse();
         assertThat(documentReference.getContent().get(0).getAttachment().getContentType()).isEqualTo(CONTENT_TYPE);
     }
 
@@ -197,6 +206,15 @@ public class DocumentReferenceTest {
         Patient patient = new Patient();
         patient.setId(PATIENT_ID);
         return patient;
+    }
+
+    private static List<PatientAttachmentLog> createAttachmentList() {
+        return Collections.singletonList(
+                PatientAttachmentLog.builder()
+                    .filename(FILENAME)
+                    .postProcessedLengthNum(ATTACHMENT_SIZE)
+                    .mid("1")
+                    .build());
     }
 
     private void setUpCodeableConceptMock() {

--- a/gp2gp-translator/src/test/java/uk/nhs/adaptors/pss/translator/service/BundleMapperServiceTest.java
+++ b/gp2gp-translator/src/test/java/uk/nhs/adaptors/pss/translator/service/BundleMapperServiceTest.java
@@ -145,7 +145,7 @@ public class BundleMapperServiceTest {
     @Test
     public void testAllMappersHaveBeenUsed() throws BundleMappingException {
         final RCMRIN030000UK06Message xml = unmarshallCodeElement(STRUCTURED_RECORD_XML);
-        Bundle bundle = bundleMapperService.mapToBundle(xml, LOSING_ODS_CODE);
+        Bundle bundle = bundleMapperService.mapToBundle(xml, LOSING_ODS_CODE, new ArrayList<>());
 
         verify(patientMapper).mapToPatient(any(RCMRMT030101UK04Patient.class), any(Organization.class));
         verify(organizationMapper).mapAuthorOrganization(anyString());
@@ -176,7 +176,7 @@ public class BundleMapperServiceTest {
             .mapResources(any(RCMRMT030101UK04EhrExtract.class), any(Patient.class), anyList(), anyString());
         verify(unknownPractitionerHandler).updateUnknownPractitionersRefs(bundle);
         verify(documentReferenceMapper).mapResources(any(RCMRMT030101UK04EhrExtract.class), any(Patient.class), anyList(),
-            any(Organization.class));
+            any(Organization.class), anyList());
         verify(templateMapper).mapResources(any(RCMRMT030101UK04EhrExtract.class), any(Patient.class), anyList(),
             anyString());
         verify(allergyIntoleranceMapper).mapResources(any(RCMRMT030101UK04EhrExtract.class), any(Patient.class), anyList(), anyString());

--- a/gp2gp-translator/src/test/java/uk/nhs/adaptors/pss/translator/service/InboundMessageMergingServiceTests.java
+++ b/gp2gp-translator/src/test/java/uk/nhs/adaptors/pss/translator/service/InboundMessageMergingServiceTests.java
@@ -6,6 +6,7 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyList;
 import static org.mockito.ArgumentMatchers.isNull;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.never;
@@ -369,7 +370,7 @@ public class InboundMessageMergingServiceTests {
         when(attachmentReferenceUpdaterService.updateReferenceToAttachment(any(), any(), any())).thenReturn(inboundMessage.getPayload());
         when(skeletonProcessingService.updateInboundMessageWithSkeleton(any(), any(), any())).thenReturn(inboundMessage);
 
-        doThrow(BundleMappingException.class).when(bundleMapperService).mapToBundle(any(RCMRIN030000UK06Message.class), any());
+        doThrow(BundleMappingException.class).when(bundleMapperService).mapToBundle(any(RCMRIN030000UK06Message.class), any(), anyList());
 
         inboundMessageMergingService.mergeAndBundleMessage(CONVERSATION_ID);
         verify(nackAckPreparationService, times(1))

--- a/gp2gp-translator/src/test/java/uk/nhs/adaptors/pss/translator/task/COPCMessageHandlerTest.java
+++ b/gp2gp-translator/src/test/java/uk/nhs/adaptors/pss/translator/task/COPCMessageHandlerTest.java
@@ -80,7 +80,11 @@ class COPCMessageHandlerTest {
     private static final String MESSAGE_ID = "CBBAE92D-C7E8-4A9C-8887-F5AEBA1F8CE1";
     private static final String NHS_NUMBER = "123456";
     private static final Integer DATA_AMOUNT = 3;
-    private static final Integer ATTACH_LENGTH = 9;
+
+    private static final String ATTACH = "RESPONSE";
+    private static final Integer INVALID_ATTACH_LENGTH = 9;
+
+    private static final Integer ATTACH_LENGTH = 8;
 
     @Mock
     private PatientMigrationRequestDao migrationRequestDao;
@@ -856,6 +860,37 @@ class COPCMessageHandlerTest {
     }
 
     @Test
+    public void When_ParentCOPCMessageIncomingAfterFragments_Expect_CorrectPostProcessedLength()
+            throws ValidationException, SAXException, AttachmentLogException,
+            InlineAttachmentProcessingException, ExternalAttachmentProcessingException, UnsupportedFileTypeException {
+
+        var inboundMessage = new InboundMessage();
+        inboundMessage.setPayload(readInboundMessageFromFile());
+        inboundMessage.setEbXML(readLargeInboundMessageEbXmlFromFile());
+        var inboundMessageId = xPathService.getNodeValue(ebXmlDocument, "/Envelope/Header/MessageHeader/MessageData/MessageId");
+
+        when(patientAttachmentLogService.findAttachmentLog(inboundMessageId, CONVERSATION_ID))
+                .thenReturn(PatientAttachmentLog.builder()
+                        .filename("test_main.txt")
+                        .mid("1")
+                        .parentMid("0")
+                        .patientMigrationReqId(1)
+                        .build());
+
+        when(patientAttachmentLogService.findAttachmentLogs(CONVERSATION_ID))
+                .thenReturn(createPatientAttachmentList(true, true, DATA_AMOUNT));
+
+        when(attachmentHandlerService.buildSingleFileStringFromPatientAttachmentLogs(any(), any())).thenReturn(ATTACH);
+
+        copcMessageHandler.checkAndMergeFileParts(inboundMessage, CONVERSATION_ID);
+        verify(attachmentHandlerService, times(1)).buildSingleFileStringFromPatientAttachmentLogs(any(), any());
+
+        var argument = ArgumentCaptor.forClass(PatientAttachmentLog.class);
+        verify(patientAttachmentLogService, times(1)).updateAttachmentLog(argument.capture(), eq(CONVERSATION_ID));
+        assertEquals(ATTACH_LENGTH, argument.getValue().getPostProcessedLengthNum());
+    }
+
+    @Test
     public void When_MergedAttachmentsBase64LengthsMismatchs_Expect_ThrowsExternalAttachmentException()
         throws ValidationException, SAXException, AttachmentLogException,
         InlineAttachmentProcessingException {
@@ -885,7 +920,7 @@ class COPCMessageHandlerTest {
                         .base64(true)
                         .compressed(false)
                         .contentType("text/plain")
-                        .lengthNum(ATTACH_LENGTH)
+                        .lengthNum(INVALID_ATTACH_LENGTH)
                         .skeleton(false)
                         .patientMigrationReqId(1).build(),
                     PatientAttachmentLog.builder().filename("test_frag_1.txt")
@@ -915,7 +950,7 @@ class COPCMessageHandlerTest {
                 )));
 
 
-        when(attachmentHandlerService.buildSingleFileStringFromPatientAttachmentLogs(any(), any())).thenReturn("RESPONSE");
+        when(attachmentHandlerService.buildSingleFileStringFromPatientAttachmentLogs(any(), any())).thenReturn(ATTACH);
 
         assertThrows(ExternalAttachmentProcessingException.class, () ->
             copcMessageHandler.checkAndMergeFileParts(inboundMessage, CONVERSATION_ID));

--- a/gp2gp-translator/src/test/java/uk/nhs/adaptors/pss/translator/task/EhrExtractMessageHandlerTest.java
+++ b/gp2gp-translator/src/test/java/uk/nhs/adaptors/pss/translator/task/EhrExtractMessageHandlerTest.java
@@ -176,7 +176,7 @@ public class EhrExtractMessageHandlerTest {
         ehrExtractMessageHandler.handleMessage(inboundMessage, CONVERSATION_ID);
 
         // mapped item is private to the class, so we cannot test an exact object
-        verify(bundleMapperService).mapToBundle(any(RCMRIN030000UK06Message.class), any());
+        verify(bundleMapperService).mapToBundle(any(RCMRIN030000UK06Message.class), any(), any());
     }
 
     @Test
@@ -339,7 +339,7 @@ public class EhrExtractMessageHandlerTest {
                 .thenReturn(inboundMessage.getPayload());
 
         doThrow(new BundleMappingException("Test Exception"))
-            .when(bundleMapperService).mapToBundle(any(RCMRIN030000UK06Message.class), any());
+            .when(bundleMapperService).mapToBundle(any(RCMRIN030000UK06Message.class), any(), any());
 
         assertThrows(BundleMappingException.class, () -> ehrExtractMessageHandler.handleMessage(inboundMessage, CONVERSATION_ID));
     }
@@ -360,7 +360,7 @@ public class EhrExtractMessageHandlerTest {
                 .winningPracticeOdsCode(WINNING_ODE_CODE)
                 .build();
 
-        when(bundleMapperService.mapToBundle(any(RCMRIN030000UK06Message.class), eq(LOSING_ODE_CODE))).thenReturn(bundle);
+        when(bundleMapperService.mapToBundle(any(RCMRIN030000UK06Message.class), eq(LOSING_ODE_CODE), any())).thenReturn(bundle);
         when(migrationRequestDao.getMigrationRequest(CONVERSATION_ID)).thenReturn(migrationRequest);
         when(attachmentReferenceUpdaterService
                 .updateReferenceToAttachment(inboundMessage.getAttachments(), CONVERSATION_ID, inboundMessage.getPayload()))
@@ -477,7 +477,7 @@ public class EhrExtractMessageHandlerTest {
         prepareMigrationRequestAndMigrationStatusMocks();
 
         ehrExtractMessageHandler.handleMessage(inboundMessage, CONVERSATION_ID);
-        verify(bundleMapperService, times(0)).mapToBundle(any(), any());
+        verify(bundleMapperService, times(0)).mapToBundle(any(), any(), any());
     }
 
     @Test
@@ -704,7 +704,7 @@ public class EhrExtractMessageHandlerTest {
         // imported from main on merge
         when(fhirParser.encodeToJson(bundle)).thenReturn(BUNDLE_STRING);
         when(objectMapper.writeValueAsString(inboundMessage)).thenReturn(INBOUND_MESSAGE_STRING);
-        when(bundleMapperService.mapToBundle(any(RCMRIN030000UK06Message.class), eq(LOSING_ODE_CODE))).thenReturn(bundle);
+        when(bundleMapperService.mapToBundle(any(RCMRIN030000UK06Message.class), eq(LOSING_ODE_CODE), any())).thenReturn(bundle);
         when(attachmentReferenceUpdaterService
                 .updateReferenceToAttachment(
                         inboundMessage.getAttachments(), CONVERSATION_ID, inboundMessage.getPayload()


### PR DESCRIPTION
Url is already present in the output, but length is not considered.

Updated db-connector with migration to store a post processed length field in the patient attachment log (as length num field is used for validation if length is provided in source)

Updated GP2GP translator to calculate lengths based on payload size and the bundle to display this as size