### PR TITLE
Hard code value of supported-filetypes within integrationTests

### DIFF
--- a/gp2gp-translator/src/integrationTest/resources/application.yml
+++ b/gp2gp-translator/src/integrationTest/resources/application.yml
@@ -61,6 +61,6 @@ timeout:
   cronTime: ${TIMEOUT_CRON_TIME:0 0 */6 * * *}
 
 supported-filetypes:
-  accepted: ${SUPPORTED_FILE_TYPES:}
+  accepted: text/plain,application/xml,video/mpeg,text/xml,image/tiff
 
 base64.skipDecode: ${SKIP_DECODE:false}


### PR DESCRIPTION
Removes need for ENV variable to be set, making running integration tests easier.

The alternative I considered was documenting that you need to set this environment variable, however that felt like a less good solution to this, which requires zero effort for a developer to get working.