### PR TITLE
NIAD-2648: bugfix - blood pressure parent missing

### DIFF
--- a/gp2gp-translator/src/main/java/uk/nhs/adaptors/pss/translator/mapper/BloodPressureMapper.java
+++ b/gp2gp-translator/src/main/java/uk/nhs/adaptors/pss/translator/mapper/BloodPressureMapper.java
@@ -3,6 +3,7 @@ package uk.nhs.adaptors.pss.translator.mapper;
 import static uk.nhs.adaptors.pss.translator.util.BloodPressureValidatorUtil.containsValidBloodPressureTriple;
 import static uk.nhs.adaptors.pss.translator.util.BloodPressureValidatorUtil.isDiastolicBloodPressure;
 import static uk.nhs.adaptors.pss.translator.util.BloodPressureValidatorUtil.isSystolicBloodPressure;
+import static uk.nhs.adaptors.pss.translator.util.CDUtil.extractSnomedCode;
 import static uk.nhs.adaptors.pss.translator.util.ObservationUtil.getEffective;
 import static uk.nhs.adaptors.pss.translator.util.ObservationUtil.getInterpretation;
 import static uk.nhs.adaptors.pss.translator.util.ObservationUtil.getIssued;
@@ -129,11 +130,16 @@ public class BloodPressureMapper extends AbstractMapper<Observation> {
                 .map(RCMRMT030101UK04PertinentInformation02::getPertinentAnnotation)
                 .map(RCMRMT030101UK04Annotation::getText)
                 .map(text -> {
-                    if (isSystolicBloodPressure(observationStatement.getCode().getCode())) {
-                        return SYSTOLIC_NOTE + text + StringUtils.SPACE;
-                    }
-                    if (isDiastolicBloodPressure(observationStatement.getCode().getCode())) {
-                        return DIASTOLIC_NOTE + text + StringUtils.SPACE;
+
+                    var code = extractSnomedCode(observationStatement.getCode());
+
+                    if (code.isPresent()) {
+                        if (isSystolicBloodPressure(code.orElseThrow())) {
+                            return SYSTOLIC_NOTE + text + StringUtils.SPACE;
+                        }
+                        if (isDiastolicBloodPressure(code.orElseThrow())) {
+                            return DIASTOLIC_NOTE + text + StringUtils.SPACE;
+                        }
                     }
                     return StringUtils.EMPTY;
                 })

--- a/gp2gp-translator/src/main/java/uk/nhs/adaptors/pss/translator/mapper/ObservationMapper.java
+++ b/gp2gp-translator/src/main/java/uk/nhs/adaptors/pss/translator/mapper/ObservationMapper.java
@@ -33,6 +33,8 @@ import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 import static org.hl7.fhir.dstu3.model.Observation.ObservationStatus.FINAL;
+
+import static uk.nhs.adaptors.pss.translator.util.CDUtil.extractSnomedCode;
 import static uk.nhs.adaptors.pss.translator.util.CompoundStatementResourceExtractors.extractAllObservationStatementsWithoutAllergies;
 import static uk.nhs.adaptors.pss.translator.util.CompoundStatementResourceExtractors.extractAllRequestStatements;
 import static uk.nhs.adaptors.pss.translator.util.ObservationUtil.getEffective;
@@ -138,9 +140,13 @@ public class ObservationMapper extends AbstractMapper<Observation> {
     }
 
     private boolean isNotBloodPressure(RCMRMT030101UK04ObservationStatement observationStatement) {
-        if (observationStatement.hasCode() && observationStatement.getCode().hasCode()) {
-            return !BloodPressureValidatorUtil.isSystolicBloodPressure(observationStatement.getCode().getCode())
-                && !BloodPressureValidatorUtil.isDiastolicBloodPressure(observationStatement.getCode().getCode());
+        if (observationStatement.hasCode()) {
+            var code = extractSnomedCode(observationStatement.getCode());
+
+            if (code.isPresent()) {
+                return !BloodPressureValidatorUtil.isSystolicBloodPressure(code.orElseThrow())
+                    && !BloodPressureValidatorUtil.isDiastolicBloodPressure(code.orElseThrow());
+            }
         }
         return true;
     }

--- a/gp2gp-translator/src/main/java/uk/nhs/adaptors/pss/translator/mapper/diagnosticreport/SpecimenMapper.java
+++ b/gp2gp-translator/src/main/java/uk/nhs/adaptors/pss/translator/mapper/diagnosticreport/SpecimenMapper.java
@@ -1,5 +1,6 @@
 package uk.nhs.adaptors.pss.translator.mapper.diagnosticreport;
 
+import static uk.nhs.adaptors.pss.translator.util.CDUtil.extractSnomedCode;
 import static uk.nhs.adaptors.pss.translator.util.ResourceUtil.buildIdentifier;
 import static uk.nhs.adaptors.pss.translator.util.ResourceUtil.generateMeta;
 import static uk.nhs.adaptors.pss.translator.util.TextUtil.extractPmipComment;
@@ -166,9 +167,11 @@ public class SpecimenMapper {
         return topLevelComponents.stream()
             .flatMap(CompoundStatementResourceExtractors::extractAllCompoundStatements)
             .filter(Objects::nonNull)
-            .filter(compoundStatement -> compoundStatement.hasCode()
-                && compoundStatement.getCode().hasCode()
-                && compoundStatement.getCode().getCode().equals(SPECIMEN_CODE)
-            ).toList();
+            .filter(RCMRMT030101UK04CompoundStatement::hasCode)
+            .filter(compoundStatement -> {
+                Optional<String> code = extractSnomedCode(compoundStatement.getCode());
+                return code.map(SPECIMEN_CODE::equals).orElse(false);
+            })
+            .toList();
     }
 }

--- a/gp2gp-translator/src/main/java/uk/nhs/adaptors/pss/translator/util/BloodPressureValidatorUtil.java
+++ b/gp2gp-translator/src/main/java/uk/nhs/adaptors/pss/translator/util/BloodPressureValidatorUtil.java
@@ -1,5 +1,7 @@
 package uk.nhs.adaptors.pss.translator.util;
 
+import static uk.nhs.adaptors.pss.translator.util.CodeUtil.extractSnomedCode;
+
 import java.util.Arrays;
 import java.util.List;
 import java.util.Objects;
@@ -77,8 +79,16 @@ public class BloodPressureValidatorUtil {
             .toList();
 
         if (observationStatements.size() == 2) {
-            return BloodPressureValidatorUtil.validateBloodPressureTriple(compoundStatement.getCode().getCode(),
-                observationStatements.get(0).getCode().getCode(), observationStatements.get(1).getCode().getCode());
+            var compoundStatementCode = extractSnomedCode(compoundStatement.getCode());
+            var obsStatementCode1 = extractSnomedCode(observationStatements.get(0).getCode());
+            var obsStatementCode2 = extractSnomedCode(observationStatements.get(1).getCode());
+
+            if (compoundStatementCode.isEmpty() || obsStatementCode1.isEmpty() || obsStatementCode2.isEmpty()) {
+                return false;
+            }
+
+            return BloodPressureValidatorUtil.validateBloodPressureTriple(compoundStatementCode.get(), obsStatementCode1.get(),
+                obsStatementCode2.get());
         }
 
         return false;

--- a/gp2gp-translator/src/main/java/uk/nhs/adaptors/pss/translator/util/BloodPressureValidatorUtil.java
+++ b/gp2gp-translator/src/main/java/uk/nhs/adaptors/pss/translator/util/BloodPressureValidatorUtil.java
@@ -1,10 +1,11 @@
 package uk.nhs.adaptors.pss.translator.util;
 
-import static uk.nhs.adaptors.pss.translator.util.CodeUtil.extractSnomedCode;
+import static uk.nhs.adaptors.pss.translator.util.CDUtil.extractSnomedCode;
 
 import java.util.Arrays;
 import java.util.List;
 import java.util.Objects;
+import java.util.Optional;
 
 import org.hl7.v3.RCMRMT030101UK04Component02;
 import org.hl7.v3.RCMRMT030101UK04CompoundStatement;
@@ -79,9 +80,9 @@ public class BloodPressureValidatorUtil {
             .toList();
 
         if (observationStatements.size() == 2) {
-            var compoundStatementCode = extractSnomedCode(compoundStatement.getCode());
-            var obsStatementCode1 = extractSnomedCode(observationStatements.get(0).getCode());
-            var obsStatementCode2 = extractSnomedCode(observationStatements.get(1).getCode());
+            Optional<String> compoundStatementCode = extractSnomedCode(compoundStatement.getCode());
+            Optional<String> obsStatementCode1 = extractSnomedCode(observationStatements.get(0).getCode());
+            Optional<String> obsStatementCode2 = extractSnomedCode(observationStatements.get(1).getCode());
 
             if (compoundStatementCode.isEmpty() || obsStatementCode1.isEmpty() || obsStatementCode2.isEmpty()) {
                 return false;

--- a/gp2gp-translator/src/main/java/uk/nhs/adaptors/pss/translator/util/CDUtil.java
+++ b/gp2gp-translator/src/main/java/uk/nhs/adaptors/pss/translator/util/CDUtil.java
@@ -4,7 +4,7 @@ import java.util.Optional;
 
 import org.hl7.v3.CD;
 
-public class CodeUtil {
+public class CDUtil {
 
     private final static String SNOMED_CODE_SYSTEM = "2.16.840.1.113883.2.1.3.2.4.15";
 

--- a/gp2gp-translator/src/main/java/uk/nhs/adaptors/pss/translator/util/CDUtil.java
+++ b/gp2gp-translator/src/main/java/uk/nhs/adaptors/pss/translator/util/CDUtil.java
@@ -6,7 +6,7 @@ import org.hl7.v3.CD;
 
 public class CDUtil {
 
-    private final static String SNOMED_CODE_SYSTEM = "2.16.840.1.113883.2.1.3.2.4.15";
+    private static final String SNOMED_CODE_SYSTEM = "2.16.840.1.113883.2.1.3.2.4.15";
 
     public static Optional<String> extractSnomedCode(CD cd) {
 
@@ -15,11 +15,11 @@ public class CDUtil {
         }
 
         if (!cd.getTranslation().isEmpty()) {
-           return cd.getTranslation().stream()
-               .filter(translation -> translation.hasCode() && translation.hasCodeSystem())
-               .filter(translation -> translation.getCodeSystem().equals(SNOMED_CODE_SYSTEM))
-               .map(CD::getCode)
-               .findFirst();
+            return cd.getTranslation().stream()
+                .filter(translation -> translation.hasCode() && translation.hasCodeSystem())
+                .filter(translation -> translation.getCodeSystem().equals(SNOMED_CODE_SYSTEM))
+                .map(CD::getCode)
+                .findFirst();
         }
 
         return Optional.empty();

--- a/gp2gp-translator/src/main/java/uk/nhs/adaptors/pss/translator/util/CodeUtil.java
+++ b/gp2gp-translator/src/main/java/uk/nhs/adaptors/pss/translator/util/CodeUtil.java
@@ -1,0 +1,27 @@
+package uk.nhs.adaptors.pss.translator.util;
+
+import java.util.Optional;
+
+import org.hl7.v3.CD;
+
+public class CodeUtil {
+
+    private final static String SNOMED_CODE_SYSTEM = "2.16.840.1.113883.2.1.3.2.4.15";
+
+    public static Optional<String> extractSnomedCode(CD cd) {
+
+        if (cd.hasCode() && cd.hasCodeSystem() && cd.getCodeSystem().equals(SNOMED_CODE_SYSTEM)) {
+            return Optional.of(cd.getCode());
+        }
+
+        if (!cd.getTranslation().isEmpty()) {
+           return cd.getTranslation().stream()
+               .filter(translation -> translation.hasCode() && translation.hasCodeSystem())
+               .filter(translation -> translation.getCodeSystem().equals(SNOMED_CODE_SYSTEM))
+               .map(CD::getCode)
+               .findFirst();
+        }
+
+        return Optional.empty();
+    }
+}

--- a/gp2gp-translator/src/main/java/uk/nhs/adaptors/pss/translator/util/ResourceFilterUtil.java
+++ b/gp2gp-translator/src/main/java/uk/nhs/adaptors/pss/translator/util/ResourceFilterUtil.java
@@ -1,7 +1,10 @@
 package uk.nhs.adaptors.pss.translator.util;
 
+import static uk.nhs.adaptors.pss.translator.util.CDUtil.extractSnomedCode;
+
 import java.util.List;
 import java.util.Objects;
+import java.util.Optional;
 
 import org.hl7.v3.RCMRMT030101UK04CompoundStatement;
 import org.hl7.v3.RCMRMT030101UK04EhrExtract;
@@ -37,10 +40,13 @@ public class ResourceFilterUtil {
     }
 
     public static boolean isDiagnosticReport(RCMRMT030101UK04CompoundStatement compoundStatement) {
-        return compoundStatement != null
-            && hasCode(compoundStatement)
-            && compoundStatement.getClassCode().stream().anyMatch(CLUSTER_VALUE::equals)
-            && PATHOLOGY_CODE.equals(compoundStatement.getCode().getCode());
+        if (compoundStatement != null && hasCode(compoundStatement)
+            && compoundStatement.getClassCode().stream().anyMatch(CLUSTER_VALUE::equals)) {
+
+            Optional<String> code = extractSnomedCode(compoundStatement.getCode());
+            return code.map(PATHOLOGY_CODE::equals).orElse(false);
+        }
+        return false;
     }
 
     public static boolean hasDiagnosticReportParent(RCMRMT030101UK04EhrExtract ehrExtract,
@@ -56,9 +62,12 @@ public class ResourceFilterUtil {
     }
 
     public static boolean isSpecimen(RCMRMT030101UK04CompoundStatement compoundStatement) {
-        return compoundStatement != null
-            && hasCode(compoundStatement)
-            && SPECIMEN_CODE.equals(compoundStatement.getCode().getCode());
+        if (compoundStatement != null && hasCode(compoundStatement)) {
+            Optional<String> code = extractSnomedCode(compoundStatement.getCode());
+            return code.map(SPECIMEN_CODE::equals).orElse(false);
+        }
+
+        return false;
     }
 
     public static boolean isTemplate(RCMRMT030101UK04CompoundStatement compoundStatement) {

--- a/gp2gp-translator/src/test/resources/xml/BloodPressure/triple_with_snomed.xml
+++ b/gp2gp-translator/src/test/resources/xml/BloodPressure/triple_with_snomed.xml
@@ -1,0 +1,50 @@
+<CompoundStatement xmlns="urn:hl7-org:v3" classCode="BATTERY" moodCode="EVN">
+    <id root="384DBA09-B72E-11ED-808B-AC162D1F16F0"/>
+    <code code="163020007" codeSystem="2.16.840.1.113883.2.1.3.2.4.15" displayName="O/E - blood pressure reading">
+        <translation code="246..00" codeSystem="2.16.840.1.113883.2.1.6.2" displayName="O/E - blood pressure reading"/>
+        <translation code="246.." codeSystem="2.16.840.1.113883.2.1.3.2.4.14" displayName="O/E - blood pressure reading"/>
+    </code>
+    <statusCode code="COMPLETE"/>
+    <effectiveTime>
+        <center value="20101216100132"/>
+    </effectiveTime>
+    <availabilityTime value="20101216100132"/>
+    <component typeCode="COMP" contextConductionInd="true">
+        <ObservationStatement classCode="OBS" moodCode="EVN">
+            <id root="384DBA0A-B72E-11ED-808B-AC162D1F16F0"/>
+            <code code="72313002" codeSystem="2.16.840.1.113883.2.1.3.2.4.15" displayName="Systolic arterial pressure">
+                <originalText>O/E - Systolic BP reading</originalText>
+                <translation code="2469.00" codeSystem="2.16.840.1.113883.2.1.6.2" displayName="O/E - Systolic BP reading"/>
+                <translation code="2469." codeSystem="2.16.840.1.113883.2.1.3.2.4.14" displayName="O/E - Systolic BP reading"/>
+            </code>
+            <statusCode code="COMPLETE"/>
+            <effectiveTime>
+                <center nullFlavor="NI"/>
+            </effectiveTime>
+            <availabilityTime value="20101216100132"/>
+            <value type="PQ" value="120" unit="mm[Hg]"/>
+        </ObservationStatement>
+    </component>
+    <component typeCode="COMP" contextConductionInd="true">
+        <ObservationStatement classCode="OBS" moodCode="EVN">
+            <id root="384DBA0B-B72E-11ED-808B-AC162D1F16F0"/>
+            <code code="1091811000000102" codeSystem="2.16.840.1.113883.2.1.3.2.4.15" displayName="Diastolic arterial pressure">
+                <originalText>O/E - Diastolic BP reading</originalText>
+                <translation code="246A." codeSystem="2.16.840.1.113883.2.1.3.2.4.14" displayName="O/E - Diastolic BP reading"/>
+                <translation code="246A.00" codeSystem="2.16.840.1.113883.2.1.6.2" displayName="O/E - Diastolic BP reading"/>
+            </code>
+            <statusCode code="COMPLETE"/>
+            <effectiveTime>
+                <center nullFlavor="NI"/>
+            </effectiveTime>
+            <availabilityTime value="20101216100132"/>
+            <value type="PQ" value="90" unit="mm[Hg]"/>
+            <pertinentInformation typeCode="PERT">
+                <sequenceNumber value="+1"/>
+                <pertinentAnnotation classCode="OBS" moodCode="EVN">
+                    <text>L</text>
+                </pertinentAnnotation>
+            </pertinentInformation>
+        </ObservationStatement>
+    </component>
+</CompoundStatement>

--- a/gp2gp-translator/src/test/resources/xml/BloodPressure/triple_with_snomed_translation.xml
+++ b/gp2gp-translator/src/test/resources/xml/BloodPressure/triple_with_snomed_translation.xml
@@ -1,0 +1,50 @@
+<CompoundStatement xmlns="urn:hl7-org:v3" classCode="BATTERY" moodCode="EVN">
+    <id root="384DBA09-B72E-11ED-808B-AC162D1F16F0"/>
+    <code code="246.." codeSystem="2.16.840.1.113883.2.1.3.2.4.14" displayName="O/E - blood pressure reading">
+        <translation code="163020007" codeSystem="2.16.840.1.113883.2.1.3.2.4.15" displayName="O/E - blood pressure reading"/>
+        <translation code="246..00" codeSystem="2.16.840.1.113883.2.1.6.2" displayName="O/E - blood pressure reading"/>
+    </code>
+    <statusCode code="COMPLETE"/>
+    <effectiveTime>
+        <center value="20101216100132"/>
+    </effectiveTime>
+    <availabilityTime value="20101216100132"/>
+    <component typeCode="COMP" contextConductionInd="true">
+        <ObservationStatement classCode="OBS" moodCode="EVN">
+            <id root="384DBA0A-B72E-11ED-808B-AC162D1F16F0"/>
+            <code code="2469." codeSystem="2.16.840.1.113883.2.1.3.2.4.14" displayName="O/E - Systolic BP reading">
+                <originalText>O/E - Systolic BP reading</originalText>
+                <translation code="72313002" codeSystem="2.16.840.1.113883.2.1.3.2.4.15" displayName="Systolic arterial pressure"/>
+                <translation code="2469.00" codeSystem="2.16.840.1.113883.2.1.6.2" displayName="O/E - Systolic BP reading"/>
+            </code>
+            <statusCode code="COMPLETE"/>
+            <effectiveTime>
+                <center nullFlavor="NI"/>
+            </effectiveTime>
+            <availabilityTime value="20101216100132"/>
+            <value type="PQ" value="120" unit="mm[Hg]"/>
+        </ObservationStatement>
+    </component>
+    <component typeCode="COMP" contextConductionInd="true">
+        <ObservationStatement classCode="OBS" moodCode="EVN">
+            <id root="384DBA0B-B72E-11ED-808B-AC162D1F16F0"/>
+            <code code="246A." codeSystem="2.16.840.1.113883.2.1.3.2.4.14" displayName="O/E - Diastolic BP reading">
+                <originalText>O/E - Diastolic BP reading</originalText>
+                <translation code="1091811000000102" codeSystem="2.16.840.1.113883.2.1.3.2.4.15" displayName="Diastolic arterial pressure"/>
+                <translation code="246A.00" codeSystem="2.16.840.1.113883.2.1.6.2" displayName="O/E - Diastolic BP reading"/>
+            </code>
+            <statusCode code="COMPLETE"/>
+            <effectiveTime>
+                <center nullFlavor="NI"/>
+            </effectiveTime>
+            <availabilityTime value="20101216100132"/>
+            <value type="PQ" value="90" unit="mm[Hg]"/>
+            <pertinentInformation typeCode="PERT">
+                <sequenceNumber value="+1"/>
+                <pertinentAnnotation classCode="OBS" moodCode="EVN">
+                    <text>L</text>
+                </pertinentAnnotation>
+            </pertinentInformation>
+        </ObservationStatement>
+    </component>
+</CompoundStatement>

--- a/gp2gp-translator/src/test/resources/xml/BloodPressure/triple_without_snomed.xml
+++ b/gp2gp-translator/src/test/resources/xml/BloodPressure/triple_without_snomed.xml
@@ -1,0 +1,47 @@
+<CompoundStatement xmlns="urn:hl7-org:v3" classCode="BATTERY" moodCode="EVN">
+    <id root="384DBA09-B72E-11ED-808B-AC162D1F16F0"/>
+    <code code="246.." codeSystem="2.16.840.1.113883.2.1.3.2.4.14" displayName="O/E - blood pressure reading">
+        <translation code="246..00" codeSystem="2.16.840.1.113883.2.1.6.2" displayName="O/E - blood pressure reading"/>
+    </code>
+    <statusCode code="COMPLETE"/>
+    <effectiveTime>
+        <center value="20101216100132"/>
+    </effectiveTime>
+    <availabilityTime value="20101216100132"/>
+    <component typeCode="COMP" contextConductionInd="true">
+        <ObservationStatement classCode="OBS" moodCode="EVN">
+            <id root="384DBA0A-B72E-11ED-808B-AC162D1F16F0"/>
+            <code code="2469." codeSystem="2.16.840.1.113883.2.1.3.2.4.14" displayName="O/E - Systolic BP reading">
+                <originalText>O/E - Systolic BP reading</originalText>
+                <translation code="2469.00" codeSystem="2.16.840.1.113883.2.1.6.2" displayName="O/E - Systolic BP reading"/>
+            </code>
+            <statusCode code="COMPLETE"/>
+            <effectiveTime>
+                <center nullFlavor="NI"/>
+            </effectiveTime>
+            <availabilityTime value="20101216100132"/>
+            <value type="PQ" value="120" unit="mm[Hg]"/>
+        </ObservationStatement>
+    </component>
+    <component typeCode="COMP" contextConductionInd="true">
+        <ObservationStatement classCode="OBS" moodCode="EVN">
+            <id root="384DBA0B-B72E-11ED-808B-AC162D1F16F0"/>
+            <code code="246A." codeSystem="2.16.840.1.113883.2.1.3.2.4.14" displayName="O/E - Diastolic BP reading">
+                <originalText>O/E - Diastolic BP reading</originalText>
+                <translation code="246A.00" codeSystem="2.16.840.1.113883.2.1.6.2" displayName="O/E - Diastolic BP reading"/>
+            </code>
+            <statusCode code="COMPLETE"/>
+            <effectiveTime>
+                <center nullFlavor="NI"/>
+            </effectiveTime>
+            <availabilityTime value="20101216100132"/>
+            <value type="PQ" value="90" unit="mm[Hg]"/>
+            <pertinentInformation typeCode="PERT">
+                <sequenceNumber value="+1"/>
+                <pertinentAnnotation classCode="OBS" moodCode="EVN">
+                    <text>L</text>
+                </pertinentAnnotation>
+            </pertinentInformation>
+        </ObservationStatement>
+    </component>
+</CompoundStatement>


### PR DESCRIPTION
Problem seen with Consultations 2 dataset. 

 - Blood pressure parent should be included in the appropriate Encounter List, this is not currently the case in the PS.

The root cause of this was that in the Consultations 2 dataset, the SNOMED codes are nested inside the code element as translations. The PS Adaptor didn't support this nested structure for blood pressures and as a result mapped them incorrectly. 

The issue was also present for  diagnostic report and allergy mappings. Diagnostic reports have been updated as part of this ticket. Allergies were already raised in a separate ticket ([NIAD-2617](https://gpitbjss.atlassian.net/browse/NIAD-2617))