### PR TITLE
NIAD-2817: Degrade codes are not mapped for all resources

### DIFF
--- a/gp2gp-translator/src/integrationTest/resources/e2e-mapping/output-json/PWTP10-output.json
+++ b/gp2gp-translator/src/integrationTest/resources/e2e-mapping/output-json/PWTP10-output.json
@@ -3186,6 +3186,11 @@
         "code": {
           "coding": [
             {
+              "system": "http://snomed.info/sct",
+              "code": "196411000000103",
+              "display": "Transfer-degraded record entry"
+            },
+            {
               "system": "https://fhir.hl7.org.uk/Id/egton-codes",
               "code": "EMISNOFH2",
               "display": "No FH: Ischaemic heart dis <60"

--- a/gp2gp-translator/src/integrationTest/resources/e2e-mapping/output-json/PWTP3-output.json
+++ b/gp2gp-translator/src/integrationTest/resources/e2e-mapping/output-json/PWTP3-output.json
@@ -2120,6 +2120,11 @@
         "code": {
           "coding": [
             {
+              "system": "http://snomed.info/sct",
+              "code": "196411000000103",
+              "display": "Transfer-degraded record entry"
+            },
+            {
               "system": "https://fhir.hl7.org.uk/Id/egton-codes",
               "code": "EMISSCE2",
               "display": "Cervical smear adequate"

--- a/gp2gp-translator/src/integrationTest/resources/e2e-mapping/output-json/PWTP3-output.json
+++ b/gp2gp-translator/src/integrationTest/resources/e2e-mapping/output-json/PWTP3-output.json
@@ -793,6 +793,11 @@
         "code": {
           "coding": [
             {
+              "system": "http://snomed.info/sct",
+              "code": "196411000000103",
+              "display": "Transfer-degraded record entry"
+            },
+            {
               "system": "https://fhir.hl7.org.uk/Id/egton-codes",
               "code": "EMISCSU6",
               "display": "Surveillance"
@@ -833,6 +838,11 @@
         "status": "final",
         "code": {
           "coding": [
+            {
+              "system": "http://snomed.info/sct",
+              "code": "196411000000103",
+              "display": "Transfer-degraded record entry"
+            },
             {
               "system": "https://fhir.hl7.org.uk/Id/egton-codes",
               "code": "EMISCTH1",
@@ -876,6 +886,11 @@
         "code": {
           "coding": [
             {
+              "system": "http://snomed.info/sct",
+              "code": "196411000000103",
+              "display": "Transfer-degraded record entry"
+            },
+            {
               "system": "https://fhir.hl7.org.uk/Id/egton-codes",
               "code": "EMISNQDXDD",
               "display": "Patient died"
@@ -916,6 +931,11 @@
         "status": "final",
         "code": {
           "coding": [
+            {
+              "system": "http://snomed.info/sct",
+              "code": "196411000000103",
+              "display": "Transfer-degraded record entry"
+            },
             {
               "system": "https://fhir.hl7.org.uk/Id/egton-codes",
               "code": "EMISD_BE1",
@@ -958,6 +978,11 @@
         "status": "final",
         "code": {
           "coding": [
+            {
+              "system": "http://snomed.info/sct",
+              "code": "196411000000103",
+              "display": "Transfer-degraded record entry"
+            },
             {
               "system": "https://fhir.hl7.org.uk/Id/egton-codes",
               "code": "HMPNQHO5",
@@ -1291,6 +1316,11 @@
         "status": "final",
         "code": {
           "coding": [
+            {
+              "system": "http://snomed.info/sct",
+              "code": "196411000000103",
+              "display": "Transfer-degraded record entry"
+            },
             {
               "system": "https://fhir.hl7.org.uk/Id/egton-codes",
               "code": "EMISSCE2",

--- a/gp2gp-translator/src/integrationTest/resources/e2e-mapping/output-json/PWTP5-output.json
+++ b/gp2gp-translator/src/integrationTest/resources/e2e-mapping/output-json/PWTP5-output.json
@@ -4169,6 +4169,13 @@
         ],
         "status": "final",
         "code": {
+          "coding": [
+            {
+              "system": "http://snomed.info/sct",
+              "code": "196411000000103",
+              "display": "Transfer-degraded record entry"
+            }
+          ],
           "text": "Banana"
         },
         "subject": {

--- a/gp2gp-translator/src/integrationTest/resources/e2e-mapping/output-json/PWTP5-output.json
+++ b/gp2gp-translator/src/integrationTest/resources/e2e-mapping/output-json/PWTP5-output.json
@@ -3516,6 +3516,11 @@
         "code": {
           "coding": [
             {
+              "system": "http://snomed.info/sct",
+              "code": "196411000000103",
+              "display": "Transfer-degraded record entry"
+            },
+            {
               "system": "https://fhir.hl7.org.uk/Id/egton-codes",
               "code": "EMISNQWI3",
               "display": "Witchcraft"

--- a/gp2gp-translator/src/integrationTest/resources/e2e-mapping/output-json/PWTP6-output.json
+++ b/gp2gp-translator/src/integrationTest/resources/e2e-mapping/output-json/PWTP6-output.json
@@ -3093,6 +3093,11 @@
         "code": {
           "coding": [
             {
+              "system": "http://snomed.info/sct",
+              "code": "196411000000103",
+              "display": "Transfer-degraded record entry"
+            },
+            {
               "system": "https://fhir.hl7.org.uk/Id/egton-codes",
               "code": "EMISQSM13",
               "display": "Smoking cessation counselling by telephone"
@@ -4184,6 +4189,11 @@
         "code": {
           "coding": [
             {
+              "system": "http://snomed.info/sct",
+              "code": "196411000000103",
+              "display": "Transfer-degraded record entry"
+            },
+            {
               "system": "https://fhir.hl7.org.uk/Id/egton-codes",
               "code": "EMISQDO6",
               "display": "Doppler of right foot - triphasic"
@@ -4224,6 +4234,11 @@
         "status": "final",
         "code": {
           "coding": [
+            {
+              "system": "http://snomed.info/sct",
+              "code": "196411000000103",
+              "display": "Transfer-degraded record entry"
+            },
             {
               "system": "https://fhir.hl7.org.uk/Id/egton-codes",
               "code": "EMISQDO2",
@@ -4781,6 +4796,11 @@
         "code": {
           "coding": [
             {
+              "system": "http://snomed.info/sct",
+              "code": "196411000000103",
+              "display": "Transfer-degraded record entry"
+            },
+            {
               "system": "https://fhir.hl7.org.uk/Id/egton-codes",
               "code": "EMISQRI6",
               "display": "Right foot monofilament 10g normal"
@@ -4822,6 +4842,11 @@
         "status": "final",
         "code": {
           "coding": [
+            {
+              "system": "http://snomed.info/sct",
+              "code": "196411000000103",
+              "display": "Transfer-degraded record entry"
+            },
             {
               "system": "https://fhir.hl7.org.uk/Id/egton-codes",
               "code": "EMISQLE7",

--- a/gp2gp-translator/src/integrationTest/resources/e2e-mapping/output-json/PWTP7_vis-output.json
+++ b/gp2gp-translator/src/integrationTest/resources/e2e-mapping/output-json/PWTP7_vis-output.json
@@ -3493,15 +3493,6 @@
             ]
           }
         ],
-        "code": {
-          "coding": [
-            {
-              "system": "http://snomed.info/sct",
-              "code": "196411000000103",
-              "display": "Transfer-degraded record entry"
-            }
-          ]
-        },
         "subject": {
           "reference": "Patient/b362eb8b-4952-4daa-83fe-c86bbd3f1f2e"
         },

--- a/gp2gp-translator/src/integrationTest/resources/e2e-mapping/output-json/PWTP7_vis-output.json
+++ b/gp2gp-translator/src/integrationTest/resources/e2e-mapping/output-json/PWTP7_vis-output.json
@@ -3493,6 +3493,15 @@
             ]
           }
         ],
+        "code": {
+          "coding": [
+            {
+              "system": "http://snomed.info/sct",
+              "code": "196411000000103",
+              "display": "Transfer-degraded record entry"
+            }
+          ]
+        },
         "subject": {
           "reference": "Patient/b362eb8b-4952-4daa-83fe-c86bbd3f1f2e"
         },

--- a/gp2gp-translator/src/integrationTest/resources/e2e-mapping/output-json/PWTP9-output.json
+++ b/gp2gp-translator/src/integrationTest/resources/e2e-mapping/output-json/PWTP9-output.json
@@ -20867,6 +20867,13 @@
           }
         ],
         "code": {
+          "coding": [
+            {
+              "system": "http://snomed.info/sct",
+              "code": "196411000000103",
+              "display": "Transfer-degraded record entry"
+            }
+          ],
           "text": "Full blood count - FBC"
         },
         "subject": {
@@ -21204,6 +21211,13 @@
           }
         ],
         "code": {
+          "coding": [
+            {
+              "system": "http://snomed.info/sct",
+              "code": "196411000000103",
+              "display": "Transfer-degraded record entry"
+            }
+          ],
           "text": "CHOL/HDL RATIO"
         },
         "subject": {

--- a/gp2gp-translator/src/integrationTest/resources/e2e-mapping/output-json/PWTP9-output.json
+++ b/gp2gp-translator/src/integrationTest/resources/e2e-mapping/output-json/PWTP9-output.json
@@ -17180,6 +17180,13 @@
         ],
         "status": "final",
         "code": {
+          "coding": [
+            {
+              "system": "http://snomed.info/sct",
+              "code": "196411000000103",
+              "display": "Transfer-degraded record entry"
+            }
+          ],
           "text": "Results repeated,Low plasma Folate"
         },
         "subject": {

--- a/gp2gp-translator/src/integrationTest/resources/e2e-mapping/output-json/PWTP9-output.json
+++ b/gp2gp-translator/src/integrationTest/resources/e2e-mapping/output-json/PWTP9-output.json
@@ -5398,6 +5398,13 @@
           }
         ],
         "code": {
+          "coding": [
+            {
+              "system": "http://snomed.info/sct",
+              "code": "196411000000103",
+              "display": "Transfer-degraded record entry"
+            }
+          ],
           "text": "FT1"
         },
         "subject": {
@@ -5472,6 +5479,13 @@
           }
         ],
         "code": {
+          "coding": [
+            {
+              "system": "http://snomed.info/sct",
+              "code": "196411000000103",
+              "display": "Transfer-degraded record entry"
+            }
+          ],
           "text": "FT2"
         },
         "subject": {
@@ -5546,6 +5560,13 @@
           }
         ],
         "code": {
+          "coding": [
+            {
+              "system": "http://snomed.info/sct",
+              "code": "196411000000103",
+              "display": "Transfer-degraded record entry"
+            }
+          ],
           "text": "FTX3"
         },
         "subject": {
@@ -5620,6 +5641,13 @@
           }
         ],
         "code": {
+          "coding": [
+            {
+              "system": "http://snomed.info/sct",
+              "code": "196411000000103",
+              "display": "Transfer-degraded record entry"
+            }
+          ],
           "text": "FTX4"
         },
         "subject": {
@@ -5694,6 +5722,13 @@
           }
         ],
         "code": {
+          "coding": [
+            {
+              "system": "http://snomed.info/sct",
+              "code": "196411000000103",
+              "display": "Transfer-degraded record entry"
+            }
+          ],
           "text": "FT1"
         },
         "subject": {
@@ -5768,6 +5803,13 @@
           }
         ],
         "code": {
+          "coding": [
+            {
+              "system": "http://snomed.info/sct",
+              "code": "196411000000103",
+              "display": "Transfer-degraded record entry"
+            }
+          ],
           "text": "FT2"
         },
         "subject": {
@@ -5842,6 +5884,13 @@
           }
         ],
         "code": {
+          "coding": [
+            {
+              "system": "http://snomed.info/sct",
+              "code": "196411000000103",
+              "display": "Transfer-degraded record entry"
+            }
+          ],
           "text": "FTX3"
         },
         "subject": {
@@ -5916,6 +5965,13 @@
           }
         ],
         "code": {
+          "coding": [
+            {
+              "system": "http://snomed.info/sct",
+              "code": "196411000000103",
+              "display": "Transfer-degraded record entry"
+            }
+          ],
           "text": "FTX4"
         },
         "subject": {
@@ -5990,6 +6046,13 @@
           }
         ],
         "code": {
+          "coding": [
+            {
+              "system": "http://snomed.info/sct",
+              "code": "196411000000103",
+              "display": "Transfer-degraded record entry"
+            }
+          ],
           "text": "FT1"
         },
         "subject": {
@@ -6064,6 +6127,13 @@
           }
         ],
         "code": {
+          "coding": [
+            {
+              "system": "http://snomed.info/sct",
+              "code": "196411000000103",
+              "display": "Transfer-degraded record entry"
+            }
+          ],
           "text": "FT2"
         },
         "subject": {
@@ -6138,6 +6208,13 @@
           }
         ],
         "code": {
+          "coding": [
+            {
+              "system": "http://snomed.info/sct",
+              "code": "196411000000103",
+              "display": "Transfer-degraded record entry"
+            }
+          ],
           "text": "FTX3"
         },
         "subject": {
@@ -6212,6 +6289,13 @@
           }
         ],
         "code": {
+          "coding": [
+            {
+              "system": "http://snomed.info/sct",
+              "code": "196411000000103",
+              "display": "Transfer-degraded record entry"
+            }
+          ],
           "text": "FTX4"
         },
         "subject": {
@@ -6375,6 +6459,13 @@
           }
         ],
         "code": {
+          "coding": [
+            {
+              "system": "http://snomed.info/sct",
+              "code": "196411000000103",
+              "display": "Transfer-degraded record entry"
+            }
+          ],
           "text": "Serum potassium"
         },
         "subject": {
@@ -6648,6 +6739,13 @@
           }
         ],
         "code": {
+          "coding": [
+            {
+              "system": "http://snomed.info/sct",
+              "code": "196411000000103",
+              "display": "Transfer-degraded record entry"
+            }
+          ],
           "text": "Serum triglycerides"
         },
         "subject": {
@@ -7701,6 +7799,13 @@
           }
         ],
         "code": {
+          "coding": [
+            {
+              "system": "http://snomed.info/sct",
+              "code": "196411000000103",
+              "display": "Transfer-degraded record entry"
+            }
+          ],
           "text": "Neutrophil count"
         },
         "subject": {
@@ -7870,6 +7975,13 @@
           }
         ],
         "code": {
+          "coding": [
+            {
+              "system": "http://snomed.info/sct",
+              "code": "196411000000103",
+              "display": "Transfer-degraded record entry"
+            }
+          ],
           "text": "Monocyte count"
         },
         "subject": {
@@ -10115,6 +10227,13 @@
           }
         ],
         "code": {
+          "coding": [
+            {
+              "system": "http://snomed.info/sct",
+              "code": "196411000000103",
+              "display": "Transfer-degraded record entry"
+            }
+          ],
           "text": "Comment"
         },
         "subject": {
@@ -10732,6 +10851,13 @@
           }
         ],
         "code": {
+          "coding": [
+            {
+              "system": "http://snomed.info/sct",
+              "code": "196411000000103",
+              "display": "Transfer-degraded record entry"
+            }
+          ],
           "text": "Packed cell volume"
         },
         "subject": {
@@ -11185,6 +11311,13 @@
           }
         ],
         "code": {
+          "coding": [
+            {
+              "system": "http://snomed.info/sct",
+              "code": "196411000000103",
+              "display": "Transfer-degraded record entry"
+            }
+          ],
           "text": "Neutrophil count"
         },
         "subject": {
@@ -11550,6 +11683,13 @@
           }
         ],
         "code": {
+          "coding": [
+            {
+              "system": "http://snomed.info/sct",
+              "code": "196411000000103",
+              "display": "Transfer-degraded record entry"
+            }
+          ],
           "text": "Basophil count"
         },
         "subject": {
@@ -12432,6 +12572,13 @@
           }
         ],
         "code": {
+          "coding": [
+            {
+              "system": "http://snomed.info/sct",
+              "code": "196411000000103",
+              "display": "Transfer-degraded record entry"
+            }
+          ],
           "text": "IgA Reticulin Abs"
         },
         "subject": {
@@ -12481,6 +12628,13 @@
           }
         ],
         "code": {
+          "coding": [
+            {
+              "system": "http://snomed.info/sct",
+              "code": "196411000000103",
+              "display": "Transfer-degraded record entry"
+            }
+          ],
           "text": "IgG Reticulin Abs"
         },
         "subject": {
@@ -12606,6 +12760,13 @@
           }
         ],
         "code": {
+          "coding": [
+            {
+              "system": "http://snomed.info/sct",
+              "code": "196411000000103",
+              "display": "Transfer-degraded record entry"
+            }
+          ],
           "text": "Ovarian Antibodies"
         },
         "subject": {
@@ -12655,6 +12816,13 @@
           }
         ],
         "code": {
+          "coding": [
+            {
+              "system": "http://snomed.info/sct",
+              "code": "196411000000103",
+              "display": "Transfer-degraded record entry"
+            }
+          ],
           "text": "Skeletal Muscle Abs"
         },
         "subject": {

--- a/gp2gp-translator/src/integrationTest/resources/json/expectedBundle.json
+++ b/gp2gp-translator/src/integrationTest/resources/json/expectedBundle.json
@@ -29979,15 +29979,6 @@
             ]
           }
         ],
-        "code": {
-          "coding": [
-            {
-              "system": "http://snomed.info/sct",
-              "code": "196411000000103",
-              "display": "Transfer-degraded record entry"
-            }
-          ]
-        },
         "subject": {
           "reference": "Patient/e2cf4cc1-08da-4971-845f-35b8447cabdd"
         },

--- a/gp2gp-translator/src/integrationTest/resources/json/expectedBundle.json
+++ b/gp2gp-translator/src/integrationTest/resources/json/expectedBundle.json
@@ -29943,6 +29943,15 @@
             ]
           }
         ],
+        "code": {
+          "coding": [
+            {
+              "system": "http://snomed.info/sct",
+              "code": "196411000000103",
+              "display": "Transfer-degraded record entry"
+            }
+          ]
+        },
         "subject": {
           "reference": "Patient/e2cf4cc1-08da-4971-845f-35b8447cabdd"
         },

--- a/gp2gp-translator/src/integrationTest/resources/json/expectedBundle.json
+++ b/gp2gp-translator/src/integrationTest/resources/json/expectedBundle.json
@@ -1466,6 +1466,11 @@
           {
             "coding": [
               {
+                "system": "http://snomed.info/sct",
+                "code": "196411000000103",
+                "display": "Transfer-degraded record entry"
+              },
+              {
                 "system": "http://read.info/ctv3",
                 "code": "496401000000100",
                 "display": "Non-consultation data"

--- a/gp2gp-translator/src/integrationTest/resources/json/expectedBundle.json
+++ b/gp2gp-translator/src/integrationTest/resources/json/expectedBundle.json
@@ -28735,6 +28735,13 @@
           }
         ],
         "code": {
+          "coding": [
+            {
+              "system": "http://snomed.info/sct",
+              "code": "196411000000103",
+              "display": "Transfer-degraded record entry"
+            }
+          ],
           "text": "Mocked code"
         },
         "subject": {
@@ -28786,6 +28793,11 @@
         "status": "final",
         "code": {
           "coding": [
+            {
+              "system": "http://snomed.info/sct",
+              "code": "196411000000103",
+              "display": "Transfer-degraded record entry"
+            },
             {
               "system": "2.16.840.1.113883.2.1.6.7",
               "code": "1683.00",
@@ -28893,6 +28905,13 @@
         ],
         "status": "final",
         "code": {
+          "coding": [
+            {
+              "system": "http://snomed.info/sct",
+              "code": "196411000000103",
+              "display": "Transfer-degraded record entry"
+            }
+          ],
           "text": "Preferred method of contact: unknown"
         },
         "subject": {
@@ -29178,6 +29197,11 @@
         "code": {
           "coding": [
             {
+              "system": "http://snomed.info/sct",
+              "code": "196411000000103",
+              "display": "Transfer-degraded record entry"
+            },
+            {
               "system": "2.16.840.1.113883.2.1.3.2.4.19",
               "code": "360300017",
               "display": "Test display"
@@ -29262,6 +29286,13 @@
           }
         ],
         "code": {
+          "coding": [
+            {
+              "system": "http://snomed.info/sct",
+              "code": "196411000000103",
+              "display": "Transfer-degraded record entry"
+            }
+          ],
           "text": "Mocked code"
         },
         "subject": {

--- a/gp2gp-translator/src/integrationTest/resources/json/expectedBundle.json
+++ b/gp2gp-translator/src/integrationTest/resources/json/expectedBundle.json
@@ -30291,6 +30291,11 @@
         "code": {
           "coding": [
             {
+              "system": "http://snomed.info/sct",
+              "code": "196411000000103",
+              "display": "Transfer-degraded record entry"
+            },
+            {
               "system": "2.16.840.1.113883.2.1.6.7",
               "code": "PKyz500",
               "display": "Happy puppet syndrome"

--- a/gp2gp-translator/src/main/java/uk/nhs/adaptors/pss/translator/mapper/BloodPressureMapper.java
+++ b/gp2gp-translator/src/main/java/uk/nhs/adaptors/pss/translator/mapper/BloodPressureMapper.java
@@ -45,7 +45,6 @@ import org.springframework.stereotype.Service;
 
 import lombok.AllArgsConstructor;
 import uk.nhs.adaptors.pss.translator.util.DegradedCodeableConcepts;
-import uk.nhs.adaptors.pss.translator.util.DegradedCodesUtil;
 
 @Service
 @AllArgsConstructor

--- a/gp2gp-translator/src/main/java/uk/nhs/adaptors/pss/translator/mapper/BloodPressureMapper.java
+++ b/gp2gp-translator/src/main/java/uk/nhs/adaptors/pss/translator/mapper/BloodPressureMapper.java
@@ -44,6 +44,8 @@ import org.hl7.v3.RCMRMT030101UK04PertinentInformation02;
 import org.springframework.stereotype.Service;
 
 import lombok.AllArgsConstructor;
+import uk.nhs.adaptors.pss.translator.util.DegradedCodeableConcepts;
+import uk.nhs.adaptors.pss.translator.util.DegradedCodesUtil;
 
 @Service
 @AllArgsConstructor
@@ -99,7 +101,15 @@ public class BloodPressureMapper extends AbstractMapper<Observation> {
     }
 
     private CodeableConcept getCode(CD code) {
-        return code != null ? codeableConceptMapper.mapToCodeableConcept(code) : null;
+        if (code != null) {
+            var codeableConcept = codeableConceptMapper.mapToCodeableConcept(code);
+            DegradedCodeableConcepts.addDegradedEntryIfRequired(
+                codeableConcept, DegradedCodeableConcepts.DEGRADED_OTHER);
+
+            return codeableConcept;
+        }
+
+        return null;
     }
 
     private List<ObservationComponentComponent> getComponent(List<RCMRMT030101UK04ObservationStatement> observationStatements) {

--- a/gp2gp-translator/src/main/java/uk/nhs/adaptors/pss/translator/mapper/ConditionMapper.java
+++ b/gp2gp-translator/src/main/java/uk/nhs/adaptors/pss/translator/mapper/ConditionMapper.java
@@ -201,13 +201,12 @@ public class ConditionMapper extends AbstractMapper<Condition> {
                         ).forEach(condition::addNote);
 
                         referencedObservationStatement.ifPresent(
-                                observationStatement ->
-                                    condition.setCode(codeableConceptMapper.mapToCodeableConcept(observationStatement.getCode()))
-                        );
-
-                        DegradedCodeableConcepts.addDegradedEntryIfRequired(
-                            condition.getCode(),
-                            DegradedCodeableConcepts.DEGRADED_OTHER);
+                                observationStatement -> {
+                                    condition.setCode(codeableConceptMapper.mapToCodeableConcept(observationStatement.getCode()));
+                                    DegradedCodeableConcepts.addDegradedEntryIfRequired(
+                                        condition.getCode(),
+                                        DegradedCodeableConcepts.DEGRADED_OTHER);
+                                });
 
                         var statementRefs = linkSet.getComponent()
                                 .stream()

--- a/gp2gp-translator/src/main/java/uk/nhs/adaptors/pss/translator/mapper/ConditionMapper.java
+++ b/gp2gp-translator/src/main/java/uk/nhs/adaptors/pss/translator/mapper/ConditionMapper.java
@@ -58,6 +58,7 @@ import org.springframework.stereotype.Service;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import uk.nhs.adaptors.pss.translator.util.CompoundStatementResourceExtractors;
+import uk.nhs.adaptors.pss.translator.util.DegradedCodeableConcepts;
 
 @Service
 @RequiredArgsConstructor(onConstructor = @__(@Autowired))
@@ -203,6 +204,10 @@ public class ConditionMapper extends AbstractMapper<Condition> {
                                 observationStatement ->
                                     condition.setCode(codeableConceptMapper.mapToCodeableConcept(observationStatement.getCode()))
                         );
+
+                        DegradedCodeableConcepts.addDegradedEntryIfRequired(
+                            condition.getCode(),
+                            DegradedCodeableConcepts.DEGRADED_OTHER);
 
                         var statementRefs = linkSet.getComponent()
                                 .stream()

--- a/gp2gp-translator/src/main/java/uk/nhs/adaptors/pss/translator/mapper/DocumentReferenceMapper.java
+++ b/gp2gp-translator/src/main/java/uk/nhs/adaptors/pss/translator/mapper/DocumentReferenceMapper.java
@@ -30,6 +30,7 @@ import lombok.AllArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import uk.nhs.adaptors.connector.model.PatientAttachmentLog;
 import uk.nhs.adaptors.pss.translator.util.DateFormatUtil;
+import uk.nhs.adaptors.pss.translator.util.DegradedCodeableConcepts;
 import uk.nhs.adaptors.pss.translator.util.ResourceFilterUtil;
 
 @Slf4j
@@ -124,18 +125,19 @@ public class DocumentReferenceMapper extends AbstractMapper<DocumentReference> {
 
     private CodeableConcept getType(RCMRMT030101UK04NarrativeStatement narrativeStatement) {
         var referenceToExternalDocument = narrativeStatement.getReference().get(0).getReferredToExternalDocument();
-
+        CodeableConcept codeableConcept = null;
         if (referenceToExternalDocument != null && referenceToExternalDocument.hasCode()) {
             if (!referenceToExternalDocument.getCode().hasOriginalText() && referenceToExternalDocument.getCode().hasDisplayName()) {
-                return codeableConceptMapper.mapToCodeableConcept(referenceToExternalDocument.getCode())
+                codeableConcept = codeableConceptMapper.mapToCodeableConcept(referenceToExternalDocument.getCode())
                     .setText(referenceToExternalDocument.getCode().getDisplayName());
             } else if (referenceToExternalDocument.getCode().hasOriginalText()) {
-                return codeableConceptMapper.mapToCodeableConcept(referenceToExternalDocument.getCode())
+                codeableConcept = codeableConceptMapper.mapToCodeableConcept(referenceToExternalDocument.getCode())
                     .setText(referenceToExternalDocument.getCode().getOriginalText());
             }
         }
 
-        return null;
+        DegradedCodeableConcepts.addDegradedEntryIfRequired(codeableConcept, DegradedCodeableConcepts.DEGRADED_OTHER);
+        return codeableConcept;
     }
 
     private Optional<Reference> getAuthor(RCMRMT030101UK04NarrativeStatement narrativeStatement,

--- a/gp2gp-translator/src/main/java/uk/nhs/adaptors/pss/translator/mapper/EncounterMapper.java
+++ b/gp2gp-translator/src/main/java/uk/nhs/adaptors/pss/translator/mapper/EncounterMapper.java
@@ -48,6 +48,7 @@ import org.springframework.util.CollectionUtils;
 
 import lombok.RequiredArgsConstructor;
 import uk.nhs.adaptors.pss.translator.util.DateFormatUtil;
+import uk.nhs.adaptors.pss.translator.util.DegradedCodeableConcepts;
 import uk.nhs.adaptors.pss.translator.util.ResourceReferenceUtil;
 
 @Service
@@ -299,7 +300,10 @@ public class EncounterMapper {
     }
 
     private List<CodeableConcept> getType(CD code) {
-        return List.of(codeableConceptMapper.mapToCodeableConcept(code));
+        var codeableConcept = codeableConceptMapper.mapToCodeableConcept(code);
+
+        DegradedCodeableConcepts.addDegradedEntryIfRequired(codeableConcept, DegradedCodeableConcepts.DEGRADED_OTHER);
+        return List.of(codeableConcept);
     }
 
     private Period getPeriod(RCMRMT030101UK04EhrComposition ehrComposition) {

--- a/gp2gp-translator/src/main/java/uk/nhs/adaptors/pss/translator/mapper/ObservationMapper.java
+++ b/gp2gp-translator/src/main/java/uk/nhs/adaptors/pss/translator/mapper/ObservationMapper.java
@@ -28,6 +28,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 import uk.nhs.adaptors.pss.translator.util.BloodPressureValidatorUtil;
 import uk.nhs.adaptors.pss.translator.util.DatabaseImmunizationChecker;
+import uk.nhs.adaptors.pss.translator.util.DegradedCodeableConcepts;
 
 import java.math.BigInteger;
 import java.util.ArrayList;
@@ -191,7 +192,13 @@ public class ObservationMapper extends AbstractMapper<Observation> {
     }
 
     private CodeableConcept getCode(CD code) {
-        return code != null ? codeableConceptMapper.mapToCodeableConcept(code) : null;
+        if (code == null) {
+            return null;
+        }
+
+        var codeableConcept = codeableConceptMapper.mapToCodeableConcept(code);
+        DegradedCodeableConcepts.addDegradedEntryIfRequired(codeableConcept, DegradedCodeableConcepts.DEGRADED_OTHER);
+        return codeableConcept;
     }
 
     private String getValueString(Object value) {

--- a/gp2gp-translator/src/main/java/uk/nhs/adaptors/pss/translator/mapper/TemplateMapper.java
+++ b/gp2gp-translator/src/main/java/uk/nhs/adaptors/pss/translator/mapper/TemplateMapper.java
@@ -41,6 +41,7 @@ import lombok.RequiredArgsConstructor;
 import uk.nhs.adaptors.pss.translator.util.CompoundStatementResourceExtractors;
 import uk.nhs.adaptors.pss.translator.util.CompoundStatementUtil;
 import uk.nhs.adaptors.pss.translator.util.DateFormatUtil;
+import uk.nhs.adaptors.pss.translator.util.DegradedCodeableConcepts;
 import uk.nhs.adaptors.pss.translator.util.ResourceFilterUtil;
 import uk.nhs.adaptors.pss.translator.util.ResourceReferenceUtil;
 
@@ -156,11 +157,14 @@ public class TemplateMapper extends AbstractMapper<DomainResource> {
         var parentObservation = new Observation();
         var id = compoundStatement.getId().get(0).getRoot();
 
+        var codeableConcept = codeableConceptMapper.mapToCodeableConcept(compoundStatement.getCode());
+        DegradedCodeableConcepts.addDegradedEntryIfRequired(codeableConcept, DegradedCodeableConcepts.DEGRADED_OTHER);
+
         parentObservation
             .setSubject(new Reference(patient))
             .setIssuedElement(getIssued(ehrComposition, ehrExtract))
             .addPerformer(getParticipantReference(compoundStatement.getParticipant(), ehrComposition))
-            .setCode(codeableConceptMapper.mapToCodeableConcept(compoundStatement.getCode()))
+            .setCode(codeableConcept)
             .setStatus(FINAL)
             .addIdentifier(buildIdentifier(id, practiseCode))
             .setMeta(generateMeta(OBSERVATION_META_PROFILE))

--- a/gp2gp-translator/src/main/java/uk/nhs/adaptors/pss/translator/mapper/diagnosticreport/SpecimenBatteryMapper.java
+++ b/gp2gp-translator/src/main/java/uk/nhs/adaptors/pss/translator/mapper/diagnosticreport/SpecimenBatteryMapper.java
@@ -47,6 +47,7 @@ import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 import uk.nhs.adaptors.pss.translator.mapper.CodeableConceptMapper;
 import uk.nhs.adaptors.pss.translator.util.CompoundStatementResourceExtractors;
+import uk.nhs.adaptors.pss.translator.util.DegradedCodeableConcepts;
 import uk.nhs.adaptors.pss.translator.util.TextUtil;
 
 @Service
@@ -189,7 +190,9 @@ public class SpecimenBatteryMapper {
     }
 
     private CodeableConcept createCode(RCMRMT030101UK04CompoundStatement compoundStatement) {
-        return codeableConceptMapper.mapToCodeableConcept(compoundStatement.getCode());
+        var codeableConcept = codeableConceptMapper.mapToCodeableConcept(compoundStatement.getCode());
+        DegradedCodeableConcepts.addDegradedEntryIfRequired(codeableConcept, DegradedCodeableConcepts.DEGRADED_OTHER);
+        return codeableConcept;
     }
 
     private CodeableConcept createCategory() {

--- a/gp2gp-translator/src/main/java/uk/nhs/adaptors/pss/translator/util/DegradedCodeableConcepts.java
+++ b/gp2gp-translator/src/main/java/uk/nhs/adaptors/pss/translator/util/DegradedCodeableConcepts.java
@@ -45,6 +45,10 @@ public final class DegradedCodeableConcepts {
             .setDisplay("Transfer-degraded record entry");
 
     public static void addDegradedEntryIfRequired(CodeableConcept codeableConcept, Coding degradedCoding) {
+        if (codeableConcept == null) {
+            return;
+        }
+
         if (codeableConcept.hasCoding()) {
             var coding = codeableConcept.getCoding();
             var hasSnomedCode = coding

--- a/gp2gp-translator/src/test/java/uk/nhs/adaptors/pss/translator/mapper/BloodPressureMapperTest.java
+++ b/gp2gp-translator/src/test/java/uk/nhs/adaptors/pss/translator/mapper/BloodPressureMapperTest.java
@@ -12,7 +12,6 @@ import java.lang.reflect.Method;
 import java.math.BigDecimal;
 import java.util.List;
 
-import com.github.mustachejava.Code;
 import org.apache.commons.lang3.StringUtils;
 import org.hl7.fhir.dstu3.model.CodeableConcept;
 import org.hl7.fhir.dstu3.model.Coding;

--- a/gp2gp-translator/src/test/java/uk/nhs/adaptors/pss/translator/mapper/BloodPressureMapperTest.java
+++ b/gp2gp-translator/src/test/java/uk/nhs/adaptors/pss/translator/mapper/BloodPressureMapperTest.java
@@ -12,6 +12,7 @@ import java.lang.reflect.Method;
 import java.math.BigDecimal;
 import java.util.List;
 
+import com.github.mustachejava.Code;
 import org.apache.commons.lang3.StringUtils;
 import org.hl7.fhir.dstu3.model.CodeableConcept;
 import org.hl7.fhir.dstu3.model.Coding;
@@ -31,6 +32,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
 
 import lombok.SneakyThrows;
 import uk.nhs.adaptors.pss.translator.util.DateFormatUtil;
+import uk.nhs.adaptors.pss.translator.util.DegradedCodeableConcepts;
 import uk.nhs.adaptors.pss.translator.util.MeasurementUnitsUtil;
 
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
@@ -109,19 +111,28 @@ public class BloodPressureMapperTest {
 
         assertFixedValues(bloodPressure);
         assertThat(bloodPressure.getId()).isEqualTo(EXAMPLE_ID);
-        assertThat(bloodPressure.getCode().getCodingFirstRep().getDisplay()).isEqualTo(CODING_DISPLAY_MOCK);
+        assertThat(bloodPressure.getComponent().get(0).getCode().getCodingFirstRep())
+            .isEqualTo(DegradedCodeableConcepts.DEGRADED_OTHER);
+        assertThat(bloodPressure.getComponent().get(0).getCode().getCoding().get(1).getDisplay())
+            .isEqualTo(CODING_DISPLAY_MOCK);
         assertThat(bloodPressure.hasSubject()).isTrue();
         assertThat(bloodPressure.getIssuedElement().asStringValue()).isEqualTo(ISSUED_EXAMPLE);
         assertThat(bloodPressure.getEffective().toString()).isEqualTo(DateFormatUtil.parseToDateTimeType(EFFECTIVE_EXAMPLE).toString());
         assertThat(bloodPressure.getPerformer().get(0).getReference()).isEqualTo(PPRF_PARTICIPANT_ID);
         assertThat(bloodPressure.getComment()).isEqualTo(COMMENT_EXAMPLE_1);
 
-        assertThat(bloodPressure.getComponent().get(0).getCode().getCodingFirstRep().getDisplay()).isEqualTo(CODING_DISPLAY_MOCK);
+        assertThat(bloodPressure.getComponent().get(0).getCode().getCodingFirstRep())
+            .isEqualTo(DegradedCodeableConcepts.DEGRADED_OTHER);
+        assertThat(bloodPressure.getComponent().get(0).getCode().getCoding().get(1).getDisplay())
+            .isEqualTo(CODING_DISPLAY_MOCK);
         assertThat(bloodPressure.getComponent().get(0).getValueQuantity().getValue()).isEqualTo(COMPONENT_1_VALUE_QUANTITY_VALUE);
         assertThat(bloodPressure.getComponent().get(0).getInterpretation().getText()).isEqualTo(COMPONENT_1_INTERPRETATION_TEXT);
         assertThat(bloodPressure.getComponent().get(0).getReferenceRange().get(0).getText()).isEqualTo(COMPONENT_1_REFERENCE_RANGE_TEXT);
 
-        assertThat(bloodPressure.getComponent().get(1).getCode().getCodingFirstRep().getDisplay()).isEqualTo(CODING_DISPLAY_MOCK);
+        assertThat(bloodPressure.getComponent().get(1).getCode().getCodingFirstRep())
+            .isEqualTo(DegradedCodeableConcepts.DEGRADED_OTHER);
+        assertThat(bloodPressure.getComponent().get(1).getCode().getCoding().get(1).getDisplay())
+            .isEqualTo(CODING_DISPLAY_MOCK);
         assertThat(bloodPressure.getComponent().get(1).getValueQuantity().getValue()).isEqualTo(COMPONENT_2_VALUE_QUANTITY_VALUE);
         assertThat(bloodPressure.getComponent().get(1).getInterpretation().getText()).isEqualTo(COMPONENT_2_INTERPRETATION_TEXT);
         assertThat(bloodPressure.getComponent().get(1).getReferenceRange().get(0).getText()).isEqualTo(COMPONENT_2_REFERENCE_RANGE_TEXT);
@@ -137,7 +148,8 @@ public class BloodPressureMapperTest {
 
         assertFixedValues(bloodPressure);
         assertThat(bloodPressure.getId()).isEqualTo(EXAMPLE_ID);
-        assertThat(bloodPressure.getCode().getCodingFirstRep().getDisplay()).isEqualTo(CODING_DISPLAY_MOCK);
+        assertThat(bloodPressure.getCode().getCodingFirstRep()).isEqualTo(DegradedCodeableConcepts.DEGRADED_OTHER);
+        assertThat(bloodPressure.getCode().getCoding().get(1).getDisplay()).isEqualTo(CODING_DISPLAY_MOCK);
         assertThat(bloodPressure.hasSubject()).isTrue();
         assertThat(bloodPressure.getIssuedElement().asStringValue()).isEqualTo(ISSUED_EXAMPLE);
         assertThat(bloodPressure.getPerformer().get(0).getReference()).isEqualTo(PPRF_PARTICIPANT_ID);
@@ -145,12 +157,18 @@ public class BloodPressureMapperTest {
         assertThat(bloodPressure.getEffective()).isNull();
         assertThat(StringUtils.isEmpty(bloodPressure.getComment())).isTrue();
 
-        assertThat(bloodPressure.getComponent().get(0).getCode().getCodingFirstRep().getDisplay()).isEqualTo(CODING_DISPLAY_MOCK);
+        assertThat(bloodPressure.getComponent().get(0).getCode().getCodingFirstRep())
+            .isEqualTo(DegradedCodeableConcepts.DEGRADED_OTHER);
+        assertThat(bloodPressure.getComponent().get(0).getCode().getCoding().get(1).getDisplay())
+            .isEqualTo(CODING_DISPLAY_MOCK);
         assertThat(bloodPressure.getComponent().get(0).getValueQuantity()).isNull();
         assertThat(bloodPressure.getComponent().get(0).getInterpretation().getCoding().isEmpty()).isTrue();
         assertThat(bloodPressure.getComponent().get(0).getReferenceRange().isEmpty()).isTrue();
 
-        assertThat(bloodPressure.getComponent().get(1).getCode().getCodingFirstRep().getDisplay()).isEqualTo(CODING_DISPLAY_MOCK);
+        assertThat(bloodPressure.getComponent().get(1).getCode().getCodingFirstRep())
+            .isEqualTo(DegradedCodeableConcepts.DEGRADED_OTHER);
+        assertThat(bloodPressure.getComponent().get(1).getCode().getCoding().get(1).getDisplay())
+            .isEqualTo(CODING_DISPLAY_MOCK);
         assertThat(bloodPressure.getComponent().get(1).getValueQuantity()).isNull();
         assertThat(bloodPressure.getComponent().get(1).getInterpretation().getCoding().isEmpty()).isTrue();
         assertThat(bloodPressure.getComponent().get(1).getReferenceRange().isEmpty()).isTrue();
@@ -222,5 +240,49 @@ public class BloodPressureMapperTest {
         var bloodPressures = bloodPressureMapper.mapResources(ehrExtract, patient, ENCOUNTER_LIST, PRACTISE_CODE);
 
         assertThat(bloodPressures.isEmpty()).isTrue();
+    }
+
+    @Test
+    public void mapBloodPressureWithNoSnomedCodeInCoding() {
+        when(codeableConceptMapper.mapToCodeableConcept(any())).thenReturn(CODEABLE_CONCEPT);
+
+        var ehrExtract = unmarshallEhrExtractElement("full_valid_data_bp_example.xml");
+
+        var bloodPressure = bloodPressureMapper.mapResources(ehrExtract, patient, ENCOUNTER_LIST, PRACTISE_CODE).get(0);
+
+
+        assertThat(bloodPressure.getCode().getCodingFirstRep())
+            .isEqualTo(DegradedCodeableConcepts.DEGRADED_OTHER);
+        assertThat(bloodPressure.getCode().getCoding().get(1).getDisplay())
+            .isEqualTo(CODING_DISPLAY_MOCK);
+        assertThat(bloodPressure.getComponent().get(0).getCode().getCodingFirstRep())
+            .isEqualTo(DegradedCodeableConcepts.DEGRADED_OTHER);
+        assertThat(bloodPressure.getComponent().get(0).getCode().getCoding().get(1).getDisplay())
+            .isEqualTo(CODING_DISPLAY_MOCK);
+        assertThat(bloodPressure.getComponent().get(1).getCode().getCodingFirstRep())
+            .isEqualTo(DegradedCodeableConcepts.DEGRADED_OTHER);
+        assertThat(bloodPressure.getComponent().get(1).getCode().getCoding().get(1).getDisplay())
+            .isEqualTo(CODING_DISPLAY_MOCK);
+    }
+
+    @Test
+    public void mapBloodPressureWithSnomedCodeInCoding() {
+        var codeableConcept = new CodeableConcept()
+            .addCoding(new Coding()
+                .setSystem("http://snomed.info/sct")
+                .setDisplay("Display")
+                .setCode("123456"));
+        when(codeableConceptMapper.mapToCodeableConcept(any())).thenReturn(codeableConcept);
+
+        var ehrExtract = unmarshallEhrExtractElement("full_valid_data_bp_example.xml");
+
+        var bloodPressure = bloodPressureMapper.mapResources(ehrExtract, patient, ENCOUNTER_LIST, PRACTISE_CODE).get(0);
+
+        assertThat(bloodPressure.getCode())
+            .isEqualTo(codeableConcept);
+        assertThat(bloodPressure.getComponent().get(0).getCode())
+            .isEqualTo(codeableConcept);
+        assertThat(bloodPressure.getComponent().get(1).getCode())
+            .isEqualTo(codeableConcept);
     }
 }

--- a/gp2gp-translator/src/test/java/uk/nhs/adaptors/pss/translator/mapper/ConditionMapperTest.java
+++ b/gp2gp-translator/src/test/java/uk/nhs/adaptors/pss/translator/mapper/ConditionMapperTest.java
@@ -232,7 +232,7 @@ public class ConditionMapperTest {
 
     @Test
     public void mapConditionWithoutSnomedCodeInCoding() {
-         var codeableConcept = new CodeableConcept().addCoding(new Coding().setDisplay(CODING_DISPLAY));
+        var codeableConcept = new CodeableConcept().addCoding(new Coding().setDisplay(CODING_DISPLAY));
         when(codeableConceptMapper.mapToCodeableConcept(any())).thenReturn(codeableConcept);
         when(dateTimeMapper.mapDateTime(any(String.class))).thenCallRealMethod();
 

--- a/gp2gp-translator/src/test/java/uk/nhs/adaptors/pss/translator/mapper/EncounterMapperTest.java
+++ b/gp2gp-translator/src/test/java/uk/nhs/adaptors/pss/translator/mapper/EncounterMapperTest.java
@@ -27,7 +27,7 @@ import org.hl7.fhir.dstu3.model.Reference;
 import org.hl7.fhir.dstu3.model.Location;
 import org.hl7.v3.RCMRMT030101UK04CompoundStatement;
 import org.hl7.v3.RCMRMT030101UK04EhrExtract;
-import org.junit.Assert;
+
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;

--- a/gp2gp-translator/src/test/java/uk/nhs/adaptors/pss/translator/mapper/ObservationMapperTest.java
+++ b/gp2gp-translator/src/test/java/uk/nhs/adaptors/pss/translator/mapper/ObservationMapperTest.java
@@ -25,10 +25,9 @@ import org.hl7.fhir.dstu3.model.Period;
 import org.hl7.fhir.dstu3.model.Quantity;
 import org.hl7.fhir.dstu3.model.StringType;
 import org.hl7.v3.RCMRMT030101UK04EhrExtract;
-import org.junit.jupiter.api.BeforeAll;
+
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.TestInstance;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;

--- a/gp2gp-translator/src/test/java/uk/nhs/adaptors/pss/translator/mapper/ObservationMapperTest.java
+++ b/gp2gp-translator/src/test/java/uk/nhs/adaptors/pss/translator/mapper/ObservationMapperTest.java
@@ -1,6 +1,9 @@
 package uk.nhs.adaptors.pss.translator.mapper;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.lenient;
+import static org.mockito.Mockito.when;
 import static org.springframework.util.ResourceUtils.getFile;
 
 import static uk.nhs.adaptors.pss.translator.util.XmlUnmarshallUtil.unmarshallFile;
@@ -23,6 +26,7 @@ import org.hl7.fhir.dstu3.model.Quantity;
 import org.hl7.fhir.dstu3.model.StringType;
 import org.hl7.v3.RCMRMT030101UK04EhrExtract;
 import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -32,9 +36,9 @@ import org.mockito.junit.jupiter.MockitoExtension;
 
 import lombok.SneakyThrows;
 import uk.nhs.adaptors.pss.translator.util.DatabaseImmunizationChecker;
+import uk.nhs.adaptors.pss.translator.util.DegradedCodeableConcepts;
 import uk.nhs.adaptors.pss.translator.util.MeasurementUnitsUtil;
 
-@TestInstance(TestInstance.Lifecycle.PER_CLASS)
 @ExtendWith(MockitoExtension.class)
 public class ObservationMapperTest {
     private static final String XML_RESOURCES_BASE = "xml/Observation/";
@@ -53,14 +57,10 @@ public class ObservationMapperTest {
     private static final BigDecimal QUANTITY_VALUE = QUANTITY_VALUE_BASE.setScale(3);
     private static final BigDecimal REFERENCE_RANGE_LOW_VALUE = new BigDecimal(20);
     private static final BigDecimal REFERENCE_RANGE_HIGH_VALUE = new BigDecimal(22);
-
-    private static final CodeableConcept CODEABLE_CONCEPT = new CodeableConcept()
-        .addCoding(new Coding().setDisplay(CODING_DISPLAY_MOCK));
-
+    private static final String SNOMED_SYSTEM = "http://snomed.info/sct";
     private static final List<Encounter> ENCOUNTER_LIST = List.of(
         (Encounter) new Encounter().setId("TEST_ID_MATCHING_ENCOUNTER")
     );
-
     private static final String ORIGINAL_TEXT = "Original Text";
     private static final String MINUS_ONE_ANNOTATION_TEXT = "minus 1 sequence comment";
     private static final String ZERO_ANNOTATION_TEXT = "zero sequence comment";
@@ -87,10 +87,12 @@ public class ObservationMapperTest {
         return method;
     }
 
-    @BeforeAll
+    @BeforeEach
     public void createMeasurementUnits() throws NoSuchMethodException, InvocationTargetException, IllegalAccessException {
         getCreateMeasurementUnitsMethod().invoke(MEASUREMENT_UNITS_UTIL);
     }
+
+
 
     @Test
     public void mapObservationWithValidData() {
@@ -280,6 +282,40 @@ public class ObservationMapperTest {
             + NULL_FLAVOR_ANNOTATION_TEXT;
 
         assertThat(observation.getComment()).isEqualTo(expectedComment);
+    }
+
+    @Test
+    public void When_MapObservation_WithoutSnomedCodeInCode_Expect_DegradedCodeableConcept() {
+        var codeableConcept = new CodeableConcept();
+        var coding = new Coding()
+            .setDisplay(CODING_DISPLAY_MOCK)
+            .setSystem("1.2.3.4.5");
+        codeableConcept.addCoding(coding);
+        when(codeableConceptMapper.mapToCodeableConcept(any())).thenReturn(codeableConcept);
+
+        var ehrExtract = unmarshallEhrExtractElement("full_valid_data_observation_example.xml");
+        var observation = observationMapper.mapResources(ehrExtract, patient, ENCOUNTER_LIST, PRACTISE_CODE).get(0);
+
+        assertThat(observation.getCode().getCodingFirstRep())
+            .isEqualTo(DegradedCodeableConcepts.DEGRADED_OTHER);
+    }
+
+    @Test
+    public void When_MapObservation_WithSnomedCodeInCode_Expect_MappedWithoutDegrading() {
+        var codeableConcept = new CodeableConcept();
+        var coding = new Coding()
+            .setDisplay(CODING_DISPLAY_MOCK)
+            .setSystem(SNOMED_SYSTEM);
+        codeableConcept.addCoding(coding);
+        lenient().when(codeableConceptMapper.mapToCodeableConcept(any())).thenReturn(codeableConcept);
+
+        var ehrExtract = unmarshallEhrExtractElement("full_valid_data_observation_example.xml");
+        var observation = observationMapper.mapResources(ehrExtract, patient, ENCOUNTER_LIST, PRACTISE_CODE).get(0);
+
+        assertThat(observation.getCode().getCodingFirstRep().getDisplay())
+            .isEqualTo(CODING_DISPLAY_MOCK);
+        assertThat(observation.getCode().getCodingFirstRep().getSystem())
+            .isEqualTo(SNOMED_SYSTEM);
     }
 
     private void assertFixedValues(Observation observation) {

--- a/gp2gp-translator/src/test/java/uk/nhs/adaptors/pss/translator/mapper/diagnosticreport/SpecimenBatteryMapperTest.java
+++ b/gp2gp-translator/src/test/java/uk/nhs/adaptors/pss/translator/mapper/diagnosticreport/SpecimenBatteryMapperTest.java
@@ -13,11 +13,19 @@ import static uk.nhs.adaptors.pss.translator.util.XmlUnmarshallUtil.unmarshallFi
 import java.util.ArrayList;
 import java.util.List;
 
-import org.hl7.fhir.dstu3.model.*;
+import org.hl7.fhir.dstu3.model.CodeableConcept;
+import org.hl7.fhir.dstu3.model.Coding;
+import org.hl7.fhir.dstu3.model.DateTimeType;
+import org.hl7.fhir.dstu3.model.DiagnosticReport;
+import org.hl7.fhir.dstu3.model.Encounter;
+import org.hl7.fhir.dstu3.model.InstantType;
+import org.hl7.fhir.dstu3.model.Observation;
 import org.hl7.fhir.dstu3.model.Observation.ObservationRelationshipType;
+import org.hl7.fhir.dstu3.model.Patient;
 import org.hl7.v3.RCMRMT030101UK04CompoundStatement;
 import org.hl7.v3.RCMRMT030101UK04EhrComposition;
 import org.hl7.v3.RCMRMT030101UK04EhrExtract;
+
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;

--- a/gp2gp-translator/src/test/java/uk/nhs/adaptors/pss/translator/mapper/diagnosticreport/SpecimenBatteryMapperTest.java
+++ b/gp2gp-translator/src/test/java/uk/nhs/adaptors/pss/translator/mapper/diagnosticreport/SpecimenBatteryMapperTest.java
@@ -2,6 +2,8 @@ package uk.nhs.adaptors.pss.translator.mapper.diagnosticreport;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.hl7.fhir.dstu3.model.Observation.ObservationStatus;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
 import static org.springframework.util.ResourceUtils.getFile;
 
 import static uk.nhs.adaptors.pss.translator.util.DateFormatUtil.parseToDateTimeType;
@@ -11,13 +13,8 @@ import static uk.nhs.adaptors.pss.translator.util.XmlUnmarshallUtil.unmarshallFi
 import java.util.ArrayList;
 import java.util.List;
 
-import org.hl7.fhir.dstu3.model.DateTimeType;
-import org.hl7.fhir.dstu3.model.DiagnosticReport;
-import org.hl7.fhir.dstu3.model.Encounter;
-import org.hl7.fhir.dstu3.model.InstantType;
-import org.hl7.fhir.dstu3.model.Observation;
+import org.hl7.fhir.dstu3.model.*;
 import org.hl7.fhir.dstu3.model.Observation.ObservationRelationshipType;
-import org.hl7.fhir.dstu3.model.Patient;
 import org.hl7.v3.RCMRMT030101UK04CompoundStatement;
 import org.hl7.v3.RCMRMT030101UK04EhrComposition;
 import org.hl7.v3.RCMRMT030101UK04EhrExtract;
@@ -31,6 +28,7 @@ import lombok.SneakyThrows;
 import uk.nhs.adaptors.pss.translator.mapper.CodeableConceptMapper;
 import uk.nhs.adaptors.pss.translator.mapper.diagnosticreport.SpecimenBatteryMapper.SpecimenBatteryParameters;
 import uk.nhs.adaptors.pss.translator.util.CompoundStatementResourceExtractors;
+import uk.nhs.adaptors.pss.translator.util.DegradedCodeableConcepts;
 
 @ExtendWith(MockitoExtension.class)
 public class SpecimenBatteryMapperTest {
@@ -52,7 +50,13 @@ public class SpecimenBatteryMapperTest {
     private static final DiagnosticReport DIAGNOSTIC_REPORT = (DiagnosticReport) new DiagnosticReport().setId(DIAGNOSTIC_REPORT_ID);
     private static final InstantType OBSERVATION_ISSUED = parseToInstantType("202203021160700");
     private static final DateTimeType OBSERVATION_EFFECTIVE = parseToDateTimeType("20100223000000");
+    private static final String CODING_DISPLAY_MOCK = "Test Display";
+    private static final String SNOMED_SYSTEM = "http://snomed.info/sct";
 
+    private static final CodeableConcept CODEABLE_CONCEPT = new CodeableConcept()
+        .addCoding(new Coding()
+            .setDisplay(CODING_DISPLAY_MOCK)
+            .setSystem(SNOMED_SYSTEM));
     private final List<Encounter> encounters = generateEncounters();
 
     @Mock
@@ -109,6 +113,67 @@ public class SpecimenBatteryMapperTest {
             .toList();
 
         assertThat(observationCommentIds.contains("BATTERY_DIRECT_CHILD_NARRATIVE_STATEMENT_ID")).isFalse();
+    }
+
+    @Test
+    public void When_MappingObservationFromBatteryCompoundStatementWithSnomedCode_Expect_CorrectlyMapped() {
+        when(codeableConceptMapper.mapToCodeableConcept(any())).thenReturn(CODEABLE_CONCEPT);
+
+        final RCMRMT030101UK04EhrExtract ehrExtract = unmarshallEhrExtract("specimen_battery_compound_statement.xml");
+        var batteryCompoundStatement = getBatteryCompoundStatements(ehrExtract);
+
+        final List<Observation> observations = getObservations();
+        final List<Observation> observationComments = getObservationComments();
+
+        var batteryParameters = SpecimenBatteryParameters.builder()
+            .ehrExtract(ehrExtract)
+            .batteryCompoundStatement(batteryCompoundStatement)
+            .specimenCompoundStatement(getSpecimenCompoundStatement(ehrExtract))
+            .ehrComposition(getEhrComposition(ehrExtract))
+            .diagnosticReport(DIAGNOSTIC_REPORT)
+            .patient(PATIENT)
+            .encounters(encounters)
+            .practiseCode(PRACTISE_CODE)
+            .observations(observations)
+            .observationComments(observationComments)
+            .build();
+
+        final Observation observation = specimenBatteryMapper.mapBatteryObservation(batteryParameters);
+
+        assertThat(observation.getCode()).isEqualTo(CODEABLE_CONCEPT);
+    }
+
+    @Test
+    public void When_MappingObservationFromBatteryCompoundStatementWithoutSnomedCode_Expect_DegradedCode() {
+        var codeableConcept = new CodeableConcept();
+        var coding = new Coding()
+            .setDisplay(CODING_DISPLAY_MOCK)
+            .setSystem("1.2.3.4.5");
+        codeableConcept.addCoding(coding);
+        when(codeableConceptMapper.mapToCodeableConcept(any())).thenReturn(codeableConcept);
+
+        final RCMRMT030101UK04EhrExtract ehrExtract = unmarshallEhrExtract("specimen_battery_compound_statement.xml");
+        var batteryCompoundStatement = getBatteryCompoundStatements(ehrExtract);
+
+        final List<Observation> observations = getObservations();
+        final List<Observation> observationComments = getObservationComments();
+
+        var batteryParameters = SpecimenBatteryParameters.builder()
+            .ehrExtract(ehrExtract)
+            .batteryCompoundStatement(batteryCompoundStatement)
+            .specimenCompoundStatement(getSpecimenCompoundStatement(ehrExtract))
+            .ehrComposition(getEhrComposition(ehrExtract))
+            .diagnosticReport(DIAGNOSTIC_REPORT)
+            .patient(PATIENT)
+            .encounters(encounters)
+            .practiseCode(PRACTISE_CODE)
+            .observations(observations)
+            .observationComments(observationComments)
+            .build();
+
+        final Observation observation = specimenBatteryMapper.mapBatteryObservation(batteryParameters);
+
+        assertThat(observation.getCode().getCodingFirstRep()).isEqualTo(DegradedCodeableConcepts.DEGRADED_OTHER);
     }
 
     private List<Observation> getObservationComments() {


### PR DESCRIPTION
If a coding block does not contain a Snomed entry (but may contain one or more non-Snomed codes) it should generate a degraded resource.

These changes add the respective degraded code to all resources which map codeableConcepts using the codeableConceptMapper.

Details of degraded codes are detailed in section 3 of the following document:
[Guidance On CodeableConcept](https://developer.nhs.uk/apis/gpconnect-1-6-0/pages/accessrecord_structured/GuidanceOnCodeableConcept.pdf)