### PR TITLE
NIAD-2640: bugfix - document ref - createdTime throws if nullFlavor

### DIFF
--- a/gp2gp-translator/src/main/java/uk/nhs/adaptors/pss/translator/mapper/DocumentReferenceMapper.java
+++ b/gp2gp-translator/src/main/java/uk/nhs/adaptors/pss/translator/mapper/DocumentReferenceMapper.java
@@ -99,7 +99,7 @@ public class DocumentReferenceMapper extends AbstractMapper<DocumentReference> {
     }
 
     private DateTimeType getCreatedTime(RCMRMT030101UK04EhrComposition ehrComposition) {
-        if (ehrComposition.hasAvailabilityTime()) {
+        if (ehrComposition.hasAvailabilityTime() && ehrComposition.getAvailabilityTime().hasValue()) {
             return DateFormatUtil.parseToDateTimeType(ehrComposition.getAvailabilityTime().getValue());
         }
         return null;

--- a/gp2gp-translator/src/test/java/uk/nhs/adaptors/pss/translator/mapper/DocumentReferenceTest.java
+++ b/gp2gp-translator/src/test/java/uk/nhs/adaptors/pss/translator/mapper/DocumentReferenceTest.java
@@ -129,6 +129,16 @@ public class DocumentReferenceTest {
         assertDocumentReferenceMappedFromNestedNarrativeStatement(documentReference);
     }
 
+    @Test
+    public void mapNarrativeStatementToDocumentReferenceWithNullFlavors() {
+        var ehrExtract = unmarshallEhrExtract("narrative_statement_null_flavors.xml");
+        List<DocumentReference> documentReferences = documentReferenceMapper.mapResources(ehrExtract, createPatient(),
+            getEncounterList(), AUTHOR_ORG, createAttachmentList());
+        var documentReference = documentReferences.get(0);
+
+        assertThat(documentReference.getCreatedElement().asStringValue()).isNull();
+    }
+
     private void assertDocumentReferenceMappedFromNestedNarrativeStatement(DocumentReference documentReference) {
         assertThat(documentReference.getId()).isEqualTo(NARRATIVE_STATEMENT_ROOT_ID);
         assertThat(documentReference.getMeta().getProfile().get(0).getValue()).isEqualTo(META_PROFILE);

--- a/gp2gp-translator/src/test/resources/xml/DocumentReference/narrative_statement_null_flavors.xml
+++ b/gp2gp-translator/src/test/resources/xml/DocumentReference/narrative_statement_null_flavors.xml
@@ -1,0 +1,47 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<EhrExtract xmlns="urn:hl7-org:v3" classCode="EXTRACT" moodCode="EVN">
+    <author typeCode="AUT" contextControlCode="OP">
+        <time value="20100114" />
+    </author>
+    <availabilityTime value="20200101010101" />
+    <component typeCode="COMP">
+        <ehrFolder classCode="FOLDER" moodCode="EVN">
+            <component typeCode="COMP">
+                <ehrComposition classCode="COMPOSITION" moodCode="EVN">
+                    <id root="62A39454-299F-432E-993E-5A6232B4E099"/>
+                    <availabilityTime nullFlavor="UNK"/>
+                    <author typeCode="AUT" contextControlCode="OP">
+                        <time value="20100114" />
+                        <agentRef classCode="AGNT">
+                            <id root="2D70F602-6BB1-47E0-B2EC-39912A59787D" />
+                        </agentRef>
+                    </author>
+                    <Participant2 typeCode="PRF" contextControlCode="OP">
+                        <agentRef classCode="AGNT">
+                            <id root="2D70F602-6BB1-47E0-B2EC-39912A59787D"/>
+                        </agentRef>
+                    </Participant2>
+                    <component typeCode="COMP">
+                        <NarrativeStatement classCode="OBS" moodCode="EVN">
+                            <id root="5E496953-065B-41F2-9577-BE8F2FBD0757"/>
+                            <text mediaType="text/x-h7uk-pmip">Some example text</text>
+                            <statusCode code="COMPLETE"/>
+                            <availabilityTime nullFlavor="UNK"/>
+                            <reference typeCode="REFR">
+                                <referredToExternalDocument classCode="DOC" moodCode="EVN">
+                                    <id root="31B75ED0-6E88-11EA-9384-E83935108FD5" />
+                                    <code code="25821000000100" codeSystem="2.16.840.1.113883.2.1.3.2.4.15" displayName="Original Text document">
+                                        <originalText>Record Attachment</originalText>
+                                    </code>
+                                    <text mediaType="text/plain">
+                                        <reference value="file://localhost/31B75ED0-6E88-11EA-9384-E83935108FD5_patient-attachment.txt" />
+                                    </text>
+                                </referredToExternalDocument>
+                            </reference>
+                        </NarrativeStatement>
+                    </component>
+                </ehrComposition>
+            </component>
+        </ehrFolder>
+    </component>
+</EhrExtract>

--- a/test-suite/docker-compose.yml
+++ b/test-suite/docker-compose.yml
@@ -38,6 +38,7 @@ services:
       - MHS_INBOUND_USE_SSL
       - TCP_PORTS=${MHS_INBOUND_PORT}
       - SERVICE_PORTS=${MHS_INBOUND_SERVICE_PORTS}
+      - SUPPORTED_FILE_TYPES
 
   outbound:
     image: ${MHS_OUTBOUND_VERSION}
@@ -67,6 +68,7 @@ services:
       - MHS_OUTBOUND_ROUTING_LOOKUP_METHOD
       - MHS_SDS_API_URL
       - MHS_SDS_API_KEY
+      - SUPPORTED_FILE_TYPES
 
   #  route:
   #    image: nhsdev/nia-mhs-route:1.2.2

--- a/test-suite/docker/docker-compose.yml
+++ b/test-suite/docker/docker-compose.yml
@@ -11,7 +11,7 @@ services:
   ############### MHS specific   ###################
 
   inbound:
-    image: nhsdev/nia-mhs-inbound:1.2.2
+    image: ${MHS_INBOUND_VERSION}
     networks:
       - nia-ps
     ports:
@@ -38,9 +38,10 @@ services:
       - MHS_INBOUND_USE_SSL
       - TCP_PORTS=${MHS_INBOUND_PORT}
       - SERVICE_PORTS=${MHS_INBOUND_SERVICE_PORTS}
+      - SUPPORTED_FILE_TYPES
 
   outbound:
-    image: nhsdev/nia-mhs-outbound:1.2.2
+    image: ${MHS_OUTBOUND_VERSION}
     networks:
       - nia-ps
     ports:
@@ -67,6 +68,7 @@ services:
       - MHS_OUTBOUND_ROUTING_LOOKUP_METHOD
       - MHS_SDS_API_URL
       - MHS_SDS_API_KEY
+      - SUPPORTED_FILE_TYPES
 
   route:
     image: nhsdev/nia-mhs-route:1.2.2


### PR DESCRIPTION
If the ehrComposition has an availabiltyTime but this has no value then an exception will be thrown trying to parse to the DateTimeType. This should be handled by checking that the it has an availabilityTime and that the value is not null, before attempting to parse to datetime