### PR TITLE
NIAD-2781: Operating Document - Database requirements

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,6 @@
+## Avoid accidently redistributing SNOMED data within the built docker images
+# The SNOMED database loader generates temporary files which contain SNOMED CT data
+snomed-database-loader/tmp_*
+# The SNOMED database is distributed as a ZIP
+snomed-database-loader/*.zip
+

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## [Unreleased]
 
+### Added
+
+* Documented database requirements in [OPERATING.md](/OPERATING.md#database-requirements)
+* New docker image published as [nhsdev/nia-ps-db-migration](https://hub.docker.com/r/nhsdev/nia-ps-db-migration)
+
 ### Fixed
 
 * Fix issue where continue message was not accepted by EMIS. 

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -59,7 +59,7 @@ pipeline {
                                         docker-compose -f docker/docker-compose.yml up -d ps_db
                                         docker-compose -f docker/docker-compose.yml up db_migration
                                         aws s3 cp s3://snomed-schema/uk_sct2mo_36.0.0_20230412000001Z.zip ./snomed-database-loader/uk_sct2mo_36.0.0_20230412000001Z.zip
-                                        docker-compose -f docker/docker-compose.yml up snomed_schema
+                                        docker-compose -f docker/docker-compose.yml run snomed_schema uk_sct2mo_36.0.0_20230412000001Z.zip
                                         docker-compose -f docker/docker-compose.yml up snomed_immunization
                                     '''
                                 }

--- a/OPERATING.md
+++ b/OPERATING.md
@@ -26,9 +26,10 @@ yyyy-mm-dd HH:mm:ss.SSS Level=DEBUG Logger=u.n.a.p.t.s.BundleMapperService Conve
 * The adaptor stores the identifiers, status, and metadata for each patient transfer
 * The adaptor uses the database as a source of SNOMED information
 * Deleting the database, or its records will cause any in-progress transfers to fail
-* The database can be used to monitor for any failed or incomplete transfers
+* In addition to the [/Patient/$gpc.migratestructuredrecord][migratestructuredrecord] endpoint, the database can be used to monitor for any failed or incomplete transfers
 
 [PostgreSQL]: https://www.postgresql.org/
+[migratestructuredrecord]: README.md#patientgpcmigratestructuredrecord
 
 ### Updating the application schema
 

--- a/docker/snomed-schema/Dockerfile
+++ b/docker/snomed-schema/Dockerfile
@@ -3,4 +3,4 @@ FROM postgres:14.0
 RUN apt-get update && apt-get install -y unzip
 COPY /snomed-database-loader/ /snomed-database-loader/
 WORKDIR /snomed-database-loader
-CMD ./load_release-postgresql.sh uk_sct2mo_36.0.0_20230412000001Z.zip
+ENTRYPOINT [ "./load_release-postgresql.sh" ]

--- a/release-scripts/release.sh
+++ b/release-scripts/release.sh
@@ -12,3 +12,4 @@ cd ..
 docker buildx build -f docker/gp2gp-translator/Dockerfile . --platform linux/arm64/v8,linux/amd64 --tag nhsdev/nia-ps-adaptor:${BUILD_TAG} --push
 docker buildx build -f docker/gpc-facade/Dockerfile . --platform linux/arm64/v8,linux/amd64 --tag nhsdev/nia-ps-facade:${BUILD_TAG} --push
 docker buildx build -f docker/db-migration/Dockerfile . --platform linux/arm64/v8,linux/amd64 --tag nhsdev/nia-ps-db-migration:${BUILD_TAG} --push
+docker buildx build -f docker/snomed-schema/Dockerfile . --platform linux/arm64/v8,linux/amd64 --tag nhsdev/nia-ps-snomed-schema:${BUILD_TAG} --push


### PR DESCRIPTION
Add database requirements section to Operating Document.

In the process, publish the SNOMED schema Docker image to DockerHub so that we can reference it within the instructions.