### PR TITLE
Niad 2644: bugfix - empty migrate structured headers

### DIFF
--- a/README.md
+++ b/README.md
@@ -214,7 +214,7 @@ messages with an unrecognised conversation ID on a dead letter queue.
 
 - `PS_DAISY_CHAINING_ACTIVE`: set to `true` to enable daisy-chaining - default = `false`
 - `GP2GP_AMQP_BROKERS`: the location of the GP2GP Adaptors inbound queue. This should be set to the url of a single JMS broker 
-- (the PS Adaptor does not support concurrent GP2GP Adaptor brokers) - default = `amqp://localhost:5672`
+(the PS Adaptor does not support concurrent GP2GP Adaptor brokers) - default = `amqp://localhost:5672`
 
 **Optional environment variables:**
 

--- a/gpc-api-facade/src/main/java/uk/nhs/adaptors/pss/gpc/controller/PatientTransferController.java
+++ b/gpc-api-facade/src/main/java/uk/nhs/adaptors/pss/gpc/controller/PatientTransferController.java
@@ -32,7 +32,7 @@ import static uk.nhs.adaptors.pss.gpc.controller.header.HttpHeaders.TO_ODS;
 import java.util.List;
 import java.util.Map;
 
-import javax.validation.constraints.NotNull;
+import javax.validation.constraints.NotBlank;
 
 import org.hl7.fhir.dstu3.model.Parameters;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -86,10 +86,10 @@ public class PatientTransferController {
     )
     public ResponseEntity<String> migratePatientStructuredRecord(
         @RequestBody @PatientTransferRequest Parameters body,
-        @RequestHeader(TO_ASID) @NotNull String toAsid,
-        @RequestHeader(FROM_ASID) @NotNull String fromAsid,
-        @RequestHeader(TO_ODS) @NotNull String toOds,
-        @RequestHeader(FROM_ODS) @NotNull String fromOds) {
+        @RequestHeader(TO_ASID) @NotBlank String toAsid,
+        @RequestHeader(FROM_ASID) @NotBlank String fromAsid,
+        @RequestHeader(TO_ODS) @NotBlank String toOds,
+        @RequestHeader(FROM_ODS) @NotBlank String fromOds) {
         LOGGER.info("Received patient transfer request");
         Map<String, String> headers = Map.of(
             TO_ASID, toAsid,


### PR DESCRIPTION
If the following headers are present in the Migrate Structured Request, the adaptor currently accepts blank values. These are then inserted into to EHR Request.

- `to-asid`

- `from-asid`

- `to-ods`

- `from-ods `

In order to prevent this, the headers should be validated to ensure they are not empty or effectively empty (whitespace only).   