### PR TITLE
COPC / attachment merge error handing updates

### DIFF
--- a/gp2gp-translator/src/main/java/uk/nhs/adaptors/pss/translator/service/InboundMessageMergingService.java
+++ b/gp2gp-translator/src/main/java/uk/nhs/adaptors/pss/translator/service/InboundMessageMergingService.java
@@ -2,7 +2,7 @@ package uk.nhs.adaptors.pss.translator.service;
 
 import static uk.nhs.adaptors.common.enums.MigrationStatus.EHR_EXTRACT_TRANSLATED;
 import static uk.nhs.adaptors.common.enums.MigrationStatus.MIGRATION_COMPLETED;
-import static uk.nhs.adaptors.pss.translator.model.NACKReason.LARGE_MESSAGE_REASSEMBLY_FAILURE;
+import static uk.nhs.adaptors.pss.translator.model.NACKReason.LARGE_MESSAGE_ATTACHMENTS_NOT_RECEIVED;
 import static uk.nhs.adaptors.pss.translator.util.XmlUnmarshallUtil.unmarshallString;
 
 import java.util.Arrays;
@@ -119,7 +119,7 @@ public class InboundMessageMergingService {
                  | BundleMappingException | JAXBException | AttachmentNotFoundException | JsonProcessingException e) {
 
             LOGGER.error("failed to merge Large Message Parts", e);
-            nackAckPreparationService.sendNackMessage(LARGE_MESSAGE_REASSEMBLY_FAILURE, payload, conversationId);
+            nackAckPreparationService.sendNackMessage(LARGE_MESSAGE_ATTACHMENTS_NOT_RECEIVED, payload, conversationId);
         }
     }
 

--- a/gp2gp-translator/src/main/java/uk/nhs/adaptors/pss/translator/task/COPCMessageHandler.java
+++ b/gp2gp-translator/src/main/java/uk/nhs/adaptors/pss/translator/task/COPCMessageHandler.java
@@ -4,6 +4,7 @@ import static uk.nhs.adaptors.common.enums.MigrationStatus.COPC_MESSAGE_PROCESSI
 import static uk.nhs.adaptors.common.enums.MigrationStatus.COPC_MESSAGE_RECEIVED;
 import static uk.nhs.adaptors.pss.translator.model.NACKReason.LARGE_MESSAGE_ATTACHMENTS_NOT_RECEIVED;
 import static uk.nhs.adaptors.pss.translator.model.NACKReason.LARGE_MESSAGE_GENERAL_FAILURE;
+import static uk.nhs.adaptors.pss.translator.model.NACKReason.LARGE_MESSAGE_REASSEMBLY_FAILURE;
 import static uk.nhs.adaptors.pss.translator.model.NACKReason.UNEXPECTED_CONDITION;
 import static uk.nhs.adaptors.pss.translator.util.XmlUnmarshallUtil.unmarshallString;
 
@@ -116,22 +117,24 @@ public class COPCMessageHandler {
                 }
             }
 
-            nackAckPreparationService.sendAckMessage(payload, conversationId, migrationRequest.getLosingPracticeOdsCode());
             checkAndMergeFileParts(inboundMessage, conversationId);
 
             // merge and uncompress large EHR message
             if (inboundMessageMergingService.canMergeCompleteBundle(conversationId)) {
                 inboundMessageMergingService.mergeAndBundleMessage(conversationId);
-
             }
+
+            nackAckPreparationService.sendAckMessage(payload, conversationId, migrationRequest.getLosingPracticeOdsCode());
+
         } catch (WebClientRequestException | ConnectionException e) {
             throw e;
+
         } catch (ParseException | ValidationException | SAXException e) {
             LOGGER.error("COPC_IN000001UK01 validation / parsing  error", e);
             nackAckPreparationService.sendNackMessage(LARGE_MESSAGE_GENERAL_FAILURE, payload, conversationId);
             failMigration(conversationId, UNEXPECTED_CONDITION);
 
-        } catch (InlineAttachmentProcessingException | ExternalAttachmentProcessingException | UnsupportedFileTypeException e) {
+        } catch (InlineAttachmentProcessingException | UnsupportedFileTypeException e) {
             LOGGER.error("Large messaging attachment processing error", e);
             nackAckPreparationService.sendNackMessage(LARGE_MESSAGE_GENERAL_FAILURE, payload, conversationId);
 
@@ -142,6 +145,12 @@ public class COPCMessageHandler {
                 migrationStatusLogService.addMigrationStatusLog(
                     LARGE_MESSAGE_ATTACHMENTS_NOT_RECEIVED.getMigrationStatus(), conversationId, null);
             }
+
+        } catch (ExternalAttachmentProcessingException e) {
+            LOGGER.error("Unable to merge attachment", e);
+            nackAckPreparationService.sendNackMessage(LARGE_MESSAGE_REASSEMBLY_FAILURE, payload, conversationId);
+
+            failMigration(conversationId, LARGE_MESSAGE_ATTACHMENTS_NOT_RECEIVED);
 
         } catch (Exception e) {
             LOGGER.error("Unexpected exception processing COPC_IN000001UK01 message", e);

--- a/gp2gp-translator/src/test/java/uk/nhs/adaptors/pss/translator/task/COPCMessageHandlerTest.java
+++ b/gp2gp-translator/src/test/java/uk/nhs/adaptors/pss/translator/task/COPCMessageHandlerTest.java
@@ -990,6 +990,8 @@ class COPCMessageHandlerTest {
     public void When_HandleMessage_WithDbConnectionException_Expect_ExceptionThrown() throws SAXException {
         InboundMessage message = new InboundMessage();
         prepareFragmentMocks(message);
+        prepareAttachmentLogs();
+
         when(patientAttachmentLogService.findAttachmentLog(MESSAGE_ID, CONVERSATION_ID))
             .thenReturn(null)
             .thenReturn(buildPatientAttachmentLog("047C22B4-613F-47D3-9A72-44A1758464FB", null, true));
@@ -1005,6 +1007,8 @@ class COPCMessageHandlerTest {
     public void When_HandleMessage_WithWebClientRequestException_Expect_ExceptionThrown() throws SAXException {
         InboundMessage message = new InboundMessage();
         prepareFragmentMocks(message);
+        prepareAttachmentLogs();
+
         when(patientAttachmentLogService.findAttachmentLog(MESSAGE_ID, CONVERSATION_ID))
             .thenReturn(null)
             .thenReturn(buildPatientAttachmentLog("047C22B4-613F-47D3-9A72-44A1758464FB", null, true));
@@ -1025,6 +1029,7 @@ class COPCMessageHandlerTest {
         try {
             InboundMessage message = new InboundMessage();
             prepareFragmentMocks(message);
+            prepareAttachmentLogs();
 
             mockedXmlUnmarshall.when(
                 () -> XmlUnmarshallUtil.unmarshallString(anyString(), eq(COPCIN000001UK01Message.class))
@@ -1107,7 +1112,7 @@ class COPCMessageHandlerTest {
     @Test
     public void When_HandleMessage_With_ValidationException_Expect_MigrationFailed() throws SAXException, JsonProcessingException,
         JAXBException, InlineAttachmentProcessingException, AttachmentNotFoundException, BundleMappingException, AttachmentLogException {
-        //TODO: use attachmentHandlerService.storeAttachmentWithoutProcessing to throw exception
+
         MockedStatic<XmlUnmarshallUtil> mockedXmlUnmarshall = Mockito.mockStatic(XmlUnmarshallUtil.class);
         InboundMessage message = new InboundMessage();
 
@@ -1410,6 +1415,14 @@ class COPCMessageHandlerTest {
                 .build();
 
         when(migrationRequestDao.getMigrationRequest(CONVERSATION_ID)).thenReturn(migrationRequest);
+    }
+
+    private void prepareAttachmentLogs() {
+        var messageId = "CBBAE92D-C7E8-4A9C-8887-F5AEBA1F8CE1";
+        when(patientAttachmentLogService.findAttachmentLog(messageId, CONVERSATION_ID)).thenReturn(null)
+            .thenReturn(buildPatientAttachmentLog("047C22B4-613F-47D3-9A72-44A1758464FB", null, true));
+        when(patientAttachmentLogService.findAttachmentLog("047C22B4-613F-47D3-9A72-44A1758464FB", CONVERSATION_ID))
+            .thenReturn(buildPatientAttachmentLog("047C22B4-613F-47D3-9A72-44A1758464FB", "CBBAE92D-C7E8-4A9C-8887-F5AEBA1F8CE1", true));
     }
 
     @SneakyThrows


### PR DESCRIPTION
- Correct Reassembly failure handling. 

- Send COPC ACK after attempting to merge.