### PR TITLE
NIAD 2737: Update JMeter to prepare for AWS testing

### DIFF
--- a/gp2gp-translator/src/nonFunctionalTest/TestPlans/PS_NF_REL_1/PS_NF_REL_1.jmx
+++ b/gp2gp-translator/src/nonFunctionalTest/TestPlans/PS_NF_REL_1/PS_NF_REL_1.jmx
@@ -113,7 +113,7 @@ SampleResult.setIgnore();</stringProp>
               </elementProp>
             </collectionProp>
           </elementProp>
-          <stringProp name="HTTPSampler.domain">localhost</stringProp>
+          <stringProp name="HTTPSampler.domain">${__P(facadeUrl, localhost)}</stringProp>
           <stringProp name="HTTPSampler.port">${__P(facadePort, 8081)}</stringProp>
           <stringProp name="HTTPSampler.protocol">http</stringProp>
           <stringProp name="HTTPSampler.contentEncoding"></stringProp>
@@ -229,7 +229,7 @@ SampleResult.setIgnore();</stringProp>
                     </elementProp>
                   </collectionProp>
                 </elementProp>
-                <stringProp name="HTTPSampler.domain">localhost</stringProp>
+                <stringProp name="HTTPSampler.domain">${__P(facadeUrl, localhost)}</stringProp>
                 <stringProp name="HTTPSampler.port">${__P(facadePort, 8081)}</stringProp>
                 <stringProp name="HTTPSampler.protocol">http</stringProp>
                 <stringProp name="HTTPSampler.contentEncoding"></stringProp>
@@ -356,7 +356,7 @@ SampleResult.setIgnore();</stringProp>
                     </elementProp>
                   </collectionProp>
                 </elementProp>
-                <stringProp name="HTTPSampler.domain">localhost</stringProp>
+                <stringProp name="HTTPSampler.domain">${__P(facadeUrl, localhost)}</stringProp>
                 <stringProp name="HTTPSampler.port">${__P(facadePort, 8081)}</stringProp>
                 <stringProp name="HTTPSampler.protocol">http</stringProp>
                 <stringProp name="HTTPSampler.contentEncoding"></stringProp>
@@ -603,7 +603,7 @@ SampleResult.setIgnore();</stringProp>
                     </elementProp>
                   </collectionProp>
                 </elementProp>
-                <stringProp name="HTTPSampler.domain">localhost</stringProp>
+                <stringProp name="HTTPSampler.domain">${__P(facadeUrl, localhost)}</stringProp>
                 <stringProp name="HTTPSampler.port">${__P(facadePort, 8081)}</stringProp>
                 <stringProp name="HTTPSampler.protocol">http</stringProp>
                 <stringProp name="HTTPSampler.contentEncoding"></stringProp>

--- a/gp2gp-translator/src/nonFunctionalTest/TestPlans/PS_NF_REL_1/config.properties
+++ b/gp2gp-translator/src/nonFunctionalTest/TestPlans/PS_NF_REL_1/config.properties
@@ -3,6 +3,7 @@
 # * Connection Properties *
 
 facadePort = 8081
+facadeUrl = localhost
 jdniPropertiesPath = ../../Configuration/jndi.properties
 
 #  * Thread Group Properties *

--- a/gp2gp-translator/src/nonFunctionalTest/TestPlans/PS_NF_REL_2/PS_NF_REL_2.jmx
+++ b/gp2gp-translator/src/nonFunctionalTest/TestPlans/PS_NF_REL_2/PS_NF_REL_2.jmx
@@ -113,7 +113,7 @@ SampleResult.setIgnore();</stringProp>
               </elementProp>
             </collectionProp>
           </elementProp>
-          <stringProp name="HTTPSampler.domain">localhost</stringProp>
+          <stringProp name="HTTPSampler.domain">${__P(facadeUrl, localhost)}</stringProp>
           <stringProp name="HTTPSampler.port">${__P(facadePort, 8081)}</stringProp>
           <stringProp name="HTTPSampler.protocol">http</stringProp>
           <stringProp name="HTTPSampler.contentEncoding"></stringProp>

--- a/gp2gp-translator/src/nonFunctionalTest/TestPlans/PS_NF_STR_1/PS_NF_STR_1.jmx
+++ b/gp2gp-translator/src/nonFunctionalTest/TestPlans/PS_NF_STR_1/PS_NF_STR_1.jmx
@@ -146,7 +146,7 @@ SampleResult.setIgnore();</stringProp>
               </elementProp>
             </collectionProp>
           </elementProp>
-          <stringProp name="HTTPSampler.domain">localhost</stringProp>
+          <stringProp name="HTTPSampler.domain">${__P(facadeUrl, localhost)}</stringProp>
           <stringProp name="HTTPSampler.port">${__P(facadePort, 8081)}</stringProp>
           <stringProp name="HTTPSampler.protocol">http</stringProp>
           <stringProp name="HTTPSampler.contentEncoding"></stringProp>
@@ -268,7 +268,7 @@ SampleResult.setIgnore();</stringProp>
                       </elementProp>
                     </collectionProp>
                   </elementProp>
-                  <stringProp name="HTTPSampler.domain">localhost</stringProp>
+                  <stringProp name="HTTPSampler.domain">${__P(facadeUrl, localhost)}</stringProp>
                   <stringProp name="HTTPSampler.port">${__P(facadePort, 8081)}</stringProp>
                   <stringProp name="HTTPSampler.protocol">http</stringProp>
                   <stringProp name="HTTPSampler.contentEncoding"></stringProp>
@@ -395,7 +395,7 @@ SampleResult.setIgnore();</stringProp>
                       </elementProp>
                     </collectionProp>
                   </elementProp>
-                  <stringProp name="HTTPSampler.domain">localhost</stringProp>
+                  <stringProp name="HTTPSampler.domain">${__P(facadeUrl, localhost)}</stringProp>
                   <stringProp name="HTTPSampler.port">${__P(facadePort, 8081)}</stringProp>
                   <stringProp name="HTTPSampler.protocol">http</stringProp>
                   <stringProp name="HTTPSampler.contentEncoding"></stringProp>
@@ -562,7 +562,7 @@ SampleResult.setIgnore();</stringProp>
         <stringProp name="filename">../../Results/PS_NF_STR_1/SummaryReport_${__time(YMDHMS)}.csv</stringProp>
       </ResultCollector>
       <hashTree/>
-      <ResultCollector guiclass="ViewResultsFullVisualizer" testclass="ResultCollector" testname="View Results Tree" enabled="true">
+      <ResultCollector guiclass="ViewResultsFullVisualizer" testclass="ResultCollector" testname="View Results Tree" enabled="false">
         <boolProp name="ResultCollector.error_logging">false</boolProp>
         <objProp>
           <name>saveConfig</name>

--- a/gp2gp-translator/src/nonFunctionalTest/TestPlans/PS_NF_STR_1/config.properties
+++ b/gp2gp-translator/src/nonFunctionalTest/TestPlans/PS_NF_STR_1/config.properties
@@ -3,6 +3,7 @@
 # * Connection Properties *
 
 facadePort = 8081
+facadeUrl = localhost
 jdniPropertiesPath = ../../Configuration/jndi.properties
 
 #  * Thread Group Properties *

--- a/gp2gp-translator/src/nonFunctionalTest/TestPlans/PS_NF_STR_2/PS_NF_STR_2.jmx
+++ b/gp2gp-translator/src/nonFunctionalTest/TestPlans/PS_NF_STR_2/PS_NF_STR_2.jmx
@@ -152,7 +152,7 @@ log.info(vars.get(&quot;threadDetails&quot;) + &quot;Preparing request with conv
               </elementProp>
             </collectionProp>
           </elementProp>
-          <stringProp name="HTTPSampler.domain">localhost</stringProp>
+          <stringProp name="HTTPSampler.domain">${__P(facadeUrl, localhost)}</stringProp>
           <stringProp name="HTTPSampler.port">${__P(facadePort, 8081)}</stringProp>
           <stringProp name="HTTPSampler.protocol">http</stringProp>
           <stringProp name="HTTPSampler.contentEncoding"></stringProp>
@@ -274,7 +274,7 @@ SampleResult.setIgnore();</stringProp>
                       </elementProp>
                     </collectionProp>
                   </elementProp>
-                  <stringProp name="HTTPSampler.domain">localhost</stringProp>
+                  <stringProp name="HTTPSampler.domain">${__P(facadeUrl, localhost)}</stringProp>
                   <stringProp name="HTTPSampler.port">${__P(facadePort, 8081)}</stringProp>
                   <stringProp name="HTTPSampler.protocol">http</stringProp>
                   <stringProp name="HTTPSampler.contentEncoding"></stringProp>
@@ -401,7 +401,7 @@ SampleResult.setIgnore();</stringProp>
                       </elementProp>
                     </collectionProp>
                   </elementProp>
-                  <stringProp name="HTTPSampler.domain">localhost</stringProp>
+                  <stringProp name="HTTPSampler.domain">${__P(facadeUrl, localhost)}</stringProp>
                   <stringProp name="HTTPSampler.port">${__P(facadePort, 8081)}</stringProp>
                   <stringProp name="HTTPSampler.protocol">http</stringProp>
                   <stringProp name="HTTPSampler.contentEncoding"></stringProp>

--- a/gp2gp-translator/src/nonFunctionalTest/TestPlans/PS_NF_STR_2/config.properties
+++ b/gp2gp-translator/src/nonFunctionalTest/TestPlans/PS_NF_STR_2/config.properties
@@ -3,6 +3,7 @@
 # * Connection Properties *
 
 facadePort = 8081
+facadeUrl = localhost
 jdniPropertiesPath = ../../Configuration/jndi.properties
 
 #  * Thread Group Properties *

--- a/gp2gp-translator/src/nonFunctionalTest/TestPlans/PS_NF_STR_3/PS_NF_STR_3.jmx
+++ b/gp2gp-translator/src/nonFunctionalTest/TestPlans/PS_NF_STR_3/PS_NF_STR_3.jmx
@@ -152,7 +152,7 @@ log.info(vars.get(&quot;threadDetails&quot;) + &quot;Preparing request with conv
               </elementProp>
             </collectionProp>
           </elementProp>
-          <stringProp name="HTTPSampler.domain">localhost</stringProp>
+          <stringProp name="HTTPSampler.domain">${__P(facadeUrl, localhost)}</stringProp>
           <stringProp name="HTTPSampler.port">${__P(facadePort, 8081)}</stringProp>
           <stringProp name="HTTPSampler.protocol">http</stringProp>
           <stringProp name="HTTPSampler.contentEncoding"></stringProp>
@@ -284,7 +284,7 @@ SampleResult.setIgnore();</stringProp>
                       </elementProp>
                     </collectionProp>
                   </elementProp>
-                  <stringProp name="HTTPSampler.domain">localhost</stringProp>
+                  <stringProp name="HTTPSampler.domain"> ${__P(facadeUrl, localhost)}</stringProp>
                   <stringProp name="HTTPSampler.port">${__P(facadePort, 8081)}</stringProp>
                   <stringProp name="HTTPSampler.protocol">http</stringProp>
                   <stringProp name="HTTPSampler.contentEncoding"></stringProp>
@@ -411,7 +411,7 @@ SampleResult.setIgnore();</stringProp>
                       </elementProp>
                     </collectionProp>
                   </elementProp>
-                  <stringProp name="HTTPSampler.domain">localhost</stringProp>
+                  <stringProp name="HTTPSampler.domain">${__P(facadeUrl, localhost)}</stringProp>
                   <stringProp name="HTTPSampler.port">${__P(facadePort, 8081)}</stringProp>
                   <stringProp name="HTTPSampler.protocol">http</stringProp>
                   <stringProp name="HTTPSampler.contentEncoding"></stringProp>
@@ -538,7 +538,7 @@ SampleResult.setIgnore();</stringProp>
                       </elementProp>
                     </collectionProp>
                   </elementProp>
-                  <stringProp name="HTTPSampler.domain">localhost</stringProp>
+                  <stringProp name="HTTPSampler.domain">${__P(facadeUrl, localhost)}</stringProp>
                   <stringProp name="HTTPSampler.port">${__P(facadePort, 8081)}</stringProp>
                   <stringProp name="HTTPSampler.protocol">http</stringProp>
                   <stringProp name="HTTPSampler.contentEncoding"></stringProp>
@@ -658,7 +658,7 @@ SampleResult.setIgnore();</stringProp>
                       </elementProp>
                     </collectionProp>
                   </elementProp>
-                  <stringProp name="HTTPSampler.domain">localhost</stringProp>
+                  <stringProp name="HTTPSampler.domain">${__P(facadeUrl, localhost)}</stringProp>
                   <stringProp name="HTTPSampler.port">${__P(facadePort, 8081)}</stringProp>
                   <stringProp name="HTTPSampler.protocol">http</stringProp>
                   <stringProp name="HTTPSampler.contentEncoding"></stringProp>
@@ -746,7 +746,7 @@ SampleResult.setIgnore();</stringProp>
         </JSR223Sampler>
         <hashTree/>
       </hashTree>
-      <ResultCollector guiclass="ViewResultsFullVisualizer" testclass="ResultCollector" testname="View Results Tree" enabled="false">
+      <ResultCollector guiclass="ViewResultsFullVisualizer" testclass="ResultCollector" testname="View Results Tree" enabled="true">
         <boolProp name="ResultCollector.error_logging">false</boolProp>
         <objProp>
           <name>saveConfig</name>
@@ -821,7 +821,7 @@ SampleResult.setIgnore();</stringProp>
         <stringProp name="filename">../../Results/PS_NF_STR_3/SummaryReport_${__time(YMDHMS)}.csv</stringProp>
       </ResultCollector>
       <hashTree/>
-      <ResultCollector guiclass="AssertionVisualizer" testclass="ResultCollector" testname="Assertion Results" enabled="true">
+      <ResultCollector guiclass="AssertionVisualizer" testclass="ResultCollector" testname="Assertion Results" enabled="false">
         <boolProp name="ResultCollector.error_logging">false</boolProp>
         <objProp>
           <name>saveConfig</name>

--- a/gp2gp-translator/src/nonFunctionalTest/TestPlans/PS_NF_STR_3/PS_NF_STR_3.jmx
+++ b/gp2gp-translator/src/nonFunctionalTest/TestPlans/PS_NF_STR_3/PS_NF_STR_3.jmx
@@ -746,7 +746,7 @@ SampleResult.setIgnore();</stringProp>
         </JSR223Sampler>
         <hashTree/>
       </hashTree>
-      <ResultCollector guiclass="ViewResultsFullVisualizer" testclass="ResultCollector" testname="View Results Tree" enabled="true">
+      <ResultCollector guiclass="ViewResultsFullVisualizer" testclass="ResultCollector" testname="View Results Tree" enabled="false">
         <boolProp name="ResultCollector.error_logging">false</boolProp>
         <objProp>
           <name>saveConfig</name>

--- a/gp2gp-translator/src/nonFunctionalTest/TestPlans/PS_NF_STR_3/README.md
+++ b/gp2gp-translator/src/nonFunctionalTest/TestPlans/PS_NF_STR_3/README.md
@@ -2,6 +2,9 @@
 
 #### Can the system process 20 batches of 12 messages submitted in parallel using 3 threads/instances?
 
+Please note that at present this test will only run on a local test environment due to the requirement
+to spin up extra instances of the GP2GP adaptor.
+
 ### Preparing Tests
 
 * Ensure that the docker (in the root of the project) folder contains a valid vars.sh.

--- a/gp2gp-translator/src/nonFunctionalTest/TestPlans/PS_NF_STR_3/build-test-environment.sh
+++ b/gp2gp-translator/src/nonFunctionalTest/TestPlans/PS_NF_STR_3/build-test-environment.sh
@@ -6,5 +6,6 @@ docker ps -a -q -f name=gp2gp_translator_nft | xargs -r docker rm
 
 source ../../../../../docker/vars.sh
 
+docker network create ps-network || true
 docker-compose build gp2gp_translator_nft1 gp2gp_translator_nft2
 docker-compose up -d gp2gp_translator_nft1 gp2gp_translator_nft2

--- a/gp2gp-translator/src/nonFunctionalTest/TestPlans/PS_NF_STR_3/config.properties
+++ b/gp2gp-translator/src/nonFunctionalTest/TestPlans/PS_NF_STR_3/config.properties
@@ -3,6 +3,7 @@
 # * Connection Properties *
 
 facadePort = 8081
+facadeUrl = localhost
 jdniPropertiesPath = ../../Configuration/jndi.properties
 
 #  * Thread Group Properties *

--- a/gp2gp-translator/src/nonFunctionalTest/TestPlans/PS_NF_STR_3/docker-compose.yml
+++ b/gp2gp-translator/src/nonFunctionalTest/TestPlans/PS_NF_STR_3/docker-compose.yml
@@ -5,7 +5,7 @@ services:
       context: ../../../../..
       dockerfile: ./docker/gp2gp-translator/Dockerfile
     ports:
-      - "8086:8086"
+      - "8087:8087"
     environment:
       - GP2GP_TRANSLATOR_SERVER_PORT
       - PS_DB_URL=jdbc:postgresql://ps_db:5432
@@ -31,7 +31,7 @@ services:
       context: ../../../../..
       dockerfile: ./docker/gp2gp-translator/Dockerfile
     ports:
-      - "8087:8087"
+      - "8088:8088"
     environment:
       - GP2GP_TRANSLATOR_SERVER_PORT
       - PS_DB_URL=jdbc:postgresql://ps_db:5432


### PR DESCRIPTION
Add facadeUrl as configuration property
ensure jndi.properties has property for url
update tests to use facadeUrl property
update build script to create network for local test from multiple GP2GP adaptors