### PR TITLE
Enable AWS instance roles for S3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 ### Added
 
 * Add details about object storage to operating documentation.
+* Enable AWS Instance Roles to be used for connecting to S3
 
 ### Fixed
 

--- a/developer-information.md
+++ b/developer-information.md
@@ -50,6 +50,11 @@ Please make sure to load the latest release of Snomed CT UK Edition. See [Config
     - KEY_PASSWORD: server private key password
     - TRUST_STORE: path to the truststore
     - TRUST_STORE_PASSWORD: truststore password
+    - STORAGE_TYPE: the type of object storage to use for attachments (S3, Azure or LocalMock)
+    - STORAGE_REGION: The AWS region (leave undefined if using an AWS instance role)
+    - CONTAINER_NAME: The name of the Azure Storage container or Amazon S3 Bucket
+    - STORAGE_REFERENCE: The Azure account name or AWS Access Key ID (leave undefined if using an AWS instance role)
+    - STORAGE_SECRET: The Azure account key or the access key for Amazon S3. (leave undefined if using an AWS instance role)
 
    The following variables are used determine if a migration has timed out:
     - SDS_BASE_URL: url of the SDS FHIR API (default is the Production environment)

--- a/gp2gp-translator/src/main/java/uk/nhs/adaptors/pss/translator/storage/AWSStorageService.java
+++ b/gp2gp-translator/src/main/java/uk/nhs/adaptors/pss/translator/storage/AWSStorageService.java
@@ -16,10 +16,7 @@ import com.amazonaws.services.s3.model.ObjectMetadata;
 import com.amazonaws.services.s3.model.S3Object;
 import com.amazonaws.services.s3.model.S3ObjectInputStream;
 import com.amazonaws.util.IOUtils;
-import org.springframework.stereotype.Service;
 
-
-@Service
 public class AWSStorageService implements StorageService {
 
     private static final long SIXY_MINUTES = 1000 * 60 * 60;
@@ -95,10 +92,10 @@ public class AWSStorageService implements StorageService {
 
     private boolean accessKeyProvided(StorageServiceConfiguration configuration) {
 
-        if (configuration.getAccountSecret() != null || configuration.getAccountSecret().isBlank()) {
+        if (configuration.getAccountSecret() == null || configuration.getAccountSecret().isBlank()) {
             return false;
         }
 
-        return configuration.getAccountReference() == null && !configuration.getAccountReference().isBlank();
+        return configuration.getAccountReference() != null && !configuration.getAccountReference().isBlank();
     }
 }

--- a/gp2gp-translator/src/main/java/uk/nhs/adaptors/pss/translator/storage/AzureStorageService.java
+++ b/gp2gp-translator/src/main/java/uk/nhs/adaptors/pss/translator/storage/AzureStorageService.java
@@ -1,19 +1,17 @@
 package uk.nhs.adaptors.pss.translator.storage;
 
-import com.azure.storage.blob.BlobContainerClient;
-import com.azure.storage.blob.BlobServiceClient;
-import com.azure.storage.blob.BlobServiceClientBuilder;
-import com.azure.storage.blob.specialized.BlockBlobClient;
-import com.azure.storage.common.StorageSharedKeyCredential;
-import org.springframework.stereotype.Service;
-
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.util.Locale;
 
-@Service
+import com.azure.storage.blob.BlobContainerClient;
+import com.azure.storage.blob.BlobServiceClient;
+import com.azure.storage.blob.BlobServiceClientBuilder;
+import com.azure.storage.blob.specialized.BlockBlobClient;
+import com.azure.storage.common.StorageSharedKeyCredential;
+
 public class AzureStorageService implements StorageService {
 
     // Consistent objects

--- a/gp2gp-translator/src/main/java/uk/nhs/adaptors/pss/translator/storage/LocalStorageService.java
+++ b/gp2gp-translator/src/main/java/uk/nhs/adaptors/pss/translator/storage/LocalStorageService.java
@@ -1,14 +1,12 @@
 package uk.nhs.adaptors.pss.translator.storage;
 
-import org.apache.commons.io.IOUtils;
-import org.springframework.stereotype.Service;
-
 import java.io.ByteArrayInputStream;
 import java.io.InputStream;
 import java.util.HashMap;
 import java.util.Map;
 
-@Service
+import org.apache.commons.io.IOUtils;
+
 public class LocalStorageService implements StorageService {
 
     // Configuration singleton parameters

--- a/gp2gp-translator/src/main/java/uk/nhs/adaptors/pss/translator/storage/StorageServiceFactoryConfig.java
+++ b/gp2gp-translator/src/main/java/uk/nhs/adaptors/pss/translator/storage/StorageServiceFactoryConfig.java
@@ -1,17 +1,14 @@
 package uk.nhs.adaptors.pss.translator.storage;
 
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
 @Configuration
 public class StorageServiceFactoryConfig {
 
-    @Autowired
     @Bean(name = "storage-service")
     public StorageServiceFactory storageServiceFactory() {
-        StorageServiceFactory factory = new StorageServiceFactory();
-        return factory;
+        return new StorageServiceFactory();
     }
 
     @Bean


### PR DESCRIPTION
## What

Enable S3 connections when using an AWS instance role. 

## Why

The current implementation always requires user credentials. The change allows credentials to be used when they are provided, otherwise attempts a connection without. This makes it possible for authorisation to be configured via an AWS Instance role.     

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)

## Checklist:

- [x] I have performed a self-review of my code
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have updated the [Changelog](CHANGELOG.md) with details of my change in the UNRELEASED section if this change will affect end users

