### PR TITLE
NIAD-2508: bug fix: medication statement end date

### DIFF
--- a/gp2gp-translator/src/integrationTest/resources/e2e-mapping/output-json/PWTP10-output.json
+++ b/gp2gp-translator/src/integrationTest/resources/e2e-mapping/output-json/PWTP10-output.json
@@ -2819,7 +2819,8 @@
           "reference": "Medication/a402af48-0694-4807-9edb-6f36826d1342"
         },
         "effectivePeriod": {
-          "start": "2010-02-06"
+          "start": "2010-02-06",
+          "end": "2010-02-06"
         },
         "dateAsserted": "2010-02-06T12:41:29+00:00",
         "subject": {

--- a/gp2gp-translator/src/integrationTest/resources/e2e-mapping/output-json/PWTP11-output.json
+++ b/gp2gp-translator/src/integrationTest/resources/e2e-mapping/output-json/PWTP11-output.json
@@ -2748,7 +2748,8 @@
           "reference": "Medication/39c1ab73-42aa-4f0c-8a9c-824afd695776"
         },
         "effectivePeriod": {
-          "start": "2010-02-10"
+          "start": "2010-02-10",
+          "end": "2010-02-10"
         },
         "dateAsserted": "2010-02-10T08:31:19+00:00",
         "subject": {
@@ -2883,7 +2884,8 @@
           "reference": "Medication/e7476d73-d88b-4340-b716-69058e71fbaf"
         },
         "effectivePeriod": {
-          "start": "2010-03-23"
+          "start": "2010-03-23",
+          "end": "2010-03-23"
         },
         "dateAsserted": "2010-03-23T15:02:45+00:00",
         "subject": {
@@ -3018,7 +3020,8 @@
           "reference": "Medication/f777d7a1-1b01-469f-90c9-c746e272868d"
         },
         "effectivePeriod": {
-          "start": "2010-03-24"
+          "start": "2010-03-24",
+          "end": "2010-03-24"
         },
         "dateAsserted": "2010-03-24T08:51:13+00:00",
         "subject": {

--- a/gp2gp-translator/src/integrationTest/resources/e2e-mapping/output-json/PWTP2-output.json
+++ b/gp2gp-translator/src/integrationTest/resources/e2e-mapping/output-json/PWTP2-output.json
@@ -3035,7 +3035,8 @@
           "reference": "Medication/86452283-c0c7-4436-901f-195eda708977"
         },
         "effectivePeriod": {
-          "start": "2010-01-13"
+          "start": "2010-01-13",
+          "end": "2010-01-13"
         },
         "dateAsserted": "2010-01-13T11:37:31+00:00",
         "subject": {
@@ -3326,7 +3327,8 @@
           "reference": "Medication/10ab05a9-c3bb-4548-ba83-fb05b4f85413"
         },
         "effectivePeriod": {
-          "start": "2010-01-13"
+          "start": "2010-01-13",
+          "end": "2010-01-13"
         },
         "dateAsserted": "2010-01-13T11:37:31+00:00",
         "subject": {
@@ -3465,7 +3467,8 @@
           "reference": "Medication/a5b5c059-564f-402f-b9e7-4902cdc4c3f8"
         },
         "effectivePeriod": {
-          "start": "2010-01-13"
+          "start": "2010-01-13",
+          "end": "2010-01-13"
         },
         "dateAsserted": "2010-01-13T11:37:31+00:00",
         "subject": {

--- a/gp2gp-translator/src/integrationTest/resources/e2e-mapping/output-json/PWTP3-output.json
+++ b/gp2gp-translator/src/integrationTest/resources/e2e-mapping/output-json/PWTP3-output.json
@@ -735,7 +735,8 @@
           "reference": "Medication/f872f2d6-62d7-4db8-8171-3eaa7018e6f0"
         },
         "effectivePeriod": {
-          "start": "2010-02-26"
+          "start": "2010-02-26",
+          "end": "2010-02-26"
         },
         "dateAsserted": "2010-02-26T11:08:17+00:00",
         "subject": {

--- a/gp2gp-translator/src/integrationTest/resources/e2e-mapping/output-json/PWTP4-output.json
+++ b/gp2gp-translator/src/integrationTest/resources/e2e-mapping/output-json/PWTP4-output.json
@@ -2988,7 +2988,8 @@
           "reference": "Medication/29456394-97f7-4e23-bfba-f7382191a63d"
         },
         "effectivePeriod": {
-          "start": "2010-01-14"
+          "start": "2010-01-14",
+          "end": "2010-01-14"
         },
         "dateAsserted": "2010-01-14T10:18:09+00:00",
         "subject": {
@@ -3132,7 +3133,8 @@
           "reference": "Medication/2ef6ced7-ac0e-4ff3-a44f-b6af38968446"
         },
         "effectivePeriod": {
-          "start": "2010-01-14"
+          "start": "2010-01-14",
+          "end": "2010-01-14"
         },
         "dateAsserted": "2010-01-14T10:21:56+00:00",
         "subject": {
@@ -3271,7 +3273,8 @@
           "reference": "Medication/d276d147-3d40-40d3-b338-b8823bba8648"
         },
         "effectivePeriod": {
-          "start": "2010-01-14"
+          "start": "2010-01-14",
+          "end": "2010-01-14"
         },
         "dateAsserted": "2010-01-14T10:22:07+00:00",
         "subject": {
@@ -3410,7 +3413,8 @@
           "reference": "Medication/8a9a1b5c-90b2-4a27-b7c3-ce1bc5321607"
         },
         "effectivePeriod": {
-          "start": "2010-01-14"
+          "start": "2010-01-14",
+          "end": "2010-01-14"
         },
         "dateAsserted": "2010-01-14T10:22:25+00:00",
         "subject": {
@@ -3554,7 +3558,8 @@
           "reference": "Medication/c9614af8-2643-411d-829e-daf9c90544b0"
         },
         "effectivePeriod": {
-          "start": "2010-01-14"
+          "start": "2010-01-14",
+          "end": "2010-01-14"
         },
         "dateAsserted": "2010-01-14T10:25:50+00:00",
         "subject": {
@@ -3693,7 +3698,8 @@
           "reference": "Medication/f4c6fcde-13fe-4e1f-b1e4-988a8e74bf40"
         },
         "effectivePeriod": {
-          "start": "2010-01-14"
+          "start": "2010-01-14",
+          "end": "2010-01-14"
         },
         "dateAsserted": "2010-01-14T10:26:05+00:00",
         "subject": {
@@ -3832,7 +3838,8 @@
           "reference": "Medication/55230589-e21a-4b18-aa04-db23562525e8"
         },
         "effectivePeriod": {
-          "start": "2010-01-14"
+          "start": "2010-01-14",
+          "end": "2010-01-14"
         },
         "dateAsserted": "2010-01-14T10:26:18+00:00",
         "subject": {
@@ -3967,7 +3974,8 @@
           "reference": "Medication/178975d2-5cd2-400c-808d-d2150059aaaf"
         },
         "effectivePeriod": {
-          "start": "2010-01-14"
+          "start": "2010-01-14",
+          "end": "2010-01-14"
         },
         "dateAsserted": "2010-01-14T10:26:31+00:00",
         "subject": {
@@ -4106,7 +4114,8 @@
           "reference": "Medication/63d09f96-4602-453f-9594-364b84cb0ba5"
         },
         "effectivePeriod": {
-          "start": "2010-01-14"
+          "start": "2010-01-14",
+          "end": "2010-01-14"
         },
         "dateAsserted": "2010-01-14T10:26:40+00:00",
         "subject": {
@@ -4245,7 +4254,8 @@
           "reference": "Medication/b0a822bc-6dfe-42d4-af32-d940a451ee3e"
         },
         "effectivePeriod": {
-          "start": "2010-01-14"
+          "start": "2010-01-14",
+          "end": "2010-01-14"
         },
         "dateAsserted": "2010-01-14T10:30:03+00:00",
         "subject": {
@@ -4406,12 +4416,13 @@
             "reference": "MedicationRequest/057C98BF-CE2C-4F14-AF6B-EA7099088F0B"
           }
         ],
-        "status": "completed",
+        "status": "stopped",
         "medicationReference": {
           "reference": "Medication/1cb87799-4298-43c0-b526-104ff7b4d7cd"
         },
         "effectivePeriod": {
-          "start": "2010-01-14"
+          "start": "2010-01-14",
+          "end": "2010-01-15"
         },
         "dateAsserted": "2010-01-14T10:34:27+00:00",
         "subject": {
@@ -4855,7 +4866,8 @@
           "reference": "Medication/b6f91a87-d1c3-4733-a5be-1a5b3ee2ae52"
         },
         "effectivePeriod": {
-          "start": "2010-01-14"
+          "start": "2010-01-14",
+          "end": "2010-01-14"
         },
         "dateAsserted": "2010-01-14T10:38:21+00:00",
         "subject": {
@@ -5017,12 +5029,13 @@
             "reference": "MedicationRequest/44771183-640A-4363-A14F-3096E8FAEED4"
           }
         ],
-        "status": "completed",
+        "status": "stopped",
         "medicationReference": {
           "reference": "Medication/014b5b50-718f-4b6e-92ef-0f997a9dda4d"
         },
         "effectivePeriod": {
-          "start": "2010-01-14"
+          "start": "2010-01-14",
+          "end": "2010-02-10"
         },
         "dateAsserted": "2010-01-14T10:41:49+00:00",
         "subject": {
@@ -5336,12 +5349,13 @@
             "reference": "MedicationRequest/8627572C-BAE5-4325-897E-F346C0B1F91B"
           }
         ],
-        "status": "completed",
+        "status": "stopped",
         "medicationReference": {
           "reference": "Medication/510efe79-fe85-4c29-a608-22396af3cd96"
         },
         "effectivePeriod": {
-          "start": "2010-01-14"
+          "start": "2010-01-14",
+          "end": "2011-09-28"
         },
         "dateAsserted": "2010-01-14T10:46:01+00:00",
         "subject": {
@@ -5476,7 +5490,8 @@
           "reference": "Medication/d10cebe6-9fed-40b9-a0e5-74472fc6e9a6"
         },
         "effectivePeriod": {
-          "start": "2010-01-14"
+          "start": "2010-01-14",
+          "end": "2010-01-14"
         },
         "dateAsserted": "2010-01-14T10:46:33+00:00",
         "subject": {
@@ -6638,7 +6653,8 @@
           "reference": "Medication/0271a31c-3f0d-4691-9869-499b45e2ff33"
         },
         "effectivePeriod": {
-          "start": "2010-01-14"
+          "start": "2010-01-14",
+          "end": "2010-01-14"
         },
         "dateAsserted": "2011-06-17T15:34:59+00:00",
         "subject": {
@@ -6753,7 +6769,8 @@
           "reference": "Medication/0271a31c-3f0d-4691-9869-499b45e2ff33"
         },
         "effectivePeriod": {
-          "start": "2010-01-14"
+          "start": "2010-01-14",
+          "end": "2010-01-14"
         },
         "dateAsserted": "2011-06-20T12:36:24+00:00",
         "subject": {
@@ -7197,7 +7214,8 @@
           "reference": "Medication/b55a434f-d0b5-4b18-961a-48536f7ba765"
         },
         "effectivePeriod": {
-          "start": "2010-01-15"
+          "start": "2010-01-15",
+          "end": "2010-01-15"
         },
         "dateAsserted": "2010-01-15T10:06:08+00:00",
         "subject": {
@@ -7341,7 +7359,8 @@
           "reference": "Medication/852cfe68-b419-43f6-9088-7d5da52c9816"
         },
         "effectivePeriod": {
-          "start": "2010-01-18"
+          "start": "2010-01-18",
+          "end": "2010-01-18"
         },
         "dateAsserted": "2010-01-18T09:16:52+00:00",
         "subject": {
@@ -7499,12 +7518,13 @@
             "reference": "MedicationRequest/54BE52A7-6C07-4402-A57F-024B3C6A391E"
           }
         ],
-        "status": "completed",
+        "status": "stopped",
         "medicationReference": {
           "reference": "Medication/a0c09dc7-eafb-4b5e-9a3a-332c0cc745bb"
         },
         "effectivePeriod": {
-          "start": "2010-01-18"
+          "start": "2010-01-18",
+          "end": "2010-01-18"
         },
         "dateAsserted": "2010-01-18T09:17:10+00:00",
         "subject": {
@@ -7808,12 +7828,13 @@
             "reference": "MedicationRequest/60F73E74-25C6-4614-9507-B52134733085"
           }
         ],
-        "status": "completed",
+        "status": "stopped",
         "medicationReference": {
           "reference": "Medication/6fe495da-1920-4551-ae08-be19d3b83084"
         },
         "effectivePeriod": {
-          "start": "2010-02-10"
+          "start": "2010-02-10",
+          "end": "2010-08-09"
         },
         "dateAsserted": "2010-02-10T13:35:08+00:00",
         "subject": {
@@ -8074,7 +8095,8 @@
           "reference": "Medication/83d285c2-2a88-4509-831b-bf5720d01d21"
         },
         "effectivePeriod": {
-          "start": "2010-03-23"
+          "start": "2010-03-23",
+          "end": "2010-03-23"
         },
         "dateAsserted": "2010-03-23T15:47:58+00:00",
         "subject": {
@@ -8203,12 +8225,13 @@
             "reference": "MedicationRequest/C3DE337C-18BE-4379-9EE8-38683327B53A"
           }
         ],
-        "status": "completed",
+        "status": "stopped",
         "medicationReference": {
           "reference": "Medication/4a362b9b-6d58-45a4-b5d0-63b3dd4c873c"
         },
         "effectivePeriod": {
-          "start": "2010-03-23"
+          "start": "2010-03-23",
+          "end": "2010-08-09"
         },
         "dateAsserted": "2010-03-23T15:59:21+00:00",
         "subject": {
@@ -9110,12 +9133,13 @@
             "reference": "MedicationRequest/BA6AA3F4-100F-4994-A12E-F96E7C931917"
           }
         ],
-        "status": "completed",
+        "status": "stopped",
         "medicationReference": {
           "reference": "Medication/7e4a75e6-21d1-4b9d-88e9-581cc514d486"
         },
         "effectivePeriod": {
-          "start": "2010-03-23"
+          "start": "2010-03-23",
+          "end": "2010-03-23"
         },
         "dateAsserted": "2010-03-23T16:40:37+00:00",
         "subject": {
@@ -9414,12 +9438,13 @@
             "reference": "MedicationRequest/B8EFEECF-A365-4C69-AB6E-6C5EFB0F71BD"
           }
         ],
-        "status": "completed",
+        "status": "stopped",
         "medicationReference": {
           "reference": "Medication/899ea7fe-366d-4a9e-8806-c0bafac12b17"
         },
         "effectivePeriod": {
-          "start": "2010-03-23"
+          "start": "2010-03-23",
+          "end": "2010-03-23"
         },
         "dateAsserted": "2010-03-23T16:44:57+00:00",
         "subject": {
@@ -9567,7 +9592,8 @@
           "reference": "Medication/d7ab9971-facc-4271-9c50-4f152e5d5c29"
         },
         "effectivePeriod": {
-          "start": "2010-03-23"
+          "start": "2010-03-23",
+          "end": "2010-03-23"
         },
         "dateAsserted": "2011-06-17T15:34:59+00:00",
         "subject": {
@@ -9695,7 +9721,8 @@
           "reference": "Medication/d7ab9971-facc-4271-9c50-4f152e5d5c29"
         },
         "effectivePeriod": {
-          "start": "2010-03-23"
+          "start": "2010-03-23",
+          "end": "2010-03-23"
         },
         "dateAsserted": "2011-06-20T12:36:25+00:00",
         "subject": {
@@ -10143,7 +10170,8 @@
           "reference": "Medication/a7698995-40c7-48cd-8dfd-c9b409317dfb"
         },
         "effectivePeriod": {
-          "start": "2010-05-21"
+          "start": "2010-05-21",
+          "end": "2010-05-21"
         },
         "dateAsserted": "2010-05-21T14:53:16+00:00",
         "subject": {
@@ -10287,7 +10315,8 @@
           "reference": "Medication/481b5c03-863f-4ecf-b78e-985c8e5a8e2b"
         },
         "effectivePeriod": {
-          "start": "2010-05-21"
+          "start": "2010-05-21",
+          "end": "2010-05-21"
         },
         "dateAsserted": "2010-05-21T14:53:38+00:00",
         "subject": {
@@ -10422,7 +10451,8 @@
           "reference": "Medication/4a90db39-ec81-4879-8239-ce0721381d5e"
         },
         "effectivePeriod": {
-          "start": "2010-08-09"
+          "start": "2010-08-09",
+          "end": "2010-08-09"
         },
         "dateAsserted": "2010-08-09T12:35:05+00:00",
         "subject": {
@@ -10541,7 +10571,8 @@
           "reference": "Medication/55230589-e21a-4b18-aa04-db23562525e8"
         },
         "effectivePeriod": {
-          "start": "2010-08-09"
+          "start": "2010-08-09",
+          "end": "2010-08-09"
         },
         "dateAsserted": "2010-08-09T12:42:22+00:00",
         "subject": {
@@ -11568,7 +11599,8 @@
           "reference": "Medication/080ff687-d4b7-48ee-b396-777f514d8cda"
         },
         "effectivePeriod": {
-          "start": "2010-08-17"
+          "start": "2010-08-17",
+          "end": "2010-08-17"
         },
         "dateAsserted": "2010-08-17T15:09:43+00:00",
         "subject": {
@@ -11707,7 +11739,8 @@
           "reference": "Medication/a3ae7310-ed25-44bc-bf64-826e1c9323ec"
         },
         "effectivePeriod": {
-          "start": "2010-08-17"
+          "start": "2010-08-17",
+          "end": "2010-08-17"
         },
         "dateAsserted": "2010-08-17T15:10:13+00:00",
         "subject": {
@@ -11846,7 +11879,8 @@
           "reference": "Medication/e58d8a7d-e2f1-400f-9a5f-7449d6b5a8de"
         },
         "effectivePeriod": {
-          "start": "2010-08-17"
+          "start": "2010-08-17",
+          "end": "2010-08-17"
         },
         "dateAsserted": "2010-08-17T15:13:55+00:00",
         "subject": {
@@ -11985,7 +12019,8 @@
           "reference": "Medication/cf890b90-65fb-4831-8d29-997a0b595632"
         },
         "effectivePeriod": {
-          "start": "2010-08-17"
+          "start": "2010-08-17",
+          "end": "2010-08-17"
         },
         "dateAsserted": "2010-08-17T15:17:48+00:00",
         "subject": {
@@ -12120,7 +12155,8 @@
           "reference": "Medication/84270a7d-667c-4c56-88bf-7000c5d237a8"
         },
         "effectivePeriod": {
-          "start": "2010-08-17"
+          "start": "2010-08-17",
+          "end": "2010-08-17"
         },
         "dateAsserted": "2010-08-17T15:18:06+00:00",
         "subject": {
@@ -12259,7 +12295,8 @@
           "reference": "Medication/44179c3a-52a7-41b8-ac01-e28dee1c24c0"
         },
         "effectivePeriod": {
-          "start": "2010-08-17"
+          "start": "2010-08-17",
+          "end": "2010-08-17"
         },
         "dateAsserted": "2010-08-17T15:18:20+00:00",
         "subject": {
@@ -12398,7 +12435,8 @@
           "reference": "Medication/bcd0b88a-9712-4952-b938-0976851c1e17"
         },
         "effectivePeriod": {
-          "start": "2010-08-17"
+          "start": "2010-08-17",
+          "end": "2010-08-17"
         },
         "dateAsserted": "2010-08-17T15:18:37+00:00",
         "subject": {
@@ -12537,7 +12575,8 @@
           "reference": "Medication/9198c6b5-87d3-40e7-b6f3-28d9b4449df1"
         },
         "effectivePeriod": {
-          "start": "2010-08-17"
+          "start": "2010-08-17",
+          "end": "2010-08-17"
         },
         "dateAsserted": "2010-08-17T15:21:50+00:00",
         "subject": {
@@ -12676,7 +12715,8 @@
           "reference": "Medication/23097808-d98d-4c95-9eaf-8943902c6bd4"
         },
         "effectivePeriod": {
-          "start": "2010-08-17"
+          "start": "2010-08-17",
+          "end": "2010-08-17"
         },
         "dateAsserted": "2010-08-17T15:26:03+00:00",
         "subject": {
@@ -12815,7 +12855,8 @@
           "reference": "Medication/d28c654f-f25d-4480-b143-4136301048c6"
         },
         "effectivePeriod": {
-          "start": "2010-08-17"
+          "start": "2010-08-17",
+          "end": "2010-08-17"
         },
         "dateAsserted": "2010-08-17T15:26:21+00:00",
         "subject": {
@@ -12954,7 +12995,8 @@
           "reference": "Medication/2808b7d2-8cca-4170-9045-a765092680dc"
         },
         "effectivePeriod": {
-          "start": "2010-08-17"
+          "start": "2010-08-17",
+          "end": "2010-08-17"
         },
         "dateAsserted": "2010-08-17T15:26:37+00:00",
         "subject": {
@@ -13069,7 +13111,8 @@
           "reference": "Medication/6cb9dcd5-3d2e-4807-a5d9-45cc3668244f"
         },
         "effectivePeriod": {
-          "start": "2010-10-01"
+          "start": "2010-10-01",
+          "end": "2010-10-01"
         },
         "dateAsserted": "2010-10-01T10:24:28+00:00",
         "subject": {
@@ -13355,12 +13398,13 @@
             "reference": "MedicationRequest/8ACB6933-1543-47CF-B166-9938ABFCFDEE"
           }
         ],
-        "status": "completed",
+        "status": "stopped",
         "medicationReference": {
           "reference": "Medication/6fe495da-1920-4551-ae08-be19d3b83084"
         },
         "effectivePeriod": {
-          "start": "2011-01-20"
+          "start": "2011-01-20",
+          "end": "2011-01-20"
         },
         "dateAsserted": "2011-01-20T14:38:17+00:00",
         "subject": {
@@ -13674,12 +13718,13 @@
             "reference": "MedicationRequest/AB0A4AA9-79BB-4663-84E5-AD10DA05D50F"
           }
         ],
-        "status": "completed",
+        "status": "stopped",
         "medicationReference": {
           "reference": "Medication/2cbe3115-5f61-495a-8267-b42be82f3d9c"
         },
         "effectivePeriod": {
-          "start": "2011-11-15"
+          "start": "2011-11-15",
+          "end": "2011-11-15"
         },
         "dateAsserted": "2011-11-15T14:44:38+00:00",
         "subject": {
@@ -13828,12 +13873,13 @@
             "reference": "MedicationRequest/1458EF9E-D0EA-4745-BB46-C38668E0EC0C"
           }
         ],
-        "status": "completed",
+        "status": "stopped",
         "medicationReference": {
           "reference": "Medication/27ced5eb-791c-4766-900b-b6486ca9639f"
         },
         "effectivePeriod": {
-          "start": "2011-11-15"
+          "start": "2011-11-15",
+          "end": "2011-11-15"
         },
         "dateAsserted": "2011-11-15T14:55:59+00:00",
         "subject": {
@@ -13972,7 +14018,8 @@
           "reference": "Medication/4c9480d4-4bdf-44f7-851d-7ae068aab61f"
         },
         "effectivePeriod": {
-          "start": "2011-12-06"
+          "start": "2011-12-06",
+          "end": "2011-12-06"
         },
         "dateAsserted": "2011-12-06T14:40:35+00:00",
         "subject": {

--- a/gp2gp-translator/src/integrationTest/resources/e2e-mapping/output-json/PWTP7_vis-output.json
+++ b/gp2gp-translator/src/integrationTest/resources/e2e-mapping/output-json/PWTP7_vis-output.json
@@ -2911,7 +2911,8 @@
           "reference": "Medication/f017b4ef-e453-49d8-a606-ae223b008b6d"
         },
         "effectivePeriod": {
-          "start": "2010-03-24"
+          "start": "2010-03-24",
+          "end": "2010-03-24"
         },
         "dateAsserted": "2010-03-24T08:43:11+00:00",
         "subject": {

--- a/gp2gp-translator/src/integrationTest/resources/json/expectedBundle.json
+++ b/gp2gp-translator/src/integrationTest/resources/json/expectedBundle.json
@@ -5934,13 +5934,13 @@
             "reference": "MedicationRequest/87102979-C329-4194-819B-D057AAEA625B"
           }
         ],
-        "status": "completed",
+        "status": "stopped",
         "medicationReference": {
           "reference": "Medication/810fca00-091b-48be-80e0-343e20cac7b6"
         },
         "effectivePeriod": {
           "start": "2010-01-14",
-          "end": "2010-02-10"
+          "end": "2010-02-10T13:15:26+00:00"
         },
         "dateAsserted": "2010-01-14",
         "subject": {
@@ -6316,13 +6316,13 @@
             "reference": "MedicationRequest/EA0D236C-2CD7-49EB-80D2-9AD58C3969F4"
           }
         ],
-        "status": "completed",
+        "status": "stopped",
         "medicationReference": {
           "reference": "Medication/ebfad4df-a985-409b-a474-789390b02cd4"
         },
         "effectivePeriod": {
           "start": "2010-01-14",
-          "end": "2010-01-14"
+          "end": "2010-01-14T10:38:27+00:00"
         },
         "dateAsserted": "2010-01-14",
         "subject": {
@@ -6861,13 +6861,13 @@
             "reference": "MedicationRequest/E2E527ED-E7FB-4161-9D3C-04FF121BF267"
           }
         ],
-        "status": "completed",
+        "status": "stopped",
         "medicationReference": {
           "reference": "Medication/e8255910-06da-4bd0-80f5-f3fceecc3be7"
         },
         "effectivePeriod": {
           "start": "2010-01-14",
-          "end": "2010-01-15"
+          "end": "2010-01-15T09:58:37+00:00"
         },
         "dateAsserted": "2010-01-14",
         "subject": {
@@ -7326,13 +7326,13 @@
             "reference": "MedicationRequest/5B72BB13-10A8-4AB3-8E13-B2C8428677BB"
           }
         ],
-        "status": "completed",
+        "status": "stopped",
         "medicationReference": {
           "reference": "Medication/b6f82a45-3e3f-46d7-bb98-0d45dcef1413"
         },
         "effectivePeriod": {
           "start": "2010-01-14",
-          "end": "2010-01-18"
+          "end": "2010-01-18T14:33:16+00:00"
         },
         "dateAsserted": "2010-01-14",
         "subject": {
@@ -12191,13 +12191,13 @@
             "reference": "MedicationRequest/9A11E815-9320-4952-96BA-CC83BECF62A3"
           }
         ],
-        "status": "completed",
+        "status": "stopped",
         "medicationReference": {
           "reference": "Medication/1c97181f-4dac-4a37-b5bb-82b76c02b417"
         },
         "effectivePeriod": {
           "start": "2010-01-18",
-          "end": "2010-01-18"
+          "end": "2010-01-18T14:37:22+00:00"
         },
         "dateAsserted": "2010-01-18",
         "subject": {
@@ -12576,13 +12576,13 @@
             "reference": "MedicationRequest/EF7BFB69-2694-46AE-8845-A49B83A88F16"
           }
         ],
-        "status": "completed",
+        "status": "stopped",
         "medicationReference": {
           "reference": "Medication/10dd5ffe-9586-4b64-80ef-9f95a77cbecb"
         },
         "effectivePeriod": {
           "start": "2010-01-18",
-          "end": "2011-09-28"
+          "end": "2011-09-28T09:22:32+00:00"
         },
         "dateAsserted": "2010-01-18",
         "subject": {
@@ -13041,13 +13041,13 @@
             "reference": "MedicationRequest/6F3E8A7A-7C40-4ACF-AD97-43A2E5DA6B29"
           }
         ],
-        "status": "completed",
+        "status": "stopped",
         "medicationReference": {
           "reference": "Medication/d9271371-6470-4fe6-9222-95c4c90f222d"
         },
         "effectivePeriod": {
           "start": "2010-02-10",
-          "end": "2010-08-09"
+          "end": "2010-08-09T13:27:43+00:00"
         },
         "dateAsserted": "2010-02-10",
         "subject": {
@@ -13962,13 +13962,13 @@
             "reference": "MedicationRequest/BCF39DFD-A6ED-43F7-A9BE-5A25EB970C8B"
           }
         ],
-        "status": "completed",
+        "status": "stopped",
         "medicationReference": {
           "reference": "Medication/1f05b691-e16a-4a51-a6a6-71f732695635"
         },
         "effectivePeriod": {
           "start": "2010-03-23",
-          "end": "2010-03-23"
+          "end": "2010-03-23T16:41:06+00:00"
         },
         "dateAsserted": "2010-03-23",
         "subject": {
@@ -14485,13 +14485,13 @@
             "reference": "MedicationRequest/64D224E0-DE90-49BB-AF2D-ECA90BA2CE0D"
           }
         ],
-        "status": "completed",
+        "status": "stopped",
         "medicationReference": {
           "reference": "Medication/df926634-ac87-4c85-af22-143bfd7fe40e"
         },
         "effectivePeriod": {
           "start": "2010-03-23",
-          "end": "2010-08-09"
+          "end": "2010-08-09T13:27:58+00:00"
         },
         "dateAsserted": "2010-03-23",
         "subject": {
@@ -20869,13 +20869,13 @@
             "reference": "MedicationRequest/E96B55C1-7C8E-40CA-A6C0-A2951CFEE860"
           }
         ],
-        "status": "completed",
+        "status": "stopped",
         "medicationReference": {
           "reference": "Medication/5eee072e-ae4b-479d-98a1-42bf30e21089"
         },
         "effectivePeriod": {
           "start": "2010-08-12",
-          "end": "2010-08-17"
+          "end": "2010-08-16T23:00:00+00:00"
         },
         "dateAsserted": "2010-08-12",
         "subject": {
@@ -23548,13 +23548,13 @@
             "reference": "MedicationRequest/2810EE1B-93EE-4417-B70B-C692AD0B2A17"
           }
         ],
-        "status": "completed",
+        "status": "stopped",
         "medicationReference": {
           "reference": "Medication/5eee072e-ae4b-479d-98a1-42bf30e21089"
         },
         "effectivePeriod": {
           "start": "2010-08-17",
-          "end": "2010-08-17"
+          "end": "2010-08-17T10:03:37+00:00"
         },
         "dateAsserted": "2010-08-17",
         "subject": {
@@ -24998,13 +24998,13 @@
             "reference": "MedicationRequest/447AE7B0-FA1A-4BEA-A90F-68C35240C5F9"
           }
         ],
-        "status": "completed",
+        "status": "stopped",
         "medicationReference": {
           "reference": "Medication/0c5b1cbb-63b7-418d-9415-c5a0ba0c5cc6"
         },
         "effectivePeriod": {
           "start": "2010-10-01",
-          "end": "2010-10-01"
+          "end": "2010-10-01T11:08:19+00:00"
         },
         "dateAsserted": "2010-10-01",
         "subject": {
@@ -25433,13 +25433,13 @@
             "reference": "MedicationRequest/77730A08-B78F-448A-8810-D6CBBF86420E"
           }
         ],
-        "status": "completed",
+        "status": "stopped",
         "medicationReference": {
           "reference": "Medication/d9271371-6470-4fe6-9222-95c4c90f222d"
         },
         "effectivePeriod": {
           "start": "2011-01-20",
-          "end": "2011-01-20"
+          "end": "2011-01-20T14:38:23+00:00"
         },
         "dateAsserted": "2011-01-20",
         "subject": {
@@ -26415,13 +26415,13 @@
             "reference": "MedicationRequest/047E10B7-9A38-46A4-B34C-CEBD35C8A4B7"
           }
         ],
-        "status": "completed",
+        "status": "stopped",
         "medicationReference": {
           "reference": "Medication/39c7ef46-628c-46e0-9963-da229270a000"
         },
         "effectivePeriod": {
           "start": "2011-11-15",
-          "end": "2011-11-15"
+          "end": "2011-11-15T14:52:00+00:00"
         },
         "dateAsserted": "2011-11-15",
         "subject": {
@@ -26792,13 +26792,13 @@
             "reference": "MedicationRequest/1751F68E-56EA-4DAE-904B-A1028952B01F"
           }
         ],
-        "status": "completed",
+        "status": "stopped",
         "medicationReference": {
           "reference": "Medication/44123956-bb4e-4417-a3ff-cf7e3c1dbb8f"
         },
         "effectivePeriod": {
           "start": "2011-11-15",
-          "end": "2011-11-15"
+          "end": "2011-11-15T15:02:50+00:00"
         },
         "dateAsserted": "2011-11-15",
         "subject": {

--- a/gp2gp-translator/src/test/resources/xml/MedicationStatement/ehrExtract_authorise_effectiveTimeHigh.xml
+++ b/gp2gp-translator/src/test/resources/xml/MedicationStatement/ehrExtract_authorise_effectiveTimeHigh.xml
@@ -1,0 +1,62 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<EhrExtract xmlns="urn:hl7-org:v3" classCode="EXTRACT" moodCode="EVN">
+    <availabilityTime value="20100115"/>
+    <component typeCode="COMP">
+        <ehrFolder classCode="FOLDER" moodCode="EVN">
+            <component typeCode="COMP">
+                <ehrComposition classCode="COMPOSITION" moodCode="EVN">
+                    <component typeCode="COMP">
+                        <MedicationStatement xmlns="urn:hl7-org:v3" classCode="SBADM" moodCode="ORD">
+                            <id root="36E3381F-3B1C-45DC-B8E7-EEC37A224AF3"/>
+                            <statusCode code="COMPLETE"/>
+                            <effectiveTime>
+                                <low value="20060426"/>
+                                <high value="20100626"/>
+                            </effectiveTime>
+                            <availabilityTime value="20060426"/>
+                            <component typeCode="COMP">
+                                <ehrSupplyAuthorise xmlns="urn:hl7-org:v3" classCode="SPLY" moodCode="INT">
+                                    <id root="TEST_ID"/>
+                                    <code code="9bG0.00" codeSystem="2.16.840.1.113883.2.1.6.2"
+                                          displayName="NHS prescription"/>
+                                    <statusCode code="COMPLETE"/>
+                                    <effectiveTime>
+                                        <low value="20100427"/>
+                                        <high value="20100627"/>
+                                    </effectiveTime>
+                                    <availabilityTime value="20100114"/>
+                                    <repeatNumber value="6"/>
+                                    <quantity value="28" unit="1">
+                                        <translation value="28">
+                                            <originalText>capsule</originalText>
+                                        </translation>
+                                    </quantity>
+                                    <pertinentInformation typeCode="PERT">
+                                        <pertinentSupplyAnnotation classCode="OBS" moodCode="EVN">
+                                            <text>1</text>
+                                        </pertinentSupplyAnnotation>
+                                    </pertinentInformation>
+                                    <pertinentInformation typeCode="PERT">
+                                        <pertinentSupplyAnnotation classCode="OBS" moodCode="EVN">
+                                            <text>2</text>
+                                        </pertinentSupplyAnnotation>
+                                    </pertinentInformation>
+                                    <pertinentInformation typeCode="PERT">
+                                        <pertinentSupplyAnnotation classCode="OBS" moodCode="EVN">
+                                            <text>3</text>
+                                        </pertinentSupplyAnnotation>
+                                    </pertinentInformation>
+                                </ehrSupplyAuthorise>
+                            </component>
+                            <pertinentInformation typeCode="PERT">
+                                <pertinentMedicationDosage classCode="SBADM" moodCode="RMD">
+                                    <text>TAKE ONE DAILY</text>
+                                </pertinentMedicationDosage>
+                            </pertinentInformation>
+                        </MedicationStatement>
+                    </component>
+                </ehrComposition>
+            </component>
+        </ehrFolder>
+    </component>
+</EhrExtract>

--- a/gp2gp-translator/src/test/resources/xml/MedicationStatement/ehrExtract_discontinue.xml
+++ b/gp2gp-translator/src/test/resources/xml/MedicationStatement/ehrExtract_discontinue.xml
@@ -1,0 +1,79 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<EhrExtract xmlns="urn:hl7-org:v3" classCode="EXTRACT" moodCode="EVN">
+    <availabilityTime value="20100115"/>
+    <component typeCode="COMP">
+        <ehrFolder classCode="FOLDER" moodCode="EVN">
+            <component typeCode="COMP">
+                <ehrComposition classCode="COMPOSITION" moodCode="EVN">
+                    <component typeCode="COMP">
+                        <MedicationStatement xmlns="urn:hl7-org:v3" classCode="SBADM" moodCode="ORD">
+                            <id root="36E3381F-3B1C-45DC-B8E7-EEC37A224AF3"/>
+                            <statusCode code="COMPLETE"/>
+                            <effectiveTime>
+                                <low value="20060426"/>
+                            </effectiveTime>
+                            <availabilityTime value="20060426"/>
+                            <component typeCode="COMP">
+                                <ehrSupplyAuthorise xmlns="urn:hl7-org:v3" classCode="SPLY" moodCode="INT">
+                                    <id root="TEST_ID"/>
+                                    <code code="9bG0.00" codeSystem="2.16.840.1.113883.2.1.6.2"
+                                          displayName="NHS prescription"/>
+                                    <statusCode code="COMPLETE"/>
+                                    <effectiveTime>
+                                        <center nullFlavor="NI"/>
+                                    </effectiveTime>
+                                    <availabilityTime value="20100114"/>
+                                    <repeatNumber value="6"/>
+                                    <quantity value="28" unit="1">
+                                        <translation value="28">
+                                            <originalText>capsule</originalText>
+                                        </translation>
+                                    </quantity>
+                                    <pertinentInformation typeCode="PERT">
+                                        <pertinentSupplyAnnotation classCode="OBS" moodCode="EVN">
+                                            <text>1</text>
+                                        </pertinentSupplyAnnotation>
+                                    </pertinentInformation>
+                                    <pertinentInformation typeCode="PERT">
+                                        <pertinentSupplyAnnotation classCode="OBS" moodCode="EVN">
+                                            <text>2</text>
+                                        </pertinentSupplyAnnotation>
+                                    </pertinentInformation>
+                                    <pertinentInformation typeCode="PERT">
+                                        <pertinentSupplyAnnotation classCode="OBS" moodCode="EVN">
+                                            <text>3</text>
+                                        </pertinentSupplyAnnotation>
+                                    </pertinentInformation>
+                                </ehrSupplyAuthorise>
+                            </component>
+                            <component typeCode="COMP">
+                                <ehrSupplyDiscontinue classCode="SPLY" moodCode="RQO">
+                                    <id root="D0BF39CA-E656-4322-879F-83EE6E688053"/>
+                                    <code code="EMISDRUG_DISCONTINUATION" codeSystem="2.16.840.1.113883.2.1.6.3"
+                                          displayName="Medication Course Ended"/>
+                                    <statusCode code="COMPLETE"/>
+                                    <availabilityTime value="20100426"/>
+                                    <reversalOf typeCode="REV">
+                                        <priorMedicationRef classCode="SBADM" moodCode="ORD">
+                                            <id root="TEST_ID"/>
+                                        </priorMedicationRef>
+                                    </reversalOf>
+                                    <pertinentInformation typeCode="PERT">
+                                        <pertinentSupplyAnnotation classCode="OBS" moodCode="EVN">
+                                            <text>Patient no longer requires these</text>
+                                        </pertinentSupplyAnnotation>
+                                    </pertinentInformation>
+                                </ehrSupplyDiscontinue>
+                            </component>
+                            <pertinentInformation typeCode="PERT">
+                                <pertinentMedicationDosage classCode="SBADM" moodCode="RMD">
+                                    <text>TAKE ONE DAILY</text>
+                                </pertinentMedicationDosage>
+                            </pertinentInformation>
+                        </MedicationStatement>
+                    </component>
+                </ehrComposition>
+            </component>
+        </ehrFolder>
+    </component>
+</EhrExtract>

--- a/gp2gp-translator/src/test/resources/xml/MedicationStatement/ehrExtract_discontinueMissingAvailabilityTime.xml
+++ b/gp2gp-translator/src/test/resources/xml/MedicationStatement/ehrExtract_discontinueMissingAvailabilityTime.xml
@@ -1,0 +1,79 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<EhrExtract xmlns="urn:hl7-org:v3" classCode="EXTRACT" moodCode="EVN">
+    <availabilityTime value="20100115"/>
+    <component typeCode="COMP">
+        <ehrFolder classCode="FOLDER" moodCode="EVN">
+            <component typeCode="COMP">
+                <ehrComposition classCode="COMPOSITION" moodCode="EVN">
+                    <component typeCode="COMP">
+                        <MedicationStatement xmlns="urn:hl7-org:v3" classCode="SBADM" moodCode="ORD">
+                            <id root="36E3381F-3B1C-45DC-B8E7-EEC37A224AF3"/>
+                            <statusCode code="COMPLETE"/>
+                            <effectiveTime>
+                                <low value="20060426"/>
+                            </effectiveTime>
+                            <availabilityTime value="20060426"/>
+                            <component typeCode="COMP">
+                                <ehrSupplyAuthorise xmlns="urn:hl7-org:v3" classCode="SPLY" moodCode="INT">
+                                    <id root="TEST_ID"/>
+                                    <code code="9bG0.00" codeSystem="2.16.840.1.113883.2.1.6.2"
+                                          displayName="NHS prescription"/>
+                                    <statusCode code="COMPLETE"/>
+                                    <effectiveTime>
+                                        <center nullFlavor="NI"/>
+                                    </effectiveTime>
+                                    <availabilityTime value="20100114"/>
+                                    <repeatNumber value="6"/>
+                                    <quantity value="28" unit="1">
+                                        <translation value="28">
+                                            <originalText>capsule</originalText>
+                                        </translation>
+                                    </quantity>
+                                    <pertinentInformation typeCode="PERT">
+                                        <pertinentSupplyAnnotation classCode="OBS" moodCode="EVN">
+                                            <text>1</text>
+                                        </pertinentSupplyAnnotation>
+                                    </pertinentInformation>
+                                    <pertinentInformation typeCode="PERT">
+                                        <pertinentSupplyAnnotation classCode="OBS" moodCode="EVN">
+                                            <text>2</text>
+                                        </pertinentSupplyAnnotation>
+                                    </pertinentInformation>
+                                    <pertinentInformation typeCode="PERT">
+                                        <pertinentSupplyAnnotation classCode="OBS" moodCode="EVN">
+                                            <text>3</text>
+                                        </pertinentSupplyAnnotation>
+                                    </pertinentInformation>
+                                </ehrSupplyAuthorise>
+                            </component>
+                            <component typeCode="COMP">
+                                <ehrSupplyDiscontinue classCode="SPLY" moodCode="RQO">
+                                    <id root="D0BF39CA-E656-4322-879F-83EE6E688053"/>
+                                    <code code="EMISDRUG_DISCONTINUATION" codeSystem="2.16.840.1.113883.2.1.6.3"
+                                          displayName="Medication Course Ended"/>
+                                    <statusCode code="COMPLETE"/>
+                                    <availabilityTime nullFlavor="NI"/>
+                                    <reversalOf typeCode="REV">
+                                        <priorMedicationRef classCode="SBADM" moodCode="ORD">
+                                            <id root="TEST_ID"/>
+                                        </priorMedicationRef>
+                                    </reversalOf>
+                                    <pertinentInformation typeCode="PERT">
+                                        <pertinentSupplyAnnotation classCode="OBS" moodCode="EVN">
+                                            <text>Patient no longer requires these</text>
+                                        </pertinentSupplyAnnotation>
+                                    </pertinentInformation>
+                                </ehrSupplyDiscontinue>
+                            </component>
+                            <pertinentInformation typeCode="PERT">
+                                <pertinentMedicationDosage classCode="SBADM" moodCode="RMD">
+                                    <text>TAKE ONE DAILY</text>
+                                </pertinentMedicationDosage>
+                            </pertinentInformation>
+                        </MedicationStatement>
+                    </component>
+                </ehrComposition>
+            </component>
+        </ehrFolder>
+    </component>
+</EhrExtract>

--- a/gp2gp-translator/src/test/resources/xml/MedicationStatement/ehrExtract_discontinue_noValidTimes.xml
+++ b/gp2gp-translator/src/test/resources/xml/MedicationStatement/ehrExtract_discontinue_noValidTimes.xml
@@ -1,0 +1,79 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<EhrExtract xmlns="urn:hl7-org:v3" classCode="EXTRACT" moodCode="EVN">
+    <availabilityTime value="20100115"/>
+    <component typeCode="COMP">
+        <ehrFolder classCode="FOLDER" moodCode="EVN">
+            <component typeCode="COMP">
+                <ehrComposition classCode="COMPOSITION" moodCode="EVN">
+                    <component typeCode="COMP">
+                        <MedicationStatement xmlns="urn:hl7-org:v3" classCode="SBADM" moodCode="ORD">
+                            <id root="36E3381F-3B1C-45DC-B8E7-EEC37A224AF3"/>
+                            <statusCode code="COMPLETE"/>
+                            <effectiveTime>
+                                <center nullFlavor="NI"/>
+                            </effectiveTime>
+                            <availabilityTime value="20060426"/>
+                            <component typeCode="COMP">
+                                <ehrSupplyAuthorise xmlns="urn:hl7-org:v3" classCode="SPLY" moodCode="INT">
+                                    <id root="TEST_ID"/>
+                                    <code code="9bG0.00" codeSystem="2.16.840.1.113883.2.1.6.2"
+                                          displayName="NHS prescription"/>
+                                    <statusCode code="COMPLETE"/>
+                                    <effectiveTime>
+                                        <center nullFlavor="NI"/>
+                                    </effectiveTime>
+                                    <availabilityTime nullFlavor="NI"/>
+                                    <repeatNumber value="6"/>
+                                    <quantity value="28" unit="1">
+                                        <translation value="28">
+                                            <originalText>capsule</originalText>
+                                        </translation>
+                                    </quantity>
+                                    <pertinentInformation typeCode="PERT">
+                                        <pertinentSupplyAnnotation classCode="OBS" moodCode="EVN">
+                                            <text>1</text>
+                                        </pertinentSupplyAnnotation>
+                                    </pertinentInformation>
+                                    <pertinentInformation typeCode="PERT">
+                                        <pertinentSupplyAnnotation classCode="OBS" moodCode="EVN">
+                                            <text>2</text>
+                                        </pertinentSupplyAnnotation>
+                                    </pertinentInformation>
+                                    <pertinentInformation typeCode="PERT">
+                                        <pertinentSupplyAnnotation classCode="OBS" moodCode="EVN">
+                                            <text>3</text>
+                                        </pertinentSupplyAnnotation>
+                                    </pertinentInformation>
+                                </ehrSupplyAuthorise>
+                            </component>
+                            <component typeCode="COMP">
+                                <ehrSupplyDiscontinue classCode="SPLY" moodCode="RQO">
+                                    <id root="D0BF39CA-E656-4322-879F-83EE6E688053"/>
+                                    <code code="EMISDRUG_DISCONTINUATION" codeSystem="2.16.840.1.113883.2.1.6.3"
+                                          displayName="Medication Course Ended"/>
+                                    <statusCode code="COMPLETE"/>
+                                    <availabilityTime nullFlavor="NI"/>
+                                    <reversalOf typeCode="REV">
+                                        <priorMedicationRef classCode="SBADM" moodCode="ORD">
+                                            <id root="TEST_ID"/>
+                                        </priorMedicationRef>
+                                    </reversalOf>
+                                    <pertinentInformation typeCode="PERT">
+                                        <pertinentSupplyAnnotation classCode="OBS" moodCode="EVN">
+                                            <text>Patient no longer requires these</text>
+                                        </pertinentSupplyAnnotation>
+                                    </pertinentInformation>
+                                </ehrSupplyDiscontinue>
+                            </component>
+                            <pertinentInformation typeCode="PERT">
+                                <pertinentMedicationDosage classCode="SBADM" moodCode="RMD">
+                                    <text>TAKE ONE DAILY</text>
+                                </pertinentMedicationDosage>
+                            </pertinentInformation>
+                        </MedicationStatement>
+                    </component>
+                </ehrComposition>
+            </component>
+        </ehrFolder>
+    </component>
+</EhrExtract>

--- a/gp2gp-translator/src/test/resources/xml/MedicationStatement/ehrExtract_effectiveTimeHigh.xml
+++ b/gp2gp-translator/src/test/resources/xml/MedicationStatement/ehrExtract_effectiveTimeHigh.xml
@@ -1,0 +1,61 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<EhrExtract xmlns="urn:hl7-org:v3" classCode="EXTRACT" moodCode="EVN">
+    <availabilityTime value="20100115"/>
+    <component typeCode="COMP">
+        <ehrFolder classCode="FOLDER" moodCode="EVN">
+            <component typeCode="COMP">
+                <ehrComposition classCode="COMPOSITION" moodCode="EVN">
+                    <component typeCode="COMP">
+                        <MedicationStatement xmlns="urn:hl7-org:v3" classCode="SBADM" moodCode="ORD">
+                            <id root="36E3381F-3B1C-45DC-B8E7-EEC37A224AF3"/>
+                            <statusCode code="COMPLETE"/>
+                            <effectiveTime>
+                                <low value="20060426"/>
+                                <high value="20100626"/>
+                            </effectiveTime>
+                            <availabilityTime value="20060426"/>
+                            <component typeCode="COMP">
+                                <ehrSupplyAuthorise xmlns="urn:hl7-org:v3" classCode="SPLY" moodCode="INT">
+                                    <id root="TEST_ID"/>
+                                    <code code="9bG0.00" codeSystem="2.16.840.1.113883.2.1.6.2"
+                                          displayName="NHS prescription"/>
+                                    <statusCode code="COMPLETE"/>
+                                    <effectiveTime>
+                                        <center nullFlavor="NI"/>
+                                    </effectiveTime>
+                                    <availabilityTime value="20100114"/>
+                                    <repeatNumber value="6"/>
+                                    <quantity value="28" unit="1">
+                                        <translation value="28">
+                                            <originalText>capsule</originalText>
+                                        </translation>
+                                    </quantity>
+                                    <pertinentInformation typeCode="PERT">
+                                        <pertinentSupplyAnnotation classCode="OBS" moodCode="EVN">
+                                            <text>1</text>
+                                        </pertinentSupplyAnnotation>
+                                    </pertinentInformation>
+                                    <pertinentInformation typeCode="PERT">
+                                        <pertinentSupplyAnnotation classCode="OBS" moodCode="EVN">
+                                            <text>2</text>
+                                        </pertinentSupplyAnnotation>
+                                    </pertinentInformation>
+                                    <pertinentInformation typeCode="PERT">
+                                        <pertinentSupplyAnnotation classCode="OBS" moodCode="EVN">
+                                            <text>3</text>
+                                        </pertinentSupplyAnnotation>
+                                    </pertinentInformation>
+                                </ehrSupplyAuthorise>
+                            </component>
+                            <pertinentInformation typeCode="PERT">
+                                <pertinentMedicationDosage classCode="SBADM" moodCode="RMD">
+                                    <text>TAKE ONE DAILY</text>
+                                </pertinentMedicationDosage>
+                            </pertinentInformation>
+                        </MedicationStatement>
+                    </component>
+                </ehrComposition>
+            </component>
+        </ehrFolder>
+    </component>
+</EhrExtract>

--- a/gp2gp-translator/src/test/resources/xml/MedicationStatement/ehrExtract_noValidTimes.xml
+++ b/gp2gp-translator/src/test/resources/xml/MedicationStatement/ehrExtract_noValidTimes.xml
@@ -1,0 +1,60 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<EhrExtract xmlns="urn:hl7-org:v3" classCode="EXTRACT" moodCode="EVN">
+    <availabilityTime value="20100115"/>
+    <component typeCode="COMP">
+        <ehrFolder classCode="FOLDER" moodCode="EVN">
+            <component typeCode="COMP">
+                <ehrComposition classCode="COMPOSITION" moodCode="EVN">
+                    <component typeCode="COMP">
+                        <MedicationStatement xmlns="urn:hl7-org:v3" classCode="SBADM" moodCode="ORD">
+                            <id root="36E3381F-3B1C-45DC-B8E7-EEC37A224AF3"/>
+                            <statusCode code="COMPLETE"/>
+                            <effectiveTime>
+                                <center nullFlavor="NI"/>
+                            </effectiveTime>
+                            <availabilityTime value="20060426"/>
+                            <component typeCode="COMP">
+                                <ehrSupplyAuthorise xmlns="urn:hl7-org:v3" classCode="SPLY" moodCode="INT">
+                                    <id root="TEST_ID"/>
+                                    <code code="9bG0.00" codeSystem="2.16.840.1.113883.2.1.6.2"
+                                          displayName="NHS prescription"/>
+                                    <statusCode code="COMPLETE"/>
+                                    <effectiveTime>
+                                        <center nullFlavor="NI"/>
+                                    </effectiveTime>
+                                    <availabilityTime nullFlavor="NI"/>
+                                    <repeatNumber value="6"/>
+                                    <quantity value="28" unit="1">
+                                        <translation value="28">
+                                            <originalText>capsule</originalText>
+                                        </translation>
+                                    </quantity>
+                                    <pertinentInformation typeCode="PERT">
+                                        <pertinentSupplyAnnotation classCode="OBS" moodCode="EVN">
+                                            <text>1</text>
+                                        </pertinentSupplyAnnotation>
+                                    </pertinentInformation>
+                                    <pertinentInformation typeCode="PERT">
+                                        <pertinentSupplyAnnotation classCode="OBS" moodCode="EVN">
+                                            <text>2</text>
+                                        </pertinentSupplyAnnotation>
+                                    </pertinentInformation>
+                                    <pertinentInformation typeCode="PERT">
+                                        <pertinentSupplyAnnotation classCode="OBS" moodCode="EVN">
+                                            <text>3</text>
+                                        </pertinentSupplyAnnotation>
+                                    </pertinentInformation>
+                                </ehrSupplyAuthorise>
+                            </component>
+                            <pertinentInformation typeCode="PERT">
+                                <pertinentMedicationDosage classCode="SBADM" moodCode="RMD">
+                                    <text>TAKE ONE DAILY</text>
+                                </pertinentMedicationDosage>
+                            </pertinentInformation>
+                        </MedicationStatement>
+                    </component>
+                </ehrComposition>
+            </component>
+        </ehrFolder>
+    </component>
+</EhrExtract>


### PR DESCRIPTION
**Description**

At the moment Medication Statements in a state of completed has no end date which is only valid in the case of an active Mediciation Statement. 

Fix: If state is in a valid `stopped` / `completed` state. The `effectivePeriod.end` date should be set to the `AvailabilityTime` found in the related `EHRSupplyDiscountinue` HL7 data.

**Implementation details**

As a GP2GP `MedicationStatement` with a status of `complete` may or may not have a `ehrSupplyDiscontinue` component the following logic has been implemented to ensure an end date is mapped:

set `medicationStatement.effectiveperiod.end` date to (in preference order): 

1. The availability time in the `EhrSupplyDiscontinue`.
2. The High value of the effective time element in the `Ehrsupplyauthorise`.
3. The High value of the effective time element in the `MedicationStatement`.
4. If the medication status is not ACTIVE, the `effectiveperiod.start` date

**Additional work**

To bring the medication statement status logic up to date with the work done on NIAD-2509: 

* Where there is a `EhrSupplyDiscontinue`  set the `medicationStatement.status` to stopped.
* If there is a discontinue but the availability time is unknown, set the `medicationStatement.status` to complete