### PR TITLE
Add change log and release scripts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,36 @@
+# Changelog
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+
+## [Unreleased]
+
+
+## [0.13] - 2023-09-13
+
+### Added
+
+* Add details about object storage to operating documentation.
+
+### Fixed
+
+* Fix issue where attachments with filenames containing special characters causes the transfer to fail.
+* Fix issue where some resource types do not contain a degraded code when a SNOMED code has not been provided.
+* Fix issue where unnecessary length checks on inline attachments could cause a transfer to fail.
+
+## [0.12] - 2023-08-29
+
+### Changed
+
+* Change the codeable concept mapping to map Egton Codes found in `code` elements.
+* Change the codeable concept mapping to map Read Codes (READV2, CTV3) found in `code` elements.
+* Change the codeable concept mapping to map unknown code systems found in `code` elements.
+
+### Fixed
+
+* Fix issue where Inbound Adaptor rejects an EHR Extract from EMIS containing inline attachments where the description 
+contains only the filename.
+* Fix issue where Allergy Intolerances are referenced incorrectly when they are referenced from a list.
+* Fix issue where a `Condition` is not correctly mapping the `code` element in all instances.
+
+

--- a/developer-information.md
+++ b/developer-information.md
@@ -88,34 +88,21 @@ You can also review what commits have gone in by using the git log command or ID
 
 Make a note of the most recent Release within GitHub, and identify what the next version number to use will be.
 
-Create a new release within GitHub, specifying the tag as the version to use (e.g. 0.11), and the target being the commit you identified.
+Create a new release within GitHub, specifying the tag as the version to use (e.g. 1.2.7), and the target being the commit you identified.
 Click on the "Generate release notes" button and this will list all the current changes from the recent commit.
 
-Log into DockerHub using the credentials stored within our AWS accounts Secrets Manager, secret name `nhsdev-dockerhub-credentials` in London region.
-Go to AWS Management Console > Service Manager then find the option 'retrieve keys'
+From the root of this repository, update the `/release.sh`, changing the `BUILD_TAG` value to match the release created above.
+Update the `CHANGELOG.md` file, copying the release information within the GitHub release.
+Raise a PR for your changes.
 
-Now build the adaptor using the following commands.
+Once your changes have been merged, log into DockerHub using the credentials stored within our AWS accounts Secrets Manager, secret name `nhsdev-dockerhub-credentials` in London region.
+Go to AWS Management Console > Secrets Manager then find the option 'retrieve keys'.
 
-```shell
-git fetch
-git checkout <version tag>
-```
-Replace \<version\> with the version tag above. (e.g. 0.11)
+If you have not created a release before then you will first need to create a new docker builder instance using `docker buildx create --use`.
 
-When running the **buildx** commands you may get an error asking you to run the following command, which you should do.
-```shell
-docker buildx create --use
-```
+Execute `./release.sh`.
 
-Replace \<version\> with the version tag above. (e.g. nhsdev/nia-ps-adaptor:0.11)
-
-_NOTE_ that the commands can take up to 20+ minutes.
-
-```shell
-docker buildx build -f docker/gp2gp-translator/Dockerfile . --platform linux/arm64/v8,linux/amd64 --tag nhsdev/nia-ps-adaptor:<version> --push
-docker buildx build -f docker/gpc-facade/Dockerfile . --platform linux/arm64/v8,linux/amd64 --tag nhsdev/nia-ps-facade:<version> --push
-docker buildx build -f docker/db-migration/Dockerfile . --platform linux/arm64/v8,linux/amd64 --tag nhsdev/nia-ps-db-migration:<version> --push
-```
+Log out of DockerHub.
 
 ### Rebuilding services
 To rebuild the GPC Api Facade run

--- a/release-scripts/release.sh
+++ b/release-scripts/release.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+
+set -e
+
+export BUILD_TAG=0.13
+
+git fetch
+git checkout $BUILD_TAG
+
+cd ..
+
+docker buildx build -f docker/gp2gp-translator/Dockerfile . --platform linux/arm64/v8,linux/amd64 --tag nhsdev/nia-ps-adaptor:${BUILD_TAG} --push
+docker buildx build -f docker/gpc-facade/Dockerfile . --platform linux/arm64/v8,linux/amd64 --tag nhsdev/nia-ps-facade:${BUILD_TAG} --push
+docker buildx build -f docker/db-migration/Dockerfile . --platform linux/arm64/v8,linux/amd64 --tag nhsdev/nia-ps-db-migration:${BUILD_TAG} --push


### PR DESCRIPTION
## What

This adds a change log to the repository for the Github releases.
It also adds a release script, taking the steps required from the developer documentation, and updates the developer documentation to reflect this.

## Why

To ensure details of a releases are captured, which alongside the documentation and release script will help to improve the efficiency of the release process.

## Type of change

- [x] Internal change (non-breaking change with no effect on the functionality affecting end users)

## Checklist:

- [x] I have performed a self-review of my code
