### PR TITLE
NIAD-2489

### DIFF
--- a/gp2gp-translator/src/integrationTest/resources/e2e-mapping/output-json/PWTP7_vis-output.json
+++ b/gp2gp-translator/src/integrationTest/resources/e2e-mapping/output-json/PWTP7_vis-output.json
@@ -3535,8 +3535,7 @@
           {
             "attachment": {
               "contentType": "text/plain",
-              "url": "file://localhost/0FA498E2-DBC9-4A45-92BF-03A31844F490_Test_att_txt.txt",
-              "title": "0FA498E2-DBC9-4A45-92BF-03A31844F490_Test_att_txt.txt"
+              "url": "file://localhost/0FA498E2-DBC9-4A45-92BF-03A31844F490_Test_att_txt.txt"
             }
           }
         ],
@@ -3591,8 +3590,7 @@
           {
             "attachment": {
               "contentType": "application/msword",
-              "url": "file://localhost/95B3D82A-BA16-4771-B2A4-03F9C0CCF87F_Test_att_doc.doc",
-              "title": "95B3D82A-BA16-4771-B2A4-03F9C0CCF87F_Test_att_doc.doc"
+              "url": "file://localhost/95B3D82A-BA16-4771-B2A4-03F9C0CCF87F_Test_att_doc.doc"
             }
           }
         ],
@@ -3647,8 +3645,7 @@
           {
             "attachment": {
               "contentType": "GP2GP generated placeholder. Original document not available. See notes for details",
-              "url": "file://localhost/3E12AB25-9A18-4239-93A6-2592F6DA9289_Test_att_bmp.bmp",
-              "title": "3E12AB25-9A18-4239-93A6-2592F6DA9289_Test_att_bmp.bmp"
+              "url": "file://localhost/3E12AB25-9A18-4239-93A6-2592F6DA9289_Test_att_bmp.bmp"
             }
           }
         ],
@@ -3703,8 +3700,7 @@
           {
             "attachment": {
               "contentType": "GP2GP generated placeholder. Original document not available. See notes for details",
-              "url": "file://localhost/3AE27487-78D3-43CF-8356-3BF156F9B479_Test_att_gif.GIF",
-              "title": "3AE27487-78D3-43CF-8356-3BF156F9B479_Test_att_gif.GIF"
+              "url": "file://localhost/3AE27487-78D3-43CF-8356-3BF156F9B479_Test_att_gif.GIF"
             }
           }
         ],
@@ -3759,8 +3755,7 @@
           {
             "attachment": {
               "contentType": "GP2GP generated placeholder. Original document not available. See notes for details",
-              "url": "file://localhost/F4AC3D0F-06D5-4A2C-8686-17B23A46F0A7_Test_att_jpg.JPG",
-              "title": "F4AC3D0F-06D5-4A2C-8686-17B23A46F0A7_Test_att_jpg.JPG"
+              "url": "file://localhost/F4AC3D0F-06D5-4A2C-8686-17B23A46F0A7_Test_att_jpg.JPG"
             }
           }
         ],
@@ -3815,8 +3810,7 @@
           {
             "attachment": {
               "contentType": "text/plain",
-              "url": "file://localhost/997CDD95-120C-4B48-99FF-D73170F275AB_Fix%20for%20Consultation%20Place%20of%20Procedure.txt",
-              "title": "997CDD95-120C-4B48-99FF-D73170F275AB_Fix%20for%20Consultation%20Place%20of%20Procedure.txt"
+              "url": "file://localhost/997CDD95-120C-4B48-99FF-D73170F275AB_Fix%20for%20Consultation%20Place%20of%20Procedure.txt"
             }
           }
         ],
@@ -3871,8 +3865,7 @@
           {
             "attachment": {
               "contentType": "text/rtf",
-              "url": "file://localhost/2AD22965-C1CE-4AC0-A013-64806E23AEFD_tmpATT_1.rtf",
-              "title": "2AD22965-C1CE-4AC0-A013-64806E23AEFD_tmpATT_1.rtf"
+              "url": "file://localhost/2AD22965-C1CE-4AC0-A013-64806E23AEFD_tmpATT_1.rtf"
             }
           }
         ],

--- a/gp2gp-translator/src/integrationTest/resources/json/LargeMessage/expectedBundleScenario1.json
+++ b/gp2gp-translator/src/integrationTest/resources/json/LargeMessage/expectedBundleScenario1.json
@@ -509,7 +509,6 @@
         "attachment": {
           "contentType": "text/plain",
           "url": "b6ae6bbd-53b8-4d76-b611-fdbad81eb3c6_277F29F1-FEAB-4D38-8266-FEB7A1E6227D_LICENSE.txt",
-          "title": "b6ae6bbd-53b8-4d76-b611-fdbad81eb3c6_277F29F1-FEAB-4D38-8266-FEB7A1E6227D_LICENSE.txt",
           "size": 15416
         }
       } ],

--- a/gp2gp-translator/src/integrationTest/resources/json/LargeMessage/expectedBundleScenario2.json
+++ b/gp2gp-translator/src/integrationTest/resources/json/LargeMessage/expectedBundleScenario2.json
@@ -509,7 +509,6 @@
         "attachment": {
           "contentType": "application/binary",
           "url": "517146eb-229c-42d3-9e1b-bf86757775e5_898A1474-F39B-491F-AEFF-315E884C26EA.txt",
-          "title": "517146eb-229c-42d3-9e1b-bf86757775e5_898A1474-F39B-491F-AEFF-315E884C26EA.txt",
           "size": 611
         }
       } ],

--- a/gp2gp-translator/src/integrationTest/resources/json/LargeMessage/expectedBundleScenario3.json
+++ b/gp2gp-translator/src/integrationTest/resources/json/LargeMessage/expectedBundleScenario3.json
@@ -509,7 +509,6 @@
         "attachment": {
           "contentType": "video/mpeg",
           "url": "1459976e-bb80-4335-b94e-89dadba685fe_8681AF4F-E577-4C8D-A2CE-43CABE3D5FB4_sample_mpeg4.mp4",
-          "title": "1459976e-bb80-4335-b94e-89dadba685fe_8681AF4F-E577-4C8D-A2CE-43CABE3D5FB4_sample_mpeg4.mp4",
           "size": 327708
         }
       } ],

--- a/gp2gp-translator/src/integrationTest/resources/json/LargeMessage/expectedBundleScenario4.json
+++ b/gp2gp-translator/src/integrationTest/resources/json/LargeMessage/expectedBundleScenario4.json
@@ -509,7 +509,6 @@
         "attachment": {
           "contentType": "text/plain",
           "url": "5739c03e-af1c-4490-8439-15d24bb66801_7CCB6A77-360E-434E-8CF4-97C7C2B47D70_book.txt",
-          "title": "5739c03e-af1c-4490-8439-15d24bb66801_7CCB6A77-360E-434E-8CF4-97C7C2B47D70_book.txt",
           "size": 1695240
         }
       } ],

--- a/gp2gp-translator/src/integrationTest/resources/json/LargeMessage/expectedBundleScenario5.json
+++ b/gp2gp-translator/src/integrationTest/resources/json/LargeMessage/expectedBundleScenario5.json
@@ -508,8 +508,7 @@
       "content": [ {
         "attachment": {
           "contentType": "text/plain",
-          "url": "file://localhost/277F29F1-FEAB-4D38-8266-FEB7A1E6227D_LICENSE.txt",
-          "title": "Filename: 277F29F1-FEAB-4D38-8266-FEB7A1E6227D_LICENSE.txt"
+          "url": "file://localhost/277F29F1-FEAB-4D38-8266-FEB7A1E6227D_LICENSE.txt"
         }
       } ],
       "context": {

--- a/gp2gp-translator/src/integrationTest/resources/json/LargeMessage/expectedBundleScenario6.json
+++ b/gp2gp-translator/src/integrationTest/resources/json/LargeMessage/expectedBundleScenario6.json
@@ -733,7 +733,6 @@
         "attachment": {
           "contentType": "image/tiff",
           "url": "17f220bd-8793-44fc-a518-a50da34c8ed1_588210BB-401D-41F9-84D2-978697CEEFE5_00011000.tif",
-          "title": "17f220bd-8793-44fc-a518-a50da34c8ed1_588210BB-401D-41F9-84D2-978697CEEFE5_00011000.tif",
           "size": 36504
         }
       } ],

--- a/gp2gp-translator/src/integrationTest/resources/json/LargeMessage/expectedBundleScenario7.json
+++ b/gp2gp-translator/src/integrationTest/resources/json/LargeMessage/expectedBundleScenario7.json
@@ -508,8 +508,7 @@
       "content": [ {
         "attachment": {
           "contentType": "text/plain",
-          "url": "file://localhost/277F29F1-FEAB-4D38-8266-FEB7A1E6227D_LICENSE.txt",
-          "title": "Filename: 277F29F1-FEAB-4D38-8266-FEB7A1E6227D_LICENSE.txt"
+          "url": "file://localhost/277F29F1-FEAB-4D38-8266-FEB7A1E6227D_LICENSE.txt"
         }
       } ],
       "context": {

--- a/gp2gp-translator/src/integrationTest/resources/json/LargeMessage/expectedBundleScenario8.json
+++ b/gp2gp-translator/src/integrationTest/resources/json/LargeMessage/expectedBundleScenario8.json
@@ -509,7 +509,6 @@
         "attachment": {
           "contentType": "text/plain",
           "url": "47ccb416-abc0-4479-bbe8-9016c06917b1_7CCB6A77-360E-434E-8CF4-97C7C2B47D70_book.txt",
-          "title": "47ccb416-abc0-4479-bbe8-9016c06917b1_7CCB6A77-360E-434E-8CF4-97C7C2B47D70_book.txt",
           "size": 2152228
         }
       } ],

--- a/gp2gp-translator/src/integrationTest/resources/json/LargeMessage/expectedBundleScenario9.json
+++ b/gp2gp-translator/src/integrationTest/resources/json/LargeMessage/expectedBundleScenario9.json
@@ -509,7 +509,6 @@
         "attachment": {
           "contentType": "text/plain",
           "url": "1e448cdc-c03f-428b-be48-61117d70b963_7CCB6A77-360E-434E-8CF4-97C7C2B47D70_book.txt",
-          "title": "1e448cdc-c03f-428b-be48-61117d70b963_7CCB6A77-360E-434E-8CF4-97C7C2B47D70_book.txt",
           "size": 2152228
         }
       } ],

--- a/gp2gp-translator/src/integrationTest/resources/json/expectedBundle.json
+++ b/gp2gp-translator/src/integrationTest/resources/json/expectedBundle.json
@@ -30627,8 +30627,7 @@
           {
             "attachment": {
               "contentType": "text/plain",
-              "url": "file://localhost/31B75ED0-6E88-11EA-9384-E83935108FD5_patient-attachment.txt.txt",
-              "title": "31B75ED0-6E88-11EA-9384-E83935108FD5_patient-attachment.txt.txt"
+              "url": "file://localhost/31B75ED0-6E88-11EA-9384-E83935108FD5_patient-attachment.txt.txt"
             }
           }
         ],
@@ -30683,8 +30682,7 @@
           {
             "attachment": {
               "contentType": "text/plain",
-              "url": "file://localhost/31B75ED0-6E88-11EA-9384-E83935108FD5_patient-attachment.txt.txt",
-              "title": "31B75ED0-6E88-11EA-9384-E83935108FD5_patient-attachment.txt.txt"
+              "url": "file://localhost/31B75ED0-6E88-11EA-9384-E83935108FD5_patient-attachment.txt.txt"
             }
           }
         ],
@@ -30739,8 +30737,7 @@
           {
             "attachment": {
               "contentType": "text/plain",
-              "url": "file://localhost/31B75ED0-6E88-11EA-9384-E83935108FD5_patient-attachment.txt",
-              "title": "31B75ED0-6E88-11EA-9384-E83935108FD5_patient-attachment.txt"
+              "url": "file://localhost/31B75ED0-6E88-11EA-9384-E83935108FD5_patient-attachment.txt"
             }
           }
         ],

--- a/gp2gp-translator/src/main/java/uk/nhs/adaptors/pss/translator/mapper/DocumentReferenceMapper.java
+++ b/gp2gp-translator/src/main/java/uk/nhs/adaptors/pss/translator/mapper/DocumentReferenceMapper.java
@@ -168,7 +168,6 @@ public class DocumentReferenceMapper extends AbstractMapper<DocumentReference> {
 
             if (!isAbsentAttachment(narrativeStatement)) {
                 attachment.setUrl(referenceToExternalDocument.getText().getReference().getValue());
-                attachment.setTitle(buildFileName(referenceToExternalDocument.getText().getReference().getValue()));
 
                 if (attachmentSize != null) {
                     attachment.setSize(attachmentSize);

--- a/gp2gp-translator/src/test/java/uk/nhs/adaptors/pss/translator/mapper/DocumentReferenceTest.java
+++ b/gp2gp-translator/src/test/java/uk/nhs/adaptors/pss/translator/mapper/DocumentReferenceTest.java
@@ -174,7 +174,7 @@ public class DocumentReferenceTest {
     }
 
     private void assertAttachmentData(DocumentReference documentReference) {
-        assertThat(documentReference.getContent().get(0).getAttachment().getTitle()).isEqualTo(FILENAME);
+        assertThat(documentReference.getContent().get(0).getAttachment().getTitle()).isNull();
         assertThat(documentReference.getContent().get(0).getAttachment().getUrl()).isEqualTo(URL);
         assertThat(documentReference.getContent().get(0).getAttachment().getContentType()).isEqualTo(CONTENT_TYPE);
         assertThat(documentReference.getContent().get(0).getAttachment().getSize()).isEqualTo(ATTACHMENT_SIZE);


### PR DESCRIPTION
Subsequent PR for #231 

A resource with one document reference resource, the content field of which is shown below:

```
 "content": [
              {
                "attachment": {
                  "contentType": "text/plain",
                  "url": "https://<url-to-file>",
                  "size": 604,
                  "title": "https://<url-to-file>"
                }
              }
            ],
```
As expected, the attachment.size and attachment.url fields are both present. However, the attachment.title field is also present. The [documentation ](https://developer.nhs.uk/apis/gpconnect-1-6-0/access_documents_development_documentreference.html#contentattachmenttitle)states the title is intended to hold the reason a file isn’t available. Therefore it is not needed here.