### PR TITLE
NIAD-2832: Fix continue message not being accepted by EMIS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## [Unreleased]
 
+### Fixed
+
+* Fix issue where continue message was not accepted by EMIS. 
 
 ## [0.13] - 2023-09-13
 

--- a/gp2gp-translator/src/main/java/uk/nhs/adaptors/pss/translator/mhs/MhsRequestBuilder.java
+++ b/gp2gp-translator/src/main/java/uk/nhs/adaptors/pss/translator/mhs/MhsRequestBuilder.java
@@ -44,7 +44,6 @@ public class MhsRequestBuilder {
         return buildSendRequest(conversationId, toOdsCode, outboundMessage, MHS_OUTBOUND_EXTRACT_CORE_INTERACTION_ID, messageId);
     }
 
-    // TODO: this method is related to the large messaging epic and can be used during implementation of NIAD-2045
     public WebClient.RequestHeadersSpec<?> buildSendContinueRequest(
         String conversationId, String toOdsCode, OutboundMessage outboundMessage, String messageId) {
         return buildSendRequest(conversationId, toOdsCode, outboundMessage, MHS_OUTBOUND_COMMON_INTERACTION_ID, messageId);

--- a/gp2gp-translator/src/main/java/uk/nhs/adaptors/pss/translator/mhs/MhsRequestBuilder.java
+++ b/gp2gp-translator/src/main/java/uk/nhs/adaptors/pss/translator/mhs/MhsRequestBuilder.java
@@ -34,29 +34,30 @@ public class MhsRequestBuilder {
     private static final String WAIT_FOR_RESPONSE = "wait-for-response";
     private static final String FALSE = "false";
     private static final String CONTENT_TYPE = "Content-type";
+    private static final String MESSAGE_ID = "Message-Id";
 
     private final RequestBuilderService requestBuilderService;
     private final MhsOutboundConfiguration mhsOutboundConfiguration;
 
     public WebClient.RequestHeadersSpec<?> buildSendEhrExtractRequest(
-        String conversationId, String toOdsCode, OutboundMessage outboundMessage) {
-        return buildSendRequest(conversationId, toOdsCode, outboundMessage, MHS_OUTBOUND_EXTRACT_CORE_INTERACTION_ID);
+        String conversationId, String toOdsCode, OutboundMessage outboundMessage, String messageId) {
+        return buildSendRequest(conversationId, toOdsCode, outboundMessage, MHS_OUTBOUND_EXTRACT_CORE_INTERACTION_ID, messageId);
     }
 
     // TODO: this method is related to the large messaging epic and can be used during implementation of NIAD-2045
     public WebClient.RequestHeadersSpec<?> buildSendContinueRequest(
-        String conversationId, String toOdsCode, OutboundMessage outboundMessage) {
-        return buildSendRequest(conversationId, toOdsCode, outboundMessage, MHS_OUTBOUND_COMMON_INTERACTION_ID);
+        String conversationId, String toOdsCode, OutboundMessage outboundMessage, String messageId) {
+        return buildSendRequest(conversationId, toOdsCode, outboundMessage, MHS_OUTBOUND_COMMON_INTERACTION_ID, messageId);
     }
 
     public WebClient.RequestHeadersSpec<?> buildSendACKRequest(
-            String conversationId, String toOdsCode, OutboundMessage outboundMessage) {
+            String conversationId, String toOdsCode, OutboundMessage outboundMessage, String messageId) {
         return buildSendRequest(conversationId, toOdsCode, outboundMessage,
-                MHS_OUTBOUND_APPLICATION_ACKNOWLEDGMENT_INTERACTION_ID);
+                MHS_OUTBOUND_APPLICATION_ACKNOWLEDGMENT_INTERACTION_ID, messageId);
     }
 
     private WebClient.RequestHeadersSpec<?> buildSendRequest(
-        String conversationId, String toOdsCode, OutboundMessage outboundMessage, String interactionId) {
+        String conversationId, String toOdsCode, OutboundMessage outboundMessage, String interactionId, String messageId) {
         SslContext sslContext = requestBuilderService.buildSSLContext();
         HttpClient httpClient = HttpClient.create().secure(t -> t.sslContext(sslContext));
         WebClient client = buildWebClient(httpClient);
@@ -72,6 +73,7 @@ public class MhsRequestBuilder {
             .header(INTERACTION_ID, interactionId)
             .header(WAIT_FOR_RESPONSE, FALSE)
             .header(CORRELATION_ID, conversationId)
+            .header(MESSAGE_ID, messageId)
             .body(bodyInserter);
     }
 

--- a/gp2gp-translator/src/main/java/uk/nhs/adaptors/pss/translator/model/ContinueRequestData.java
+++ b/gp2gp-translator/src/main/java/uk/nhs/adaptors/pss/translator/model/ContinueRequestData.java
@@ -13,4 +13,5 @@ public class ContinueRequestData {
     private String fromOdsCode;
     private String conversationId;
     private String mcciIN010000UK13creationTime;
+    private String ehrExtractId;
 }

--- a/gp2gp-translator/src/main/java/uk/nhs/adaptors/pss/translator/service/ApplicationAcknowledgementMessageService.java
+++ b/gp2gp-translator/src/main/java/uk/nhs/adaptors/pss/translator/service/ApplicationAcknowledgementMessageService.java
@@ -27,14 +27,13 @@ public class ApplicationAcknowledgementMessageService {
         loadTemplate("applicationAcknowledgementTemplate.mustache");
 
     private final DateUtils dateUtils;
-    private final IdGeneratorService idGeneratorService;
 
-    public String buildNackMessage(NACKMessageData messageData) throws IllegalArgumentException {
+    public String buildNackMessage(NACKMessageData messageData, String messageId) throws IllegalArgumentException {
 
         LOGGER.debug("Building NACK message for message = [{}]", messageData.getMessageRef());
 
         ApplicationAcknowledgmentParams params = ApplicationAcknowledgmentParams.builder()
-            .messageId(idGeneratorService.generateUuid())
+            .messageId(messageId)
             .creationTime(toHl7Format(dateUtils.getCurrentInstant()))
             .toAsid(messageData.getToAsid())
             .fromAsid(messageData.getFromAsid())
@@ -45,12 +44,12 @@ public class ApplicationAcknowledgementMessageService {
         return fillTemplate(NACK_MESSAGE_TEMPLATE, params);
     }
 
-    public String buildAckMessage(ACKMessageData messageData) throws IllegalArgumentException {
+    public String buildAckMessage(ACKMessageData messageData, String messageId) throws IllegalArgumentException {
 
         LOGGER.debug("Building ACK message for message = [{}]", messageData.getMessageRef());
 
         ApplicationAcknowledgmentParams params = ApplicationAcknowledgmentParams.builder()
-            .messageId(idGeneratorService.generateUuid())
+            .messageId(messageId)
             .creationTime(toHl7Format(dateUtils.getCurrentInstant()))
             .toAsid(messageData.getToAsid())
             .fromAsid(messageData.getFromAsid())

--- a/gp2gp-translator/src/main/java/uk/nhs/adaptors/pss/translator/service/ContinueRequestService.java
+++ b/gp2gp-translator/src/main/java/uk/nhs/adaptors/pss/translator/service/ContinueRequestService.java
@@ -23,26 +23,26 @@ public class ContinueRequestService {
     private final IdGeneratorService idGeneratorService;
 
     public String buildContinueRequest(
-             String conversationId,
              String nhsNumber,
              String fromAsid,
              String toAsid,
              String fromOdsCode,
              String toOdsCode,
-             String mcciIn010000UK13creationTime
+             String mcciIn010000UK13creationTime,
+             String ehrExtractId
     ) throws IOException {
         LOGGER.debug("Building ContinueRequest");
 
         SendContinueRequestParams params = SendContinueRequestParams.builder()
             .messageId(idGeneratorService.generateUuid().toLowerCase())
             .timestamp(DateFormatUtil.toHl7Format(dateUtils.getCurrentInstant()))
-            .conversationId(conversationId)
             .nhsNumber(nhsNumber)
             .toAsid(toAsid)
             .fromAsid(fromAsid)
             .fromOdsCode(fromOdsCode)
             .toOdsCode(toOdsCode)
             .mcciIN010000UK13creationTime(mcciIn010000UK13creationTime)
+            .ehrExtractId(ehrExtractId)
             .build();
 
         return fillTemplate(CONTINUE_REQUEST_FILE, params);

--- a/gp2gp-translator/src/main/java/uk/nhs/adaptors/pss/translator/service/ContinueRequestService.java
+++ b/gp2gp-translator/src/main/java/uk/nhs/adaptors/pss/translator/service/ContinueRequestService.java
@@ -9,6 +9,7 @@ import org.springframework.stereotype.Service;
 import lombok.AllArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import uk.nhs.adaptors.common.util.DateUtils;
+import uk.nhs.adaptors.pss.translator.model.ContinueRequestData;
 import uk.nhs.adaptors.pss.translator.util.DateFormatUtil;
 import uk.nhs.adaptors.pss.translator.util.template.parameter.SendContinueRequestParams;
 import static uk.nhs.adaptors.pss.translator.util.template.TemplateUtil.fillTemplate;
@@ -20,29 +21,20 @@ import static uk.nhs.adaptors.pss.translator.util.template.TemplateUtil.loadTemp
 public class ContinueRequestService {
     private static final Mustache CONTINUE_REQUEST_FILE = loadTemplate("sendContinueRequest.mustache");
     private final DateUtils dateUtils;
-    private final IdGeneratorService idGeneratorService;
 
-    public String buildContinueRequest(
-             String nhsNumber,
-             String fromAsid,
-             String toAsid,
-             String fromOdsCode,
-             String toOdsCode,
-             String mcciIn010000UK13creationTime,
-             String ehrExtractId
-    ) throws IOException {
+    public String buildContinueRequest(ContinueRequestData data, String messageId) throws IOException {
         LOGGER.debug("Building ContinueRequest");
 
         SendContinueRequestParams params = SendContinueRequestParams.builder()
-            .messageId(idGeneratorService.generateUuid().toLowerCase())
+            .messageId(messageId)
             .timestamp(DateFormatUtil.toHl7Format(dateUtils.getCurrentInstant()))
-            .nhsNumber(nhsNumber)
-            .toAsid(toAsid)
-            .fromAsid(fromAsid)
-            .fromOdsCode(fromOdsCode)
-            .toOdsCode(toOdsCode)
-            .mcciIN010000UK13creationTime(mcciIn010000UK13creationTime)
-            .ehrExtractId(ehrExtractId)
+            .nhsNumber(data.getNhsNumber())
+            .toAsid(data.getToAsid())
+            .fromAsid(data.getFromAsid())
+            .fromOdsCode(data.getFromOdsCode())
+            .toOdsCode(data.getToOdsCode())
+            .mcciIN010000UK13creationTime(data.getMcciIN010000UK13creationTime())
+            .ehrExtractId(data.getEhrExtractId())
             .build();
 
         return fillTemplate(CONTINUE_REQUEST_FILE, params);

--- a/gp2gp-translator/src/main/java/uk/nhs/adaptors/pss/translator/service/EhrExtractRequestService.java
+++ b/gp2gp-translator/src/main/java/uk/nhs/adaptors/pss/translator/service/EhrExtractRequestService.java
@@ -25,11 +25,11 @@ public class EhrExtractRequestService {
     private final DateUtils dateUtils;
     private final IdGeneratorService idGeneratorService;
 
-    public String buildEhrExtractRequest(TransferRequestMessage transferRequestMessage) {
+    public String buildEhrExtractRequest(TransferRequestMessage transferRequestMessage, String messageId) {
         LOGGER.debug("Building EHRExtractRequest with nhsNumber=[{}]", transferRequestMessage.getPatientNhsNumber());
 
         SendEhrExtractRequestParams params = SendEhrExtractRequestParams.builder()
-            .messageId(idGeneratorService.generateUuid())
+            .messageId(messageId)
             .timestamp(toHl7Format(dateUtils.getCurrentInstant()))
             .toAsid(transferRequestMessage.getToAsid())
             .fromAsid(transferRequestMessage.getFromAsid())

--- a/gp2gp-translator/src/main/java/uk/nhs/adaptors/pss/translator/task/EhrExtractMessageHandler.java
+++ b/gp2gp-translator/src/main/java/uk/nhs/adaptors/pss/translator/task/EhrExtractMessageHandler.java
@@ -232,7 +232,8 @@ public class EhrExtractMessageHandler {
             conversationId,
             patientNhsNumber,
             migrationRequest.getWinningPracticeOdsCode(),
-            migrationStatusLog.getDate().toInstant()
+            migrationStatusLog.getDate().toInstant(),
+            messageId
         );
     }
 
@@ -305,10 +306,18 @@ public class EhrExtractMessageHandler {
         String conversationId,
         String patientNhsNumber,
         String winningPracticeOdsCode,
-        Instant mcciIN010000UK13creationTime
+        Instant mcciIN010000UK13creationTime,
+        String ehrExtractId
     ) {
         sendContinueRequestHandler.prepareAndSendRequest(
-            prepareContinueRequestData(payload, conversationId, patientNhsNumber, winningPracticeOdsCode, mcciIN010000UK13creationTime)
+            prepareContinueRequestData(
+                payload,
+                conversationId,
+                patientNhsNumber,
+                winningPracticeOdsCode,
+                mcciIN010000UK13creationTime,
+                ehrExtractId
+            )
         );
     }
 
@@ -317,7 +326,8 @@ public class EhrExtractMessageHandler {
         String conversationId,
         String patientNhsNumber,
         String winningPracticeOdsCode,
-        Instant mcciIN010000UK13creationTime
+        Instant mcciIN010000UK13creationTime,
+        String ehrExtractId
     ) {
         var fromAsid = XmlParseUtilService.parseFromAsid(payload);
         var toAsid = XmlParseUtilService.parseToAsid(payload);
@@ -332,6 +342,7 @@ public class EhrExtractMessageHandler {
             .toOdsCode(toOdsCode)
             .fromOdsCode(winningPracticeOdsCode)
             .mcciIN010000UK13creationTime(mcciIN010000UK13creationTimeToHl7Format)
+            .ehrExtractId(ehrExtractId)
             .build();
     }
 

--- a/gp2gp-translator/src/main/java/uk/nhs/adaptors/pss/translator/task/SendACKMessageHandler.java
+++ b/gp2gp-translator/src/main/java/uk/nhs/adaptors/pss/translator/task/SendACKMessageHandler.java
@@ -1,17 +1,18 @@
 package uk.nhs.adaptors.pss.translator.task;
 
-import lombok.AllArgsConstructor;
-import lombok.SneakyThrows;
-import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 import org.springframework.web.reactive.function.client.WebClientResponseException;
 
+import lombok.AllArgsConstructor;
+import lombok.SneakyThrows;
+import lombok.extern.slf4j.Slf4j;
 import uk.nhs.adaptors.pss.translator.exception.MhsServerErrorException;
 import uk.nhs.adaptors.pss.translator.mhs.MhsRequestBuilder;
 import uk.nhs.adaptors.pss.translator.mhs.model.OutboundMessage;
 import uk.nhs.adaptors.pss.translator.model.ACKMessageData;
 import uk.nhs.adaptors.pss.translator.service.ApplicationAcknowledgementMessageService;
+import uk.nhs.adaptors.pss.translator.service.IdGeneratorService;
 import uk.nhs.adaptors.pss.translator.service.MhsClientService;
 
 @Slf4j
@@ -22,16 +23,20 @@ public class SendACKMessageHandler {
     private final MhsRequestBuilder requestBuilder;
     private final MhsClientService mhsClientService;
     private final ApplicationAcknowledgementMessageService messageService;
+    private final IdGeneratorService idGeneratorService;
 
     @SneakyThrows
     public boolean prepareAndSendMessage(ACKMessageData messageData) {
-        String ackMessage = messageService.buildAckMessage(messageData);
+        String messageId = idGeneratorService.generateUuid().toUpperCase();
+
+        String ackMessage = messageService.buildAckMessage(messageData, messageId);
         OutboundMessage outboundMessage = new OutboundMessage(ackMessage);
 
         var request = requestBuilder.buildSendACKRequest(
             messageData.getConversationId(),
             messageData.getToOdsCode(),
-            outboundMessage);
+            outboundMessage,
+            messageId);
 
         try {
             mhsClientService.send(request);

--- a/gp2gp-translator/src/main/java/uk/nhs/adaptors/pss/translator/task/SendContinueRequestHandler.java
+++ b/gp2gp-translator/src/main/java/uk/nhs/adaptors/pss/translator/task/SendContinueRequestHandler.java
@@ -28,13 +28,13 @@ public class SendContinueRequestHandler {
     @SneakyThrows
     public void prepareAndSendRequest(ContinueRequestData data) {
         String continueRequest = continueRequestService.buildContinueRequest(
-                data.getConversationId(),
                 data.getNhsNumber(),
                 data.getFromAsid(),
                 data.getToAsid(),
                 data.getFromOdsCode(),
                 data.getToOdsCode(),
-                data.getMcciIN010000UK13creationTime()
+                data.getMcciIN010000UK13creationTime(),
+                data.getEhrExtractId()
         );
         var outboundMessage = new OutboundMessage(continueRequest);
         var request = requestBuilder.buildSendContinueRequest(data.getConversationId(), data.getToOdsCode(), outboundMessage);

--- a/gp2gp-translator/src/main/java/uk/nhs/adaptors/pss/translator/task/SendContinueRequestHandler.java
+++ b/gp2gp-translator/src/main/java/uk/nhs/adaptors/pss/translator/task/SendContinueRequestHandler.java
@@ -14,6 +14,7 @@ import uk.nhs.adaptors.pss.translator.mhs.MhsRequestBuilder;
 import uk.nhs.adaptors.pss.translator.mhs.model.OutboundMessage;
 import uk.nhs.adaptors.pss.translator.model.ContinueRequestData;
 import uk.nhs.adaptors.pss.translator.service.ContinueRequestService;
+import uk.nhs.adaptors.pss.translator.service.IdGeneratorService;
 import uk.nhs.adaptors.pss.translator.service.MhsClientService;
 
 @Slf4j
@@ -24,20 +25,17 @@ public class SendContinueRequestHandler {
     private final MhsClientService mhsClientService;
     private final MigrationStatusLogService migrationStatusLogService;
     private final ContinueRequestService continueRequestService;
+    private final IdGeneratorService idGeneratorService;
 
     @SneakyThrows
     public void prepareAndSendRequest(ContinueRequestData data) {
-        String continueRequest = continueRequestService.buildContinueRequest(
-                data.getNhsNumber(),
-                data.getFromAsid(),
-                data.getToAsid(),
-                data.getFromOdsCode(),
-                data.getToOdsCode(),
-                data.getMcciIN010000UK13creationTime(),
-                data.getEhrExtractId()
-        );
+
+        String messageId = idGeneratorService.generateUuid().toUpperCase();
+
+        String continueRequest = continueRequestService.buildContinueRequest(data, messageId);
         var outboundMessage = new OutboundMessage(continueRequest);
-        var request = requestBuilder.buildSendContinueRequest(data.getConversationId(), data.getToOdsCode(), outboundMessage);
+        var request = requestBuilder.buildSendContinueRequest(
+            data.getConversationId(), data.getToOdsCode(), outboundMessage, messageId);
 
         try {
             mhsClientService.send(request);

--- a/gp2gp-translator/src/main/java/uk/nhs/adaptors/pss/translator/task/SendNACKMessageHandler.java
+++ b/gp2gp-translator/src/main/java/uk/nhs/adaptors/pss/translator/task/SendNACKMessageHandler.java
@@ -12,6 +12,7 @@ import uk.nhs.adaptors.pss.translator.mhs.MhsRequestBuilder;
 import uk.nhs.adaptors.pss.translator.mhs.model.OutboundMessage;
 import uk.nhs.adaptors.pss.translator.model.NACKMessageData;
 import uk.nhs.adaptors.pss.translator.service.ApplicationAcknowledgementMessageService;
+import uk.nhs.adaptors.pss.translator.service.IdGeneratorService;
 import uk.nhs.adaptors.pss.translator.service.MhsClientService;
 
 @Slf4j
@@ -22,16 +23,20 @@ public class SendNACKMessageHandler {
     private final MhsRequestBuilder requestBuilder;
     private final MhsClientService mhsClientService;
     private final ApplicationAcknowledgementMessageService messageService;
+    private final IdGeneratorService idGeneratorService;
 
     @SneakyThrows
     public boolean prepareAndSendMessage(NACKMessageData messageData) {
-        String ackMessage = messageService.buildNackMessage(messageData);
+        String messageId = idGeneratorService.generateUuid().toUpperCase();
+
+        String ackMessage = messageService.buildNackMessage(messageData, messageId);
         OutboundMessage outboundMessage = new OutboundMessage(ackMessage);
 
         var request = requestBuilder.buildSendACKRequest(
             messageData.getConversationId(),
             messageData.getToOdsCode(),
-            outboundMessage);
+            outboundMessage,
+            messageId);
 
         try {
 

--- a/gp2gp-translator/src/main/java/uk/nhs/adaptors/pss/translator/util/template/parameter/SendContinueRequestParams.java
+++ b/gp2gp-translator/src/main/java/uk/nhs/adaptors/pss/translator/util/template/parameter/SendContinueRequestParams.java
@@ -8,11 +8,11 @@ import lombok.Getter;
 public class SendContinueRequestParams {
     private String messageId;
     private String timestamp;
-    private String conversationId;
     private String nhsNumber;
     private String toAsid;
     private String fromAsid;
     private String toOdsCode;
     private String fromOdsCode;
     private String mcciIN010000UK13creationTime;
+    private String ehrExtractId;
 }

--- a/gp2gp-translator/src/main/resources/templates/sendContinueRequest.mustache
+++ b/gp2gp-translator/src/main/resources/templates/sendContinueRequest.mustache
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<COPC_IN000001UK01 xmlns="urn:hl7-org:v3">
+<COPC_IN000001UK01 xmlns="urn:hl7-org:v3" xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
     <id root="{{messageId}}"/>
     <creationTime value="{{timestamp}}"/>
     <versionCode code="V3NPfIT3.0"/>
@@ -7,20 +7,20 @@
     <processingCode code="P"/>
     <processingModeCode code="T"/>
     <acceptAckCode code="NE"/>
-    <communicationFunctionRcv>
-        <device>
+    <communicationFunctionRcv typeCode="RCV">
+        <device classCode="DEV" determinerCode="INSTANCE">
             <id extension="{{toAsid}}" root="1.2.826.0.1285.0.2.0.107"/>
         </device>
     </communicationFunctionRcv>
-    <communicationFunctionSnd>
-        <device>
+    <communicationFunctionSnd typeCode="SND">
+        <device classCode="DEV" determinerCode="INSTANCE">
             <id extension="{{fromAsid}}" root="1.2.826.0.1285.0.2.0.107"/>
         </device>
     </communicationFunctionSnd>
     <ControlActEvent classCode="CACT" moodCode="EVN">
-        <author1>
-            <AgentSystemSDS>
-                <agentSystemSDS>
+        <author1 typeCode="AUT">
+            <AgentSystemSDS classCode="AGNT">
+                <agentSystemSDS classCode="DEV" determinerCode="INSTANCE">
                     <id extension="{{fromAsid}}" root="1.2.826.0.1285.0.2.0.107"/>
                 </agentSystemSDS>
             </AgentSystemSDS>
@@ -65,13 +65,13 @@
                                             <id root="{{conversationId}}"/>
                                         </messageRef>
                                     </acknowledgement>
-                                    <communicationFunctionRcv>
-                                        <device>
+                                    <communicationFunctionRcv typecode="RCV">
+                                        <device classCode="DEV" determinerCode="INSTANCE">
                                             <id extension="{{toAsid}}" root="1.2.826.0.1285.0.2.0.107"/>
                                         </device>
                                     </communicationFunctionRcv>
-                                    <communicationFunctionSnd>
-                                        <device>
+                                    <communicationFunctionSnd typeCode="SND">
+                                        <device classCode="DEV" determinerCode="INSTANCE">
                                             <id extension="{{fromAsid}}" root="1.2.826.0.1285.0.2.0.107"/>
                                         </device>
                                     </communicationFunctionSnd>

--- a/gp2gp-translator/src/main/resources/templates/sendContinueRequest.mustache
+++ b/gp2gp-translator/src/main/resources/templates/sendContinueRequest.mustache
@@ -62,7 +62,7 @@
                                             <code code="0" codeSystem="2.16.840.1.113883.2.1.3.2.4.17.101" displayName="Continue"/>
                                         </acknowledgementDetail>
                                         <messageRef>
-                                            <id root="{{conversationId}}"/>
+                                            <id root="{{ehrExtractId}}"/>
                                         </messageRef>
                                     </acknowledgement>
                                     <communicationFunctionRcv typecode="RCV">
@@ -77,7 +77,7 @@
                                     </communicationFunctionSnd>
                                 </Message>
                                 <gp:acknowledgedMessage>
-                                    <gp:id root="{{conversationId}}"/>
+                                    <gp:id root="{{ehrExtractId}}"/>
                                 </gp:acknowledgedMessage>
                             </gp:Gp2gpfragment>
                         </value>

--- a/gp2gp-translator/src/test/java/uk/nhs/adaptors/pss/translator/service/ApplicationAcknowledgementMessageServiceTest.java
+++ b/gp2gp-translator/src/test/java/uk/nhs/adaptors/pss/translator/service/ApplicationAcknowledgementMessageServiceTest.java
@@ -43,9 +43,6 @@ public class ApplicationAcknowledgementMessageServiceTest {
     @Mock
     private DateUtils dateUtils;
 
-    @Mock
-    private IdGeneratorService idGeneratorService;
-
     @InjectMocks
     private ApplicationAcknowledgementMessageService messageService;
 
@@ -55,7 +52,6 @@ public class ApplicationAcknowledgementMessageServiceTest {
     public void setup() {
         Instant instant = Instant.now();
         when(dateUtils.getCurrentInstant()).thenReturn(instant);
-        when(idGeneratorService.generateUuid()).thenReturn(MESSAGE_ID);
 
         messageData = NACKMessageData.builder()
             .conversationId(TEST_CONVERSATION_ID)
@@ -69,35 +65,35 @@ public class ApplicationAcknowledgementMessageServiceTest {
 
     @Test
     public void When_BuildNackMessage_WithValidTestData_Expect_NackCodeIsSetCorrectly() {
-        String nackMessage = messageService.buildNackMessage(messageData);
+        String nackMessage = messageService.buildNackMessage(messageData, MESSAGE_ID);
 
         assertTrue(nackMessage.contains(NACK_CODE));
     }
 
     @Test
     public void When_BuildNackMessage_WithValidTestData_Expect_MessageIdIsSetCorrectly() {
-        String nackMessage = messageService.buildNackMessage(messageData);
+        String nackMessage = messageService.buildNackMessage(messageData, MESSAGE_ID);
 
         assertTrue(nackMessage.contains(MESSAGE_ID));
     }
 
     @Test
     public void When_BuildNackMessage_WithValidTestData_Expect_MessageRefIsSetCorrectly() {
-        String nackMessage = messageService.buildNackMessage(messageData);
+        String nackMessage = messageService.buildNackMessage(messageData, MESSAGE_ID);
 
         assertTrue(nackMessage.contains(MESSAGE_REF));
     }
 
     @Test
     public void When_BuildNackMessage_WithValidTestData_Expect_ToAsidIsSetCorrectly() {
-        String nackMessage = messageService.buildNackMessage(messageData);
+        String nackMessage = messageService.buildNackMessage(messageData, MESSAGE_ID);
 
         assertTrue(nackMessage.contains(TEST_TO_ASID));
     }
 
     @Test
     public void When_NackMessage_WithTestData_Expect_FromAsidIsSetCorrectly() {
-        String nackMessage = messageService.buildNackMessage(messageData);
+        String nackMessage = messageService.buildNackMessage(messageData, MESSAGE_ID);
 
         assertTrue(nackMessage.contains(TEST_FROM_ASID));
     }
@@ -107,14 +103,14 @@ public class ApplicationAcknowledgementMessageServiceTest {
         Instant instant = Instant.now();
         when(dateUtils.getCurrentInstant()).thenReturn(instant);
 
-        String nackMessage = messageService.buildNackMessage(messageData);
+        String nackMessage = messageService.buildNackMessage(messageData, MESSAGE_ID);
 
         assertTrue(nackMessage.contains(toHl7Format(instant)));
     }
 
     @Test
     public void When_NackMessage_WithNackCodePresent_Expect_TypeCodeSetCorrectly() {
-        String nackMessage = messageService.buildNackMessage(messageData);
+        String nackMessage = messageService.buildNackMessage(messageData, MESSAGE_ID);
 
         assertTrue(nackMessage.contains("typeCode=\"AE\""));
         assertFalse(nackMessage.contains("typeCode=\"AA\""));
@@ -123,7 +119,7 @@ public class ApplicationAcknowledgementMessageServiceTest {
     @Test
     public void When_BuildNackMessage_WithNackCodePresent_Expect_ReasonElementIncluded() throws ParserConfigurationException, IOException,
         SAXException {
-        String nackMessage = messageService.buildNackMessage(messageData);
+        String nackMessage = messageService.buildNackMessage(messageData, MESSAGE_ID);
 
         DocumentBuilderFactory dbf = DocumentBuilderFactory.newInstance();
         DocumentBuilder db = dbf.newDocumentBuilder();
@@ -136,7 +132,7 @@ public class ApplicationAcknowledgementMessageServiceTest {
     @Test
     public void When_BuildNackMessage_WithNackCodePresent_Expect_ReasonHasCorrectAttribute() throws ParserConfigurationException,
         IOException, SAXException {
-        String nackMessage = messageService.buildNackMessage(messageData);
+        String nackMessage = messageService.buildNackMessage(messageData, MESSAGE_ID);
 
         DocumentBuilderFactory dbf = DocumentBuilderFactory.newInstance();
         DocumentBuilder db = dbf.newDocumentBuilder();

--- a/gp2gp-translator/src/test/java/uk/nhs/adaptors/pss/translator/service/ContinueRequestServiceTest.java
+++ b/gp2gp-translator/src/test/java/uk/nhs/adaptors/pss/translator/service/ContinueRequestServiceTest.java
@@ -17,22 +17,21 @@ import org.mockito.junit.jupiter.MockitoExtension;
 
 import lombok.SneakyThrows;
 import uk.nhs.adaptors.common.util.DateUtils;
+import uk.nhs.adaptors.pss.translator.model.ContinueRequestData;
 
 @ExtendWith(MockitoExtension.class)
 public class ContinueRequestServiceTest {
     private static final String NHS_NUMBER = "9446363101";
-    private static final String LOSING_ODS_CODE = "B83002"; //to odds code
-    private static final String WINNING_ODS_CODE = "C81007"; //from odds code
+    private static final String LOSING_ODS_CODE = "C81007";
+    private static final String WINNING_ODS_CODE = "B83002";
     private static final String TO_ASID = "715373337545";
     private static final String FROM_ASID = "276827251543";
     private static final String MCCI_IN010000UK13_CREATIONTIME = "20220407194614";
     private static final String TEST_EHR_EXTRACT_ID = "TEST-EHR-EXTRACT-ID";
+    private static final String MESSAGE_ID = "c258107f-7a3f-4fb5-8b36-d7c0f6496a17";
 
     @Mock
     private DateUtils dateUtils;
-
-    @Mock
-    private IdGeneratorService idGeneratorService;
 
     @InjectMocks
     private ContinueRequestService continueRequestService;
@@ -42,23 +41,24 @@ public class ContinueRequestServiceTest {
             throws IOException {
         prepareMocks();
 
+        var continueMessageData = ContinueRequestData.builder()
+            .nhsNumber(NHS_NUMBER)
+            .fromAsid(FROM_ASID)
+            .toAsid(TO_ASID)
+            .toOdsCode(LOSING_ODS_CODE)
+            .fromOdsCode(WINNING_ODS_CODE)
+            .mcciIN010000UK13creationTime(MCCI_IN010000UK13_CREATIONTIME)
+            .ehrExtractId(TEST_EHR_EXTRACT_ID)
+            .build();
+
         String expected = readLargeInboundMessagePayloadFromFile();
-        String actual = continueRequestService.buildContinueRequest(
-                NHS_NUMBER,
-                FROM_ASID,
-                TO_ASID,
-                LOSING_ODS_CODE,
-                WINNING_ODS_CODE,
-                MCCI_IN010000UK13_CREATIONTIME,
-                TEST_EHR_EXTRACT_ID
-        );
+        String actual = continueRequestService.buildContinueRequest(continueMessageData, MESSAGE_ID);
 
         assertEquals(expected, actual);
     }
 
     @SneakyThrows
     private void prepareMocks() {
-        when(idGeneratorService.generateUuid()).thenReturn("C258107F-7A3F-4FB5-8B36-D7C0F6496A17");
 
         final int YEAR = 1980;
         final int MONTH = 4;

--- a/gp2gp-translator/src/test/java/uk/nhs/adaptors/pss/translator/service/ContinueRequestServiceTest.java
+++ b/gp2gp-translator/src/test/java/uk/nhs/adaptors/pss/translator/service/ContinueRequestServiceTest.java
@@ -1,30 +1,32 @@
 package uk.nhs.adaptors.pss.translator.service;
 
-import lombok.SneakyThrows;
-import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
-import org.mockito.InjectMocks;
-import org.mockito.Mock;
-import org.mockito.junit.jupiter.MockitoExtension;
-import uk.nhs.adaptors.common.util.DateUtils;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.when;
+
+import static uk.nhs.adaptors.common.util.FileUtil.readResourceAsString;
 
 import java.io.IOException;
 import java.time.OffsetDateTime;
 import java.time.ZoneOffset;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.mockito.Mockito.when;
-import static uk.nhs.adaptors.common.util.FileUtil.readResourceAsString;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import lombok.SneakyThrows;
+import uk.nhs.adaptors.common.util.DateUtils;
 
 @ExtendWith(MockitoExtension.class)
 public class ContinueRequestServiceTest {
     private static final String NHS_NUMBER = "9446363101";
-    private static final String CONVERSATION_ID = "6E242658-3D8E-11E3-A7DC-172BDA00FA67";
     private static final String LOSING_ODS_CODE = "B83002"; //to odds code
     private static final String WINNING_ODS_CODE = "C81007"; //from odds code
     private static final String TO_ASID = "715373337545";
     private static final String FROM_ASID = "276827251543";
     private static final String MCCI_IN010000UK13_CREATIONTIME = "20220407194614";
+    private static final String TEST_EHR_EXTRACT_ID = "TEST-EHR-EXTRACT-ID";
 
     @Mock
     private DateUtils dateUtils;
@@ -42,13 +44,13 @@ public class ContinueRequestServiceTest {
 
         String expected = readLargeInboundMessagePayloadFromFile();
         String actual = continueRequestService.buildContinueRequest(
-                CONVERSATION_ID,
                 NHS_NUMBER,
                 FROM_ASID,
                 TO_ASID,
                 LOSING_ODS_CODE,
                 WINNING_ODS_CODE,
-                MCCI_IN010000UK13_CREATIONTIME
+                MCCI_IN010000UK13_CREATIONTIME,
+                TEST_EHR_EXTRACT_ID
         );
 
         assertEquals(expected, actual);

--- a/gp2gp-translator/src/test/java/uk/nhs/adaptors/pss/translator/service/EhrExtractRequestServiceTest.java
+++ b/gp2gp-translator/src/test/java/uk/nhs/adaptors/pss/translator/service/EhrExtractRequestServiceTest.java
@@ -37,7 +37,7 @@ public class EhrExtractRequestServiceTest {
     public void whenBuildEhrExtractRequestThenTemplateIsFilled() {
         var instant = Instant.now();
         when(dateUtils.getCurrentInstant()).thenReturn(instant);
-        when(idGeneratorService.generateUuid()).thenReturn(MESSAGE_ID, EHR_REQUEST_ID);
+        when(idGeneratorService.generateUuid()).thenReturn(EHR_REQUEST_ID);
         var message = TransferRequestMessage.builder()
             .patientNhsNumber(TEST_NHS_NUMBER)
             .fromAsid(TEST_FROM_ASID)
@@ -46,7 +46,7 @@ public class EhrExtractRequestServiceTest {
             .toOds(TEST_TO_ODS_CODE)
             .build();
 
-        final var ehrExtractRequest = ehrExtractRequestService.buildEhrExtractRequest(message);
+        final var ehrExtractRequest = ehrExtractRequestService.buildEhrExtractRequest(message, MESSAGE_ID);
         assertTrue(ehrExtractRequest.contains(TEST_NHS_NUMBER));
         assertTrue(ehrExtractRequest.contains(TEST_FROM_ODS_CODE));
         assertTrue(ehrExtractRequest.contains(TEST_TO_ODS_CODE));

--- a/gp2gp-translator/src/test/java/uk/nhs/adaptors/pss/translator/task/EhrExtractMessageHandlerTest.java
+++ b/gp2gp-translator/src/test/java/uk/nhs/adaptors/pss/translator/task/EhrExtractMessageHandlerTest.java
@@ -83,7 +83,9 @@ public class EhrExtractMessageHandlerTest {
     private static final String LOSING_ODE_CODE = "G543";
     private static final String WINNING_ODE_CODE = "B943";
     private static final String MESSAGE_ID = randomUUID().toString();
+    private static final String MESSAGE_ID_PATH = "/Envelope/Header/MessageHeader/MessageData/MessageId";
     public static final int MIGRATION_REQUEST_ID = 999;
+
 
     @Mock
     private ObjectMapper objectMapper;
@@ -268,16 +270,18 @@ public class EhrExtractMessageHandlerTest {
         inboundMessage.setExternalAttachments(externalAttachmentsTestList);
 
         prepareMigrationRequestAndMigrationStatusMocks();
+        when(xPathService.getNodeValue(any(), eq(MESSAGE_ID_PATH))).thenReturn(MESSAGE_ID);
 
         EhrExtractMessageHandler ehrExtractMessageHandlerSpy = Mockito.spy(ehrExtractMessageHandler);
         ehrExtractMessageHandlerSpy.handleMessage(inboundMessage, CONVERSATION_ID);
 
         verify(ehrExtractMessageHandlerSpy).sendContinueRequest(
             any(RCMRIN030000UK06Message.class),
-            any(String.class),
-            any(String.class),
-            any(String.class),
-            any(Instant.class)
+            anyString(),
+            anyString(),
+            anyString(),
+            any(Instant.class),
+            anyString()
         );
     }
 
@@ -443,10 +447,11 @@ public class EhrExtractMessageHandlerTest {
 
         verify(ehrExtractMessageHandlerSpy, times(0)).sendContinueRequest(
                 any(RCMRIN030000UK06Message.class),
-                any(String.class),
-                any(String.class),
-                any(String.class),
-                any(Instant.class)
+                anyString(),
+                anyString(),
+                anyString(),
+                any(Instant.class),
+                anyString()
         );
     }
 
@@ -530,7 +535,7 @@ public class EhrExtractMessageHandlerTest {
         assertEquals(attachment.getContentType(), log.getContentType());
         assertFalse(log.getCompressed());
         assertFalse(log.getLargeAttachment());
-        assertTrue(!log.getOriginalBase64());
+        assertFalse(log.getOriginalBase64());
         assertFalse(log.getSkeleton());
         assertTrue(log.getUploaded());
         assertEquals(0, log.getLengthNum());

--- a/gp2gp-translator/src/test/java/uk/nhs/adaptors/pss/translator/task/SendACKMessageHandlerTest.java
+++ b/gp2gp-translator/src/test/java/uk/nhs/adaptors/pss/translator/task/SendACKMessageHandlerTest.java
@@ -7,6 +7,7 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static org.springframework.http.HttpStatus.INTERNAL_SERVER_ERROR;
 
@@ -109,5 +110,12 @@ public class SendACKMessageHandlerTest {
 
         assertThatThrownBy(() -> messageHandler.prepareAndSendMessage(messageData))
             .isInstanceOf(MhsServerErrorException.class);
+    }
+
+    @Test
+    public void When_PrepareAndSendRequest_Expect_MessageBuilderCalledWithCorrectParams() {
+        messageHandler.prepareAndSendMessage(messageData);
+
+        verify(messageService).buildAckMessage(eq(messageData), eq(TEST_MESSAGE_ID.toUpperCase()));
     }
 }

--- a/gp2gp-translator/src/test/java/uk/nhs/adaptors/pss/translator/task/SendACKMessageHandlerTest.java
+++ b/gp2gp-translator/src/test/java/uk/nhs/adaptors/pss/translator/task/SendACKMessageHandlerTest.java
@@ -1,5 +1,17 @@
 package uk.nhs.adaptors.pss.translator.task;
 
+import static java.util.UUID.randomUUID;
+
+import static org.assertj.core.api.AssertionsForClassTypes.assertThatThrownBy;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.when;
+import static org.springframework.http.HttpStatus.INTERNAL_SERVER_ERROR;
+
+import java.nio.charset.Charset;
+
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -16,19 +28,8 @@ import uk.nhs.adaptors.pss.translator.mhs.MhsRequestBuilder;
 import uk.nhs.adaptors.pss.translator.mhs.model.OutboundMessage;
 import uk.nhs.adaptors.pss.translator.model.ACKMessageData;
 import uk.nhs.adaptors.pss.translator.service.ApplicationAcknowledgementMessageService;
+import uk.nhs.adaptors.pss.translator.service.IdGeneratorService;
 import uk.nhs.adaptors.pss.translator.service.MhsClientService;
-
-import java.nio.charset.Charset;
-
-import static java.util.UUID.randomUUID;
-
-import static org.assertj.core.api.AssertionsForClassTypes.assertThatThrownBy;
-import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.eq;
-import static org.mockito.Mockito.when;
-import static org.springframework.http.HttpStatus.INTERNAL_SERVER_ERROR;
 
 @ExtendWith(MockitoExtension.class)
 public class SendACKMessageHandlerTest {
@@ -38,6 +39,7 @@ public class SendACKMessageHandlerTest {
     private static final String TEST_TO_ODS = "1234";
     private static final String TEST_TO_ASID = "5678";
     private static final String TEST_FROM_ASID = "98765";
+    private static final String TEST_MESSAGE_ID = "test-message-id";
 
     @Mock
     private MhsClientService mhsClientService;
@@ -50,6 +52,8 @@ public class SendACKMessageHandlerTest {
 
     @Mock
     private WebClient.RequestHeadersSpec request;
+    @Mock
+    private IdGeneratorService idGeneratorService;
 
     @InjectMocks
     private SendACKMessageHandler messageHandler;
@@ -66,7 +70,10 @@ public class SendACKMessageHandlerTest {
             .fromAsid(TEST_FROM_ASID)
             .build();
 
-        when(requestBuilder.buildSendACKRequest(eq(TEST_CONVERSATION_ID), eq(TEST_TO_ODS), any(OutboundMessage.class)))
+        when(idGeneratorService.generateUuid()).thenReturn(TEST_MESSAGE_ID);
+
+        when(requestBuilder.buildSendACKRequest(eq(TEST_CONVERSATION_ID), eq(TEST_TO_ODS), any(OutboundMessage.class),
+            eq(TEST_MESSAGE_ID.toUpperCase())))
             .thenReturn(request);
     }
 

--- a/gp2gp-translator/src/test/java/uk/nhs/adaptors/pss/translator/task/SendContinueRequestHandlerTest.java
+++ b/gp2gp-translator/src/test/java/uk/nhs/adaptors/pss/translator/task/SendContinueRequestHandlerTest.java
@@ -3,6 +3,8 @@ package uk.nhs.adaptors.pss.translator.task;
 import static java.nio.charset.StandardCharsets.UTF_8;
 
 import lombok.extern.slf4j.Slf4j;
+
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
@@ -16,6 +18,7 @@ import uk.nhs.adaptors.pss.translator.exception.MhsServerErrorException;
 import uk.nhs.adaptors.pss.translator.mhs.MhsRequestBuilder;
 import uk.nhs.adaptors.pss.translator.model.ContinueRequestData;
 import uk.nhs.adaptors.pss.translator.service.ContinueRequestService;
+import uk.nhs.adaptors.pss.translator.service.IdGeneratorService;
 import uk.nhs.adaptors.pss.translator.service.MhsClientService;
 
 import static org.assertj.core.api.AssertionsForClassTypes.assertThatThrownBy;
@@ -39,6 +42,7 @@ public class SendContinueRequestHandlerTest {
     private static final String TO_ASID = "715373337545";
     private static final String FROM_ASID = "276827251543";
     private static final String MCCI_IN010000UK13_CREATIONTIME = "20220407194614";
+    private static final String MESSAGE_ID = "message-id";
 
     @Mock
     private MhsRequestBuilder requestBuilder;
@@ -57,9 +61,16 @@ public class SendContinueRequestHandlerTest {
 
     @Mock
     private HttpHeaders headers;
+    @Mock
+    private IdGeneratorService idGeneratorService;
 
     @InjectMocks
     private SendContinueRequestHandler sendContinueRequestHandler;
+
+    @BeforeEach
+    public void setup() {
+        when(idGeneratorService.generateUuid()).thenReturn(MESSAGE_ID);
+    }
 
     @Test
     public void When_PrepareAndSendRequest_ToMhsAndGetError_Expect_ThrowError() {

--- a/gp2gp-translator/src/test/java/uk/nhs/adaptors/pss/translator/task/SendEhrExtractRequestHandlerTest.java
+++ b/gp2gp-translator/src/test/java/uk/nhs/adaptors/pss/translator/task/SendEhrExtractRequestHandlerTest.java
@@ -3,6 +3,7 @@ package uk.nhs.adaptors.pss.translator.task;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -21,12 +22,13 @@ import org.springframework.web.reactive.function.client.WebClient;
 import org.springframework.web.reactive.function.client.WebClientResponseException;
 
 import lombok.SneakyThrows;
-import uk.nhs.adaptors.common.model.TransferRequestMessage;
 import uk.nhs.adaptors.common.enums.MigrationStatus;
+import uk.nhs.adaptors.common.model.TransferRequestMessage;
 import uk.nhs.adaptors.connector.service.MigrationStatusLogService;
 import uk.nhs.adaptors.pss.translator.mhs.MhsRequestBuilder;
 import uk.nhs.adaptors.pss.translator.mhs.model.OutboundMessage;
 import uk.nhs.adaptors.pss.translator.service.EhrExtractRequestService;
+import uk.nhs.adaptors.pss.translator.service.IdGeneratorService;
 import uk.nhs.adaptors.pss.translator.service.MhsClientService;
 
 @ExtendWith(MockitoExtension.class)
@@ -35,6 +37,7 @@ public class SendEhrExtractRequestHandlerTest {
     private static final String TEST_TO_ODS_CODE = "TEST_FROM_ODS";
     private static final String TEST_PAYLOAD_BODY = "TEST_PAYLOAD_BODY";
     private static final String CONVERSATION_ID = "abc-236";
+    private static final String TEST_MESSAGE_ID = "message-id";
 
     @Mock
     private MhsRequestBuilder builder;
@@ -50,6 +53,8 @@ public class SendEhrExtractRequestHandlerTest {
 
     @Mock
     private MhsClientService mhsClientService;
+    @Mock
+    private IdGeneratorService idGeneratorService;
 
     @InjectMocks
     private SendEhrExtractRequestHandler sendEhrExtractRequestHandler;
@@ -64,8 +69,12 @@ public class SendEhrExtractRequestHandlerTest {
             .toOds(TEST_TO_ODS_CODE)
             .conversationId(CONVERSATION_ID)
             .build();
-        when(ehrExtractRequestService.buildEhrExtractRequest(pssQueueMessage)).thenReturn(TEST_PAYLOAD_BODY);
-        when(builder.buildSendEhrExtractRequest(eq(CONVERSATION_ID), eq(TEST_TO_ODS_CODE), any(OutboundMessage.class)))
+
+        when(idGeneratorService.generateUuid()).thenReturn(TEST_MESSAGE_ID);
+
+        when(ehrExtractRequestService.buildEhrExtractRequest(eq(pssQueueMessage), anyString())).thenReturn(TEST_PAYLOAD_BODY);
+        when(builder.buildSendEhrExtractRequest(eq(CONVERSATION_ID), eq(TEST_TO_ODS_CODE), any(OutboundMessage.class),
+            eq(TEST_MESSAGE_ID.toUpperCase())))
             .thenReturn(request);
     }
 

--- a/gp2gp-translator/src/test/java/uk/nhs/adaptors/pss/translator/task/SendEhrExtractRequestHandlerTest.java
+++ b/gp2gp-translator/src/test/java/uk/nhs/adaptors/pss/translator/task/SendEhrExtractRequestHandlerTest.java
@@ -3,7 +3,6 @@ package uk.nhs.adaptors.pss.translator.task;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -72,7 +71,8 @@ public class SendEhrExtractRequestHandlerTest {
 
         when(idGeneratorService.generateUuid()).thenReturn(TEST_MESSAGE_ID);
 
-        when(ehrExtractRequestService.buildEhrExtractRequest(eq(pssQueueMessage), anyString())).thenReturn(TEST_PAYLOAD_BODY);
+        when(ehrExtractRequestService.buildEhrExtractRequest(eq(pssQueueMessage), eq(TEST_MESSAGE_ID.toUpperCase())))
+            .thenReturn(TEST_PAYLOAD_BODY);
         when(builder.buildSendEhrExtractRequest(eq(CONVERSATION_ID), eq(TEST_TO_ODS_CODE), any(OutboundMessage.class),
             eq(TEST_MESSAGE_ID.toUpperCase())))
             .thenReturn(request);

--- a/gp2gp-translator/src/test/java/uk/nhs/adaptors/pss/translator/task/SendNACKMessageHandlerTest.java
+++ b/gp2gp-translator/src/test/java/uk/nhs/adaptors/pss/translator/task/SendNACKMessageHandlerTest.java
@@ -7,6 +7,7 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.any;
 import static org.mockito.Mockito.eq;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static org.springframework.http.HttpStatus.INTERNAL_SERVER_ERROR;
 
@@ -111,6 +112,13 @@ public class SendNACKMessageHandlerTest {
 
         assertThatThrownBy(() -> messageHandler.prepareAndSendMessage(messageData))
             .isInstanceOf(MhsServerErrorException.class);
+    }
+
+    @Test
+    public void When_PrepareAndSendRequest_Expect_MessageBuilderCalledWithCorrectParams() {
+        messageHandler.prepareAndSendMessage(messageData);
+
+        verify(messageService).buildNackMessage(eq(messageData), eq(TEST_MESSAGE_ID.toUpperCase()));
     }
 
 }

--- a/gp2gp-translator/src/test/java/uk/nhs/adaptors/pss/translator/task/SendNACKMessageHandlerTest.java
+++ b/gp2gp-translator/src/test/java/uk/nhs/adaptors/pss/translator/task/SendNACKMessageHandlerTest.java
@@ -27,8 +27,9 @@ import uk.nhs.adaptors.pss.translator.exception.MhsServerErrorException;
 import uk.nhs.adaptors.pss.translator.mhs.MhsRequestBuilder;
 import uk.nhs.adaptors.pss.translator.mhs.model.OutboundMessage;
 import uk.nhs.adaptors.pss.translator.model.NACKMessageData;
-import uk.nhs.adaptors.pss.translator.service.MhsClientService;
 import uk.nhs.adaptors.pss.translator.service.ApplicationAcknowledgementMessageService;
+import uk.nhs.adaptors.pss.translator.service.IdGeneratorService;
+import uk.nhs.adaptors.pss.translator.service.MhsClientService;
 
 @ExtendWith(MockitoExtension.class)
 public class SendNACKMessageHandlerTest {
@@ -39,6 +40,7 @@ public class SendNACKMessageHandlerTest {
     private static final String TEST_TO_ASID = "5678";
     private static final String TEST_FROM_ASID = "98765";
     private static final String TEST_NACK_CODE = "30";
+    private static final String TEST_MESSAGE_ID = "test-message-id";
 
     @Mock
     private MhsClientService mhsClientService;
@@ -51,6 +53,8 @@ public class SendNACKMessageHandlerTest {
 
     @Mock
     private WebClient.RequestHeadersSpec request;
+    @Mock
+    private IdGeneratorService idGeneratorService;
 
     @InjectMocks
     private SendNACKMessageHandler messageHandler;
@@ -68,7 +72,10 @@ public class SendNACKMessageHandlerTest {
             .nackCode(TEST_NACK_CODE)
             .build();
 
-        when(requestBuilder.buildSendACKRequest(eq(TEST_CONVERSATION_ID), eq(TEST_TO_ODS), any(OutboundMessage.class)))
+        when(idGeneratorService.generateUuid()).thenReturn(TEST_MESSAGE_ID);
+
+        when(requestBuilder.buildSendACKRequest(eq(TEST_CONVERSATION_ID), eq(TEST_TO_ODS), any(OutboundMessage.class),
+            eq(TEST_MESSAGE_ID.toUpperCase())))
             .thenReturn(request);
     }
 

--- a/gp2gp-translator/src/test/resources/xml/COPC_IN000001UK01_CONTINUE/payload.xml
+++ b/gp2gp-translator/src/test/resources/xml/COPC_IN000001UK01_CONTINUE/payload.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<COPC_IN000001UK01 xmlns="urn:hl7-org:v3">
+<COPC_IN000001UK01 xmlns="urn:hl7-org:v3" xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
     <id root="c258107f-7a3f-4fb5-8b36-d7c0f6496a17"/>
     <creationTime value="19800409141545"/>
     <versionCode code="V3NPfIT3.0"/>
@@ -7,20 +7,20 @@
     <processingCode code="P"/>
     <processingModeCode code="T"/>
     <acceptAckCode code="NE"/>
-    <communicationFunctionRcv>
-        <device>
+    <communicationFunctionRcv typeCode="RCV">
+        <device classCode="DEV" determinerCode="INSTANCE">
             <id extension="715373337545" root="1.2.826.0.1285.0.2.0.107"/>
         </device>
     </communicationFunctionRcv>
-    <communicationFunctionSnd>
-        <device>
+    <communicationFunctionSnd typeCode="SND">
+        <device classCode="DEV" determinerCode="INSTANCE">
             <id extension="276827251543" root="1.2.826.0.1285.0.2.0.107"/>
         </device>
     </communicationFunctionSnd>
     <ControlActEvent classCode="CACT" moodCode="EVN">
-        <author1>
-            <AgentSystemSDS>
-                <agentSystemSDS>
+        <author1 typeCode="AUT">
+            <AgentSystemSDS classCode="AGNT">
+                <agentSystemSDS classCode="DEV" determinerCode="INSTANCE">
                     <id extension="276827251543" root="1.2.826.0.1285.0.2.0.107"/>
                 </agentSystemSDS>
             </AgentSystemSDS>
@@ -62,22 +62,22 @@
                                             <code code="0" codeSystem="2.16.840.1.113883.2.1.3.2.4.17.101" displayName="Continue"/>
                                         </acknowledgementDetail>
                                         <messageRef>
-                                            <id root="6E242658-3D8E-11E3-A7DC-172BDA00FA67"/>
+                                            <id root="TEST-EHR-EXTRACT-ID"/>
                                         </messageRef>
                                     </acknowledgement>
-                                    <communicationFunctionRcv>
-                                        <device>
+                                    <communicationFunctionRcv typecode="RCV">
+                                        <device classCode="DEV" determinerCode="INSTANCE">
                                             <id extension="715373337545" root="1.2.826.0.1285.0.2.0.107"/>
                                         </device>
                                     </communicationFunctionRcv>
-                                    <communicationFunctionSnd>
-                                        <device>
+                                    <communicationFunctionSnd typeCode="SND">
+                                        <device classCode="DEV" determinerCode="INSTANCE">
                                             <id extension="276827251543" root="1.2.826.0.1285.0.2.0.107"/>
                                         </device>
                                     </communicationFunctionSnd>
                                 </Message>
                                 <gp:acknowledgedMessage>
-                                    <gp:id root="6E242658-3D8E-11E3-A7DC-172BDA00FA67"/>
+                                    <gp:id root="TEST-EHR-EXTRACT-ID"/>
                                 </gp:acknowledgedMessage>
                             </gp:Gp2gpfragment>
                         </value>


### PR DESCRIPTION
## What

- Add fixed value attributes to the continue message, as the MIM states they should be included.
- Reference the EHR extract in the continue message's ACK payload
- Send `Message-Id` header in all requests sent to the MHS Outbound service

## Why

- To fix an issue where the GP2GP Continue Message was not accepted by EMIS. 

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Internal change (non-breaking change with no effect on the functionality affecting end users)

## Checklist:

- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have updated the [Changelog](CHANGELOG.md) with details of my change in the UNRELEASED section if this change will affect end users