### PR TITLE
Niad-2612: bugfix diagnostic report result referencing

### DIFF
--- a/gp2gp-translator/src/integrationTest/resources/e2e-mapping/output-json/PWTP9-output.json
+++ b/gp2gp-translator/src/integrationTest/resources/e2e-mapping/output-json/PWTP9-output.json
@@ -16566,18 +16566,6 @@
         ],
         "result": [
           {
-            "reference": "Observation/97D287E0-1613-45D7-BF35-1A5758796E01"
-          },
-          {
-            "reference": "Observation/BE104861-C99D-4DE5-BF5E-A87D44FF4F6A"
-          },
-          {
-            "reference": "Observation/1F0CDC7B-BD70-424B-A885-7BBC5A42C7AD"
-          },
-          {
-            "reference": "Observation/C83C896F-E847-4FE8-AB86-A7949F5A4D5A"
-          },
-          {
             "reference": "Observation/5668ACD3-4700-4C6B-B6EE-A9F28A80A780"
           }
         ]
@@ -16626,18 +16614,6 @@
         ],
         "result": [
           {
-            "reference": "Observation/7D29B0F6-EE38-44DC-A762-21F8D167E827"
-          },
-          {
-            "reference": "Observation/A0EFCDBD-B2D1-4D87-9D5A-3AA9F51BFFED"
-          },
-          {
-            "reference": "Observation/5F044AF2-8BBA-4569-8967-06D06E0B3644"
-          },
-          {
-            "reference": "Observation/C254A5AF-5D3A-49B4-BAA6-81E1BA144BBA"
-          },
-          {
             "reference": "Observation/F15C600B-7482-4D0E-938E-78279096DB18"
           }
         ]
@@ -16685,18 +16661,6 @@
           }
         ],
         "result": [
-          {
-            "reference": "Observation/7678077F-26D7-46F0-A195-16228EE11369"
-          },
-          {
-            "reference": "Observation/2B9134CC-56D2-40BC-BAEB-855B90D2ECC9"
-          },
-          {
-            "reference": "Observation/DD8D3D76-7E97-4A2A-A372-66799FA9EACF"
-          },
-          {
-            "reference": "Observation/3FCF9063-A612-4542-853A-7E38B8BAD1A9"
-          },
           {
             "reference": "Observation/1834153D-6DB1-43FB-BE4E-8F53C62882FE"
           }
@@ -16752,70 +16716,13 @@
         ],
         "result": [
           {
-            "reference": "Observation/01098FF9-D3FF-496A-977F-ED392DBAD54D"
-          },
-          {
-            "reference": "Observation/E787706E-1E26-484C-9320-77CA84961B75"
-          },
-          {
-            "reference": "Observation/12ACE36E-16C8-4274-85A8-4F054BCA1FF9"
-          },
-          {
             "reference": "Observation/C08DC916-614C-4F49-8505-86F6D57E6EB5"
-          },
-          {
-            "reference": "Observation/E7DD9AF8-4865-4FE8-B2BE-B1AA65150A7F"
-          },
-          {
-            "reference": "Observation/8CC6511A-ABAC-4AB0-8879-06E3C7006469"
-          },
-          {
-            "reference": "Observation/174808E1-1A4D-44F9-8E47-132A8D4CB55B"
-          },
-          {
-            "reference": "Observation/40FD13C3-50FB-423F-8E42-F1E630260521"
           },
           {
             "reference": "Observation/057C3B4D-69BD-4DCB-915C-3DC0AF875E50"
           },
           {
             "reference": "Observation/BA2E67A6-43E3-423B-9C7C-971C6B19211C"
-          },
-          {
-            "reference": "Observation/18238625-DA03-46E2-9C8C-46EFF7E5617D"
-          },
-          {
-            "reference": "Observation/38F86682-1295-4F7F-9BF4-A9E644BF5EB5"
-          },
-          {
-            "reference": "Observation/72E2F295-F90B-4C0C-8AA1-45019B9E715E"
-          },
-          {
-            "reference": "Observation/4070E0E4-5207-4AB8-881E-0F9FCB15CB3F"
-          },
-          {
-            "reference": "Observation/40E51B3E-B2B9-4DFC-AAF0-446C23A1FA91"
-          },
-          {
-            "reference": "Observation/7DD41119-5BF3-4EEA-9A46-7BD579A2BBD5"
-          },
-          {
-            "reference": "Observation/8839823F-1DA8-4724-B956-7665B25096A5"
-          },
-          {
-            "reference": "Observation/476BB667-97FE-4761-A29A-B4C06A22C1A2"
-          },
-          {
-            "reference": "Observation/578AB598-B8C4-4282-A013-56803DC0AD9F"
-          },
-          {
-            "reference": "Observation/4B0109D0-86BE-42D3-9CC4-A28B0D71BA40"
-          },
-          {
-            "reference": "Observation/476F133F-A18A-451A-9A90-5777AFCDA6C2"
-          },
-          {
-            "reference": "Observation/8E2D33CD-6682-4F77-923A-FB6EF652BC71"
           },
           {
             "reference": "Observation/9BDA0AA6-965B-4593-82E4-E370EE6850EF"
@@ -16875,37 +16782,7 @@
             "reference": "Observation/45F8816D-FC99-4131-ABE6-01CD8A8DE49C"
           },
           {
-            "reference": "Observation/DF6691CB-9617-4701-A186-17F197A997A0"
-          },
-          {
-            "reference": "Observation/01A03AE1-ADC5-4A7B-B6B4-BB391F498A7C"
-          },
-          {
-            "reference": "Observation/E346D597-8A42-4631-BA4D-0C8A17F62C0D"
-          },
-          {
-            "reference": "Observation/C38CCDE2-9EFB-4249-BB78-D23C312D66A4"
-          },
-          {
-            "reference": "Observation/5FFC469E-00A9-4F2F-AE4A-BCA589416266"
-          },
-          {
-            "reference": "Observation/F76B671C-D2CE-409F-B801-4320B20D4CA4"
-          },
-          {
             "reference": "Observation/B39D6784-5532-45FB-BDCC-7F7F21A70857"
-          },
-          {
-            "reference": "Observation/33DFF813-0B97-4D38-906D-B477946390BE"
-          },
-          {
-            "reference": "Observation/AB137387-5068-42C6-BC0A-FC6CE39FD813"
-          },
-          {
-            "reference": "Observation/A7DC554C-1738-4E1A-BF83-5144DA40CA7F"
-          },
-          {
-            "reference": "Observation/DD3CF20D-03A5-4310-954C-47DA2D5BBFB2"
           },
           {
             "reference": "Observation/CDC2077F-F701-47F9-AFF9-87E8C07E8C69"
@@ -16964,21 +16841,6 @@
           },
           {
             "reference": "Observation/36DA8895-114B-40D6-9FA1-82B543D86893"
-          },
-          {
-            "reference": "Observation/D6050BB4-0BB2-4481-A0B2-88C94807BEEF"
-          },
-          {
-            "reference": "Observation/F4014842-A140-4B4F-9F5F-EE3C49892D16"
-          },
-          {
-            "reference": "Observation/EAE91006-6F22-476E-BFF4-08FE121F42C6"
-          },
-          {
-            "reference": "Observation/820006B7-2AF3-4C07-B33A-E3C4B65338B1"
-          },
-          {
-            "reference": "Observation/CE493BAD-46EF-4C81-B14C-45827C3E4C7B"
           },
           {
             "reference": "Observation/15A8BA89-FF03-4880-B540-613745F6BFE3"
@@ -17087,51 +16949,6 @@
             "reference": "Observation/69832EFE-727E-4270-BDF5-179851BDF295"
           },
           {
-            "reference": "Observation/BD5058DC-7A94-4467-A422-41F8715FDEEC"
-          },
-          {
-            "reference": "Observation/F7B19B0F-7AE8-4B81-AA47-7931ADBE65FE"
-          },
-          {
-            "reference": "Observation/FDAC8F0E-52C3-41E5-BE5B-7CA0C6FDC181"
-          },
-          {
-            "reference": "Observation/DEDB6849-33B3-4E1D-B095-58B842456136"
-          },
-          {
-            "reference": "Observation/CF6655E2-CA0C-4558-B5D5-243622CAF0FA"
-          },
-          {
-            "reference": "Observation/010C38C8-9940-4CB0-BDE7-F2D1F4BAAE40"
-          },
-          {
-            "reference": "Observation/DA7E7FA0-F286-4C2C-8620-2CA04251D656"
-          },
-          {
-            "reference": "Observation/C133CD71-10AE-49CD-A990-64EC229ACD88"
-          },
-          {
-            "reference": "Observation/B594990F-11E8-435F-A6D5-AAA70A5638B6"
-          },
-          {
-            "reference": "Observation/AE444553-CB79-46EB-BA1B-177CC0D001D8"
-          },
-          {
-            "reference": "Observation/064CD03E-63A0-492B-8897-C4757C73D2D0"
-          },
-          {
-            "reference": "Observation/167BF6A8-D797-470A-B5C2-E5FC497B56AD"
-          },
-          {
-            "reference": "Observation/2FC40009-302A-4429-A15B-37A35F36D4CB"
-          },
-          {
-            "reference": "Observation/054A8A00-1553-4DA2-BC5A-C150D4844DB0"
-          },
-          {
-            "reference": "Observation/E87C2915-678D-4001-9C07-CDAA9A08007C"
-          },
-          {
             "reference": "Observation/0F1AD848-FA61-4278-B273-048B0E247D39"
           }
         ],
@@ -17211,12 +17028,6 @@
             "reference": "Observation/D04342AD-DD02-40A4-AE8B-CBB62588B448"
           },
           {
-            "reference": "Observation/54468844-4EF9-4F84-B5AC-1615687AC84D"
-          },
-          {
-            "reference": "Observation/417F140A-E61F-4AC5-9421-7C3CED9EFC51"
-          },
-          {
             "reference": "Observation/8DDBEE57-3545-490B-BE7F-EEB352A5BB6F"
           }
         ]
@@ -17268,28 +17079,7 @@
             "reference": "Observation/5578BCAA-4C60-482E-ADFD-095CC8CAB102"
           },
           {
-            "reference": "Observation/9F80209D-3466-4DF2-B6BB-5C1623C09A37"
-          },
-          {
-            "reference": "Observation/FA8AD8E4-5F0E-4FE2-90DF-7E5694F3A054"
-          },
-          {
-            "reference": "Observation/2C193166-3A4A-4569-91EA-FF93475B2DE6"
-          },
-          {
-            "reference": "Observation/E02A4D1C-78B2-46D1-B899-776FC940C11B"
-          },
-          {
             "reference": "Observation/EBEDD7EA-EE7A-4632-BEE4-FDDA9B4D4B11"
-          },
-          {
-            "reference": "Observation/C737A049-F93E-4C52-AFDF-21B0D1C7298C"
-          },
-          {
-            "reference": "Observation/E47B3A50-EEBE-4336-AA48-5932A01BC1B5"
-          },
-          {
-            "reference": "Observation/8673E805-9884-4040-993A-D72AECF4D363"
           },
           {
             "reference": "Observation/2418B6B6-C4C0-46CB-9030-5B7DD39C80FC"

--- a/gp2gp-translator/src/integrationTest/resources/json/expectedBundle.json
+++ b/gp2gp-translator/src/integrationTest/resources/json/expectedBundle.json
@@ -30355,12 +30355,6 @@
             "reference": "Observation/O277BE3-481B-4254-AA8E-17B2529244B6"
           },
           {
-            "reference": "Observation/OBSERVATION_STATEMENT_ID"
-          },
-          {
-            "reference": "Observation/BATTERY_DIRECT_CHILD_OBSERVATION_STATEMENT"
-          },
-          {
             "reference": "Observation/SPECIMEN_CHILD_BATTERY_COMPOUND_STATEMENT_ID_1"
           }
         ],

--- a/gp2gp-translator/src/main/java/uk/nhs/adaptors/pss/translator/mapper/diagnosticreport/DiagnosticReportMapper.java
+++ b/gp2gp-translator/src/main/java/uk/nhs/adaptors/pss/translator/mapper/diagnosticreport/DiagnosticReportMapper.java
@@ -48,6 +48,12 @@ public class DiagnosticReportMapper extends AbstractMapper<DiagnosticReport> {
     private static final String META_PROFILE_URL_SUFFIX = "DiagnosticReport-1";
     private static final String LAB_REPORT_COMMENT_TYPE = "CommentType:LABORATORY RESULT COMMENT(E141)";
 
+    public static void addResultToDiagnosticReport(Observation observation, DiagnosticReport diagnosticReport) {
+        if (!containsReference(diagnosticReport.getResult(), observation.getId())) {
+            diagnosticReport.addResult(new Reference(observation));
+        }
+    }
+
     @Override
     public List<DiagnosticReport> mapResources(RCMRMT030101UK04EhrExtract ehrExtract, Patient patient, List<Encounter> encounters,
         String practiseCode) {
@@ -219,5 +225,21 @@ public class DiagnosticReportMapper extends AbstractMapper<DiagnosticReport> {
             .setSystem("http://snomed.info/sct")
             .setDisplay("Diagnostic studies report");
         return codeableConcept;
+    }
+
+    private static boolean containsReference(List<Reference> references, String id) {
+        if (!references.isEmpty()) {
+            return references.stream()
+                .map(reference -> {
+                    if (reference.hasReference()) {
+                        return reference.getReference();
+                    }
+                    if (reference.getResource() != null) {
+                        return reference.getResource().getIdElement().getValue();
+                    }
+                    return StringUtils.EMPTY;
+                }).anyMatch(referenceId -> referenceId.contains(id));
+        }
+        return false;
     }
 }

--- a/gp2gp-translator/src/test/java/uk/nhs/adaptors/pss/translator/mapper/diagnosticreport/SpecimenCompoundsMapperTest.java
+++ b/gp2gp-translator/src/test/java/uk/nhs/adaptors/pss/translator/mapper/diagnosticreport/SpecimenCompoundsMapperTest.java
@@ -1,6 +1,9 @@
 package uk.nhs.adaptors.pss.translator.mapper.diagnosticreport;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
 import static org.springframework.util.ResourceUtils.getFile;
 import static uk.nhs.adaptors.pss.translator.util.XmlUnmarshallUtil.unmarshallFile;
 
@@ -102,6 +105,8 @@ public class SpecimenCompoundsMapperTest {
         assertThat(observation.getRelatedFirstRep().getTarget().getResource()).isNotNull();
         assertThat(observation.getRelatedFirstRep().getTarget().getResource().getIdElement().getValue())
             .isEqualTo(NARRATIVE_STATEMENT_ID);
+
+        assertThat(diagnosticReports.get(0).getResult().size()).isOne();
     }
 
     @Test
@@ -115,6 +120,9 @@ public class SpecimenCompoundsMapperTest {
         assertParentSpecimenIsReferenced(observations.get(1));
         assertThat(observationComments.size()).isEqualTo(2);
         assertThat(observationComments.get(0).getComment()).isEqualTo(TEST_COMMENT_LINE_1);
+
+        assertThat(diagnosticReports.get(0).getResult().isEmpty()).isTrue();
+        verify(specimenBatteryMapper, times(1)).mapBatteryObservation(any());
     }
 
     @Test


### PR DESCRIPTION
Diagnostic report is incorrectly referencing all observations instead of just the primary parent observation