### PR TITLE
Update test suite container versions and tidy up scripts.

### DIFF
--- a/test-suite/daisy-chaining/docker-compose.yml
+++ b/test-suite/daisy-chaining/docker-compose.yml
@@ -38,6 +38,7 @@ services:
       - MHS_INBOUND_USE_SSL
       - TCP_PORTS=${MHS_INBOUND_PORT}
       - SERVICE_PORTS=${MHS_INBOUND_SERVICE_PORTS}
+      - SUPPORTED_FILE_TYPES
 
   outbound:
     image: ${MHS_OUTBOUND_VERSION}
@@ -67,13 +68,12 @@ services:
       - MHS_OUTBOUND_ROUTING_LOOKUP_METHOD
       - MHS_SDS_API_URL
       - MHS_SDS_API_KEY
+      - SUPPORTED_FILE_TYPES
 
   ########### PS Adapter Specific ###############
 
   gpc_facade:
-    build:
-      context: ../../
-      dockerfile: ./docker/gpc-facade/Dockerfile
+    image: ${PS_FACADE_VERSION}
     ports:
       - "8081:8081"
     depends_on:
@@ -92,9 +92,7 @@ services:
       - nia-daisy-chain
 
   ps_gp2gp_translator:
-    build:
-      context: ../../
-      dockerfile: ./docker/gp2gp-translator/Dockerfile
+    image: ${PS_TRANSLATOR_VERSION}
     ports:
       - "8085:8085"
     depends_on:

--- a/test-suite/daisy-chaining/start-daisy-chain-environment.sh
+++ b/test-suite/daisy-chaining/start-daisy-chain-environment.sh
@@ -2,7 +2,9 @@
 
 set -x -e
 
-source ../vars.sh
+cd ../
+source ./vars.sh
+cd daisy-chaining
 source ./daisy_chaining_vars.sh
 source ./vars-versions.sh
 
@@ -17,27 +19,23 @@ chmod +x gradlew
 cd ../daisy-chaining
 
 
-LIGHT_GREEN='\033[1;32m'
-RED='\033[0;31m'
-NC='\033[0m'
-
-echo "${LIGHT_GREEN}Exporting environment variables${NC}"
+echo "Exporting environment variables"
 
 if [[ -z "${MHS_SECRET_PARTY_KEY}" ]]; then
-  echo "${RED}Secret key not set for MHS_SECRET_PARTY_KEY${NC}"
+  echo "Secret key not set for MHS_SECRET_PARTY_KEY"
   exit 1
 elif [[ -z "${MHS_SECRET_CLIENT_CERT}" ]]; then
-  echo "${RED}Secret key not set for MHS_SECRET_CLIENT_CERT${NC}"
+  echo "Secret key not set for MHS_SECRET_CLIENT_CERT"
   exit 1
 elif [[ -z "${MHS_SECRET_CLIENT_KEY}" ]]; then
-  echo "${RED}Secret key not set for MHS_SECRET_CLIENT_KEY${NC}"
+  echo "Secret key not set for MHS_SECRET_CLIENT_KEY"
   exit 1
 elif [[ -z "${MHS_SECRET_CA_CERTS}" ]]; then
-  echo "${RED}Secret key not set for MHS_SECRET_CA_CERTS${NC}"
+  echo "Secret key not set for MHS_SECRET_CA_CERTS"
   exit 1
 fi
 
-echo "${LIGHT_GREEN}Running containers${NC}"
+echo "Running containers"
 
 if [[ "$(docker network ls | grep "nia-daisy-chain")" == "" ]] ; then
     docker network create nia-daisy-chain

--- a/test-suite/daisy-chaining/vars-versions.sh
+++ b/test-suite/daisy-chaining/vars-versions.sh
@@ -1,16 +1,5 @@
 #!/usr/bin/env bash
 
-export MHS_INBOUND_VERSION="nhsdev/nia-mhs-inbound:1.2.4-arm64"  # has an arm64 and amd64 version
-export MHS_OUTBOUND_VERSION="nhsdev/nia-mhs-outbound:1.2.2"
-export PS_TRANSLATOR_VERSION="nhsdev/nia-ps-adaptor:0.5-arm64" # has an arm64 and amd64 version
-export PS_FACADE_VERSION="nhsdev/nia-ps-facade:0.4-arm64" # has an arm64 and amd64 version
-export PS_DB_MIGRATION_VERSION="nhsdev/nia-ps-db-migration:0.2"
-
-export ACTIVEMQ_VERSION="nhsdev/nia-ps-activemq:0.1-arm64" # has an arm64 and amd64 version
-export POSTGRES_VERSION="postgres:14.0"
-export DYNAMODB_VERSION="nhsdev/nia-dynamodb-local:1.0.3"
-export REDIS_VERSION="redis"
 export MONGODB_VERSION="mongo"
-
-export GP2GP_ADAPTOR_VERSION="nhsdev/nia-gp2gp-adaptor:1.5.5-arm64"  # has an arm64 and amd64 version
-export GPCC_ADAPTOR_VERSION="nhsdev/nia-gpcc-gp2gp-invest:0.1"
+export GP2GP_ADAPTOR_VERSION="nhsdev/nia-gp2gp-adaptor:1.5.9-amd64"  # has an arm64 and amd64 version
+export GPCC_ADAPTOR_VERSION="nhsdev/nia-gpc-consumer-adaptor:0.3.3" # or "nhsdev/nia-gpcc-gp2gp-invest:0.1" for arm64

--- a/test-suite/start-test-environment.sh
+++ b/test-suite/start-test-environment.sh
@@ -14,28 +14,23 @@ chmod +x gradlew
 
 cd ..
 
-
-LIGHT_GREEN='\033[1;32m'
-RED='\033[0;31m'
-NC='\033[0m'
-
-echo "${LIGHT_GREEN}Exporting environment variables${NC}"
+echo "Exporting environment variables"
 
 if [[ -z "${MHS_SECRET_PARTY_KEY}" ]]; then
-  echo "${RED}Secret key not set for MHS_SECRET_PARTY_KEY${NC}"
+  echo "Secret key not set for MHS_SECRET_PARTY_KEY"
   exit 1
 elif [[ -z "${MHS_SECRET_CLIENT_CERT}" ]]; then
-  echo "${RED}Secret key not set for MHS_SECRET_CLIENT_CERT${NC}"
+  echo "Secret key not set for MHS_SECRET_CLIENT_CERT"
   exit 1
 elif [[ -z "${MHS_SECRET_CLIENT_KEY}" ]]; then
-  echo "${RED}Secret key not set for MHS_SECRET_CLIENT_KEY${NC}"
+  echo "Secret key not set for MHS_SECRET_CLIENT_KEY"
   exit 1
 elif [[ -z "${MHS_SECRET_CA_CERTS}" ]]; then
-  echo "${RED}Secret key not set for MHS_SECRET_CA_CERTS${NC}"
+  echo "Secret key not set for MHS_SECRET_CA_CERTS"
   exit 1
 fi
 
-echo "${LIGHT_GREEN}Running containers${NC}"
+echo "Running containers"
 
 if [[ "$(docker network ls | grep "nia-ps")" == "" ]] ; then
     docker network create nia-ps

--- a/test-suite/vars-versions.sh
+++ b/test-suite/vars-versions.sh
@@ -1,15 +1,13 @@
 #!/usr/bin/env bash
 
-export MHS_INBOUND_VERSION="nhsdev/nia-mhs-inbound:1.2.6-arm64"  # has an arm64 and amd64 version
-export MHS_OUTBOUND_VERSION="nhsdev/nia-mhs-outbound:1.2.6-arm64" # has an arm64 and amd64 version
-export MHS_ROUTE_VERSION="nhsdev/nia-mhs-route:1.2.2" #Not Used in test version
+export MHS_INBOUND_VERSION="nhsdev/nia-mhs-inbound:1.2.6-amd64"  # has an arm64 and amd64 version
+export MHS_OUTBOUND_VERSION="nhsdev/nia-mhs-outbound:1.2.6-amd64" # has an arm64 and amd64 version
 
-export PS_TRANSLATOR_VERSION="nhsdev/nia-ps-adaptor:0.5-arm64" # has an arm64 and amd64 version
-export PS_FACADE_VERSION="nhsdev/nia-ps-facade:0.4-arm64" # has an arm64 and amd64 version
-export PS_DB_MIGRATION_VERSION="nhsdev/nia-ps-db-migration:0.2"
+export PS_TRANSLATOR_VERSION="nhsdev/nia-ps-adaptor:0.10"
+export PS_FACADE_VERSION="nhsdev/nia-ps-facade:0.7"
+export PS_DB_MIGRATION_VERSION="nhsdev/nia-ps-db-migration:0.4"
 
-export ACTIVEMQ_VERSION="nhsdev/nia-ps-activemq:0.1-arm64" # has an arm64 and amd64 version
+export ACTIVEMQ_VERSION="nhsdev/nia-ps-activemq:0.1-amd64" # has an arm64 and amd64 version
 export POSTGRES_VERSION="postgres:14.0"
 export DYNAMODB_VERSION="nhsdev/nia-dynamodb-local:1.0.3"
 export REDIS_VERSION="redis"
-export MONGODB_VERSION="mongo"


### PR DESCRIPTION
## Description

As we have pushed new images to Docker Hub the default test suite images are out of date. There are also unused and duplicate environment variables for the images in `test-suite/vars-versions.sh` and  `test-suite/daisy-chaining/vars-versions.sh`.

### Work undertaken

- Update the default image variables to the latest versions. 
- Tidy up the scripts to remove duplication
- Update the daisy chaining docker-compose  file to use images for the PS Adaptor, as the changes necessary  to enable daisy chaining have now been released
- Remove coloured text from the start environment scripts as it wasn't displayed correctly in a WSL Ubuntu shell 