### PR TITLE
NIAD-2874: Bug Fix - duplicate attachment URLs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 ### Fixed
 
 * Fix issue where continue message was not accepted by EMIS.
-* Fixed issue where EMIS `cid` references caused large message merging to fail.  
+* Fixed issue where EMIS `cid` references caused large message merging to fail. 
+* Fix issue where documents were given the incorrect object storage URL.
 
 ## [0.13] - 2023-09-13
 

--- a/gp2gp-translator/src/main/java/uk/nhs/adaptors/pss/translator/service/AttachmentReferenceUpdaterService.java
+++ b/gp2gp-translator/src/main/java/uk/nhs/adaptors/pss/translator/service/AttachmentReferenceUpdaterService.java
@@ -60,9 +60,10 @@ public class AttachmentReferenceUpdaterService {
             if (expectedFilenames.contains(decodedFilename)) {
 
                 String fileLocation = storageManagerService.getFileLocation(decodedFilename, conversationId);
+                String referenceElement = wrapWithReferenceElement(xmlEscape(fileLocation));
 
-                resultPayload = matcher.replaceAll(wrapWithReferenceElement(xmlEscape(fileLocation)));
-                matcher.reset();
+                resultPayload = resultPayload.replace(matcher.group(0), referenceElement);
+
                 expectedFilenames.remove(decodedFilename);
             }
         }

--- a/gp2gp-translator/src/test/resources/xml/RCMRIN030000UK06_LARGE_MSG/expected_encoded_urls.xml
+++ b/gp2gp-translator/src/test/resources/xml/RCMRIN030000UK06_LARGE_MSG/expected_encoded_urls.xml
@@ -260,7 +260,7 @@
                                                                     <translation code="37251000000104" codeSystem="2.16.840.1.113883.2.1.3.2.4.15" displayName="Other digital signal"/>
                                                                 </code>
                                                                 <text mediaType="text/plain">
-                                                                    <reference value="file://localhost/277F29F1-FEAB-4D38-8266-FEB7A1E6227D_LICENSE%20%2659.txt"/>
+                                                                    <reference value="https://location.com/LICENCE.txt"/>
                                                                 </text>
                                                             </referredToExternalDocument>
                                                         </reference>
@@ -297,7 +297,7 @@
                                                                     <translation code="37251000000104" codeSystem="2.16.840.1.113883.2.1.3.2.4.15" displayName="Other digital signal"/>
                                                                 </code>
                                                                 <text mediaType="text/plain">
-                                                                    <reference value="file://localhost/7CCB6A77-360E-434E-8CF4-97C7C2B47D70_Hello%20G%C3%BCnter.txt"/>
+                                                                    <reference value="https://location.com/helloGunter.txt"/>
                                                                 </text>
                                                             </referredToExternalDocument>
                                                         </reference>
@@ -334,7 +334,7 @@
                                                                     <translation code="37251000000104" codeSystem="2.16.840.1.113883.2.1.3.2.4.15" displayName="Other digital signal"/>
                                                                 </code>
                                                                 <text mediaType="video/mpeg">
-                                                                    <reference value="file://localhost/8681AF4F-E577-4C8D-A2CE-43CABE3D5FB4_sample%5fmpeg4.mp4"/>
+                                                                    <reference value="https://location.com/sampleMpeg4.mp4"/>
                                                                 </text>
                                                             </referredToExternalDocument>
                                                         </reference>


### PR DESCRIPTION
## What

Fix issue where the incorrect object storage URLs were inserted into the EHR prior to mapping

## Why

An identical URL was inserted into the mapped bundle for every document. Therefore, the correct document would not be retrieved from Object Storage. 

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have updated the [Changelog](/CHANGELOG.md) with details of my change in the UNRELEASED section if this change will affect end users
