### PR TITLE
Niad 2864 unable to download error

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,25 @@
+## What
+
+Please include a summary of the changes and the related issue
+
+## Why
+
+Please include details of the reasoning for these changes
+
+## Type of change
+
+Please delete options that are not relevant.
+
+- [ ] Bug fix (non-breaking change which fixes an issue)
+- [ ] New feature (non-breaking change which adds functionality)
+- [ ] Internal change (non-breaking change with no effect on the functionality affecting end users)
+- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
+
+## Checklist:
+
+- [ ] I have performed a self-review of my code
+- [ ] I have made corresponding changes to the documentation
+- [ ] My changes generate no new warnings
+- [ ] I have added tests that prove my fix is effective or that my feature works
+- [ ] New and existing unit tests pass locally with my changes
+- [ ] I have updated the [Changelog](/CHANGELOG.md) with details of my change in the UNRELEASED section if this change will affect end users

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ### Fixed
 
-* Fix issue where continue message was not accepted by EMIS. 
+* Fix issue where continue message was not accepted by EMIS.
+* Fixed issue where EMIS `cid` references caused large message merging to fail.  
 
 ## [0.13] - 2023-09-13
 

--- a/gp2gp-translator/src/test/java/uk/nhs/adaptors/pss/translator/task/COPCMessageHandlerTest.java
+++ b/gp2gp-translator/src/test/java/uk/nhs/adaptors/pss/translator/task/COPCMessageHandlerTest.java
@@ -71,6 +71,7 @@ import uk.nhs.adaptors.pss.translator.model.EbxmlReference;
 import uk.nhs.adaptors.pss.translator.model.NACKMessageData;
 import uk.nhs.adaptors.pss.translator.service.AttachmentHandlerService;
 import uk.nhs.adaptors.pss.translator.service.FailedProcessHandlingService;
+import uk.nhs.adaptors.pss.translator.service.IdGeneratorService;
 import uk.nhs.adaptors.pss.translator.service.InboundMessageMergingService;
 import uk.nhs.adaptors.pss.translator.service.NackAckPreparationService;
 import uk.nhs.adaptors.pss.translator.service.XPathService;
@@ -124,6 +125,8 @@ class COPCMessageHandlerTest {
     private InboundMessageUtil inboundMessageUtil;
     @Mock
     private SendNACKMessageHandler sendNACKMessageHandler;
+    @Mock
+    private IdGeneratorService idGeneratorService;
     @InjectMocks
     private COPCMessageHandler copcMessageHandler;
     @Captor
@@ -290,15 +293,17 @@ class COPCMessageHandlerTest {
             AttachmentLogException, AttachmentNotFoundException, BundleMappingException, JsonProcessingException {
 
         var childMid = "28B31-4245-4AFC-8DA2-8A40623A5101";
-        var childCid = "435B1171-31F6-4EF2-AD7F-C7E64EEFF357";
+        var generatedCid = "ADAPTOR_GENERATED_TEST-ID";
         InboundMessage message = new InboundMessage();
         prepareFragmentIndexWithCidMocks(message);
+
+        when(idGeneratorService.generateUuid()).thenReturn("test-id");
 
         when(patientAttachmentLogService.findAttachmentLog(MESSAGE_ID, CONVERSATION_ID))
             .thenReturn(buildPatientAttachmentLog("CBBAE92D-C7E8-4A9C-8887-F5AEBA1F8CE1", null, true));
         when(patientAttachmentLogService.findAttachmentLog(childMid, CONVERSATION_ID))
             .thenReturn(null);
-        when(patientAttachmentLogService.findAttachmentLog(childCid, CONVERSATION_ID))
+        when(patientAttachmentLogService.findAttachmentLog(generatedCid, CONVERSATION_ID))
             .thenReturn(null);
         when(patientAttachmentLogService.findAttachmentLog("CBBAE92D-C7E8-4A9C-8887-F5AEBA1F8CE1", CONVERSATION_ID))
             .thenReturn(buildPatientAttachmentLog("047C22B4-613F-47D3-9A72-44A1758464FB", "CBBAE92D-C7E8-4A9C-8887-F5AEBA1F8CE1", true));
@@ -323,7 +328,7 @@ class COPCMessageHandlerTest {
         PatientAttachmentLog actualCidAttachmentLog = patientLogCaptor.getAllValues().get(0);
         PatientAttachmentLog actualMidAttachmentLog = patientLogCaptor.getAllValues().get(1);
 
-        assertEquals(childCid, actualCidAttachmentLog.getMid());
+        assertEquals(generatedCid, actualCidAttachmentLog.getMid());
         assertEquals(childMid, actualMidAttachmentLog.getMid());
     }
 


### PR DESCRIPTION
## What

Generate unique IDs when saving inline attachments

## Why

An assumption was made that `cid` references would be unique. EMIS does not provide unique references, which caused the attachment merging process to fail. 

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have updated the [Changelog](/CHANGELOG.md) with details of my change in the UNRELEASED section if this change will affect end users
