### PR TITLE
NIAD-2576: Mapping Bug PWTP9 - Reference range comparators is not a supported item in FHIR

### DIFF
--- a/gp2gp-translator/src/integrationTest/resources/e2e-mapping/output-json/PWTP9-output.json
+++ b/gp2gp-translator/src/integrationTest/resources/e2e-mapping/output-json/PWTP9-output.json
@@ -3731,7 +3731,6 @@
       } ],
       "valueQuantity": {
         "value": 0.5,
-        "comparator": "<=",
         "unit": "g/L"
       },
       "specimen": {
@@ -3785,7 +3784,6 @@
       } ],
       "valueQuantity": {
         "value": 1000,
-        "comparator": ">=",
         "unit": "ng/L"
       },
       "specimen": {
@@ -3932,7 +3930,6 @@
       } ],
       "valueQuantity": {
         "value": 200,
-        "comparator": ">",
         "unit": "mg/L"
       },
       "specimen": {
@@ -11728,7 +11725,6 @@
       } ],
       "valueQuantity": {
         "value": 0.1000000000000000055511151231257827021181583404541015625,
-        "comparator": "<",
         "unit": "10*9/L"
       },
       "referenceRange": [ {

--- a/gp2gp-translator/src/main/java/uk/nhs/adaptors/pss/translator/util/ObservationUtil.java
+++ b/gp2gp-translator/src/main/java/uk/nhs/adaptors/pss/translator/util/ObservationUtil.java
@@ -41,6 +41,8 @@ public class ObservationUtil {
             } else {
                 valueQuantity = QUANTITY_MAPPER.mapQuantity((IVLPQ) value);
             }
+            
+            valueQuantity.setComparator(null);
 
             if (uncertaintyCode != null) {
                 valueQuantity.getExtension().add(new Extension()

--- a/gp2gp-translator/src/main/java/uk/nhs/adaptors/pss/translator/util/ObservationUtil.java
+++ b/gp2gp-translator/src/main/java/uk/nhs/adaptors/pss/translator/util/ObservationUtil.java
@@ -41,7 +41,6 @@ public class ObservationUtil {
             } else {
                 valueQuantity = QUANTITY_MAPPER.mapQuantity((IVLPQ) value);
             }
-            
             valueQuantity.setComparator(null);
 
             if (uncertaintyCode != null) {


### PR DESCRIPTION
Under Resource Type Observation the the data item valueQuantity has a field called “comparator“. This needs to be removed…

                "valueQuantity": {
                    "value": 1000.000,
                    "comparator": ">=",
                    "unit": "ng/L"
                },


Update ObservationUtil to remove comparator if ValueQuantity mapper adds 
Update expected PWTP9 output for E2E Tests to ensure comparator is not set for observations