### PR TITLE
NIAD-2777: Bug Fix - attachments not decompressed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 * Fix issue where continue message was not accepted by EMIS.
 * Fixed issue where EMIS `cid` references caused large message merging to fail. 
-* Fix issue where documents were given the incorrect object storage URL.
+* Fix issue where attachments were given the incorrect object storage URL.
+* Fix issue where attachments were not de-compressed.
 
 ## [0.13] - 2023-09-13
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 * Fixed issue where EMIS `cid` references caused large message merging to fail. 
 * Fix issue where attachments were given the incorrect object storage URL.
 * Fix issue where attachments were not de-compressed.
+* Enable logging of migration status updates when PS_LOGGING_LEVEL is set to DEBUG.
 
 ## [0.13] - 2023-09-13
 

--- a/db-connector/src/main/java/uk/nhs/adaptors/connector/model/PatientAttachmentLog.java
+++ b/db-connector/src/main/java/uk/nhs/adaptors/connector/model/PatientAttachmentLog.java
@@ -28,15 +28,13 @@ public class PatientAttachmentLog {
     private Boolean isBase64;
 
     public String getFileDescription() {
-        String description = String.format(
-            "Filename=\"%s\" ContentType=%s Compressed=%s LargeAttachment=%s OriginalBase64=%s Length=%s",
-            getFilename(),
-            getContentType(),
-            getYesNoString(getCompressed()),
-            getYesNoString(getLargeAttachment()),
-            getYesNoString(getOriginalBase64()),
-            getLengthNum()
-        );
+        String description =
+            "Filename=\"" + getFilename() + "\""
+            + " ContentType=" + getContentType()
+            + " Compressed=" +  getYesNoString(getCompressed())
+            + " LargeAttachment=" + getYesNoString(getLargeAttachment())
+            + " OriginalBase64=" +  getYesNoString(getOriginalBase64())
+            + " Length=" + getLengthNum();
 
         if (getSkeleton()) {
             description += " DomainData=\"X-GP2GP-Skeleton: Yes\"";

--- a/db-connector/src/main/java/uk/nhs/adaptors/connector/model/PatientAttachmentLog.java
+++ b/db-connector/src/main/java/uk/nhs/adaptors/connector/model/PatientAttachmentLog.java
@@ -13,7 +13,6 @@ public class PatientAttachmentLog {
     @NonNull
     private String mid;
     private String parentMid;
-//  @NonNull filename required to create
     private String filename;
     private String contentType;
     private Boolean compressed;
@@ -22,10 +21,31 @@ public class PatientAttachmentLog {
     private Boolean skeleton;
     private Boolean uploaded;
     private Integer lengthNum;
-//  @NonNull patientMigrationReqId required to create
     private Integer patientMigrationReqId;
     private Integer orderNum;
     private Boolean deleted;
     private Integer postProcessedLengthNum;
     private Boolean isBase64;
+
+    public String getFileDescription() {
+        String description = String.format(
+            "Filename=\"%s\" ContentType=%s Compressed=%s LargeAttachment=%s OriginalBase64=%s Length=%s",
+            getFilename(),
+            getContentType(),
+            getYesNoString(getCompressed()),
+            getYesNoString(getLargeAttachment()),
+            getYesNoString(getOriginalBase64()),
+            getLengthNum()
+        );
+
+        if (getSkeleton()) {
+            description += " DomainData=\"X-GP2GP-Skeleton: Yes\"";
+        }
+
+        return description;
+    }
+
+    private String getYesNoString(boolean bool) {
+        return bool ? "Yes" : "No";
+    }
 }

--- a/db-connector/src/test/java/uk/nhs/adaptors/connector/model/PatientAttachmentLogTest.java
+++ b/db-connector/src/test/java/uk/nhs/adaptors/connector/model/PatientAttachmentLogTest.java
@@ -1,0 +1,65 @@
+package uk.nhs.adaptors.connector.model;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import org.junit.jupiter.api.Test;
+
+public class PatientAttachmentLogTest {
+
+    public static final int ONE_HUNDRED = 100;
+    public static final int ONE_HUNDRED_AND_FIVE = 105;
+
+    @Test
+    public void When_GetFileDescription_With_ValuesTrue_Expect_CorrectDescription() {
+        PatientAttachmentLog patientAttachmentLog = PatientAttachmentLog.builder()
+            .mid("TEST_MID")
+            .filename("TEST_FILENAME.txt")
+            .contentType("plain/text")
+            .compressed(true)
+            .largeAttachment(true)
+            .originalBase64(true)
+            .skeleton(true)
+            .uploaded(true)
+            .lengthNum(ONE_HUNDRED)
+            .patientMigrationReqId(1)
+            .orderNum(0)
+            .deleted(true)
+            .postProcessedLengthNum(ONE_HUNDRED_AND_FIVE)
+            .isBase64(true)
+            .build();
+
+        String expectedDescription = "Filename=\"TEST_FILENAME.txt\" ContentType=plain/text Compressed=Yes "
+            + "LargeAttachment=Yes OriginalBase64=Yes Length=100 DomainData=\"X-GP2GP-Skeleton: Yes\"";
+
+        String description = patientAttachmentLog.getFileDescription();
+
+        assertEquals(expectedDescription, description);
+    }
+
+    @Test
+    public void When_GetFileDescription_With_ValuesFalse_Expect_CorrectDescription() {
+        PatientAttachmentLog patientAttachmentLog = PatientAttachmentLog.builder()
+            .mid("TEST_MID")
+            .filename("TEST_FILENAME.txt")
+            .contentType("plain/text")
+            .compressed(false)
+            .largeAttachment(false)
+            .originalBase64(false)
+            .skeleton(false)
+            .uploaded(false)
+            .lengthNum(ONE_HUNDRED)
+            .patientMigrationReqId(1)
+            .orderNum(0)
+            .deleted(false)
+            .postProcessedLengthNum(ONE_HUNDRED_AND_FIVE)
+            .isBase64(false)
+            .build();
+
+        String expectedDescription = "Filename=\"TEST_FILENAME.txt\" ContentType=plain/text Compressed=No "
+            + "LargeAttachment=No OriginalBase64=No Length=100";
+
+        String description = patientAttachmentLog.getFileDescription();
+
+        assertEquals(expectedDescription, description);
+    }
+}

--- a/gp2gp-translator/src/main/java/uk/nhs/adaptors/pss/translator/service/AttachmentHandlerService.java
+++ b/gp2gp-translator/src/main/java/uk/nhs/adaptors/pss/translator/service/AttachmentHandlerService.java
@@ -158,17 +158,7 @@ public class AttachmentHandlerService {
         for (var  i = 0; i < attachmentLogs.size(); i++) {
             var log = attachmentLogs.get(i);
 
-            var fileDescription =
-                "Filename=" + "\"" + log.getFilename()  + "\" "
-                    + "ContentType=" + log.getContentType() + " "
-                    + "Compressed=" + log.getCompressed().toString() + " "
-                    + "LargeAttachment=" + log.getLargeAttachment().toString() + " "
-                    + "OriginalBase64=" + log.getOriginalBase64().toString() + " "
-                    + "Length=" + log.getLengthNum();
-
-            if (log.getSkeleton()) {
-                fileDescription += " DomainData=\\\"X-GP2GP-Skeleton:Yes\\\"";
-            }
+            var fileDescription = log.getFileDescription();
 
             var payload = "";
             if (payloads == null || payloads.get(i) == null) {

--- a/gp2gp-translator/src/main/java/uk/nhs/adaptors/pss/translator/task/COPCMessageHandler.java
+++ b/gp2gp-translator/src/main/java/uk/nhs/adaptors/pss/translator/task/COPCMessageHandler.java
@@ -272,13 +272,7 @@ public class COPCMessageHandler {
 
     private List<InboundMessage.Attachment> createNewLargeAttachmentInList(PatientAttachmentLog largeFileLog, String payload) {
 
-        var fileDescription =
-            "Filename=" + "\"" + largeFileLog.getFilename()  + "\" "
-                + "ContentType=" + largeFileLog.getContentType() + " "
-                + "Compressed=" + largeFileLog.getCompressed().toString() + " "
-                + "LargeAttachment=" + largeFileLog.getLargeAttachment().toString() + " "
-                + "OriginalBase64=" + largeFileLog.getOriginalBase64().toString() + " "
-                + "Length=" + largeFileLog.getLengthNum();
+        var fileDescription = largeFileLog.getFileDescription();
 
         return Collections.singletonList(
                 InboundMessage.Attachment.builder()

--- a/gp2gp-translator/src/main/java/uk/nhs/adaptors/pss/translator/util/XmlParseUtilService.java
+++ b/gp2gp-translator/src/main/java/uk/nhs/adaptors/pss/translator/util/XmlParseUtilService.java
@@ -41,7 +41,7 @@ public class XmlParseUtilService {
 
     private static final String FILENAME_PATTERN = "Filename=\"([\\S]{1}[^\"]*)\"";
 
-    private static final String COMPRESSED_PATTERN = "Compressed=(Yes|No|true|false)";
+    private static final String COMPRESSED_PATTERN = "Compressed=(Yes|No)";
 
     public static boolean parseOriginalBase64(String description) throws ParseException {
         Pattern pattern = Pattern.compile("OriginalBase64=(Yes|No)");

--- a/gp2gp-translator/src/main/resources/application.yml
+++ b/gp2gp-translator/src/main/resources/application.yml
@@ -4,7 +4,7 @@ server:
 logging:
   level:
     uk.nhs.adaptors.pss.translator: ${PS_LOGGING_LEVEL:INFO}
-
+    uk.nhs.adaptors.connector.service: ${PS_LOGGING_LEVEL:INFO}
 spring:
   datasource:
     url: ${PS_DB_URL:jdbc:postgresql://localhost:5436}/patient_switching

--- a/gp2gp-translator/src/main/resources/logback.xml
+++ b/gp2gp-translator/src/main/resources/logback.xml
@@ -12,4 +12,5 @@
     </root>
 
     <logger name="uk.nhs.adaptors.pss.translator" level="${PS_LOGGING_LEVEL:-INFO}" />
+    <logger name="uk.nhs.adaptors.connector.service" level="${PS_LOGGING_LEVEL: -INFO}" />
 </configuration>


### PR DESCRIPTION
## What

Update the code that builds the file description when an attachments metadata is re-built from the database.  Refactor the code to reduce duplication of this functionality.

Enable logging for migration status updates using `PS_LOGGING_LEVEL`.

## Why

Compressed large attachments are not decompressed when uploading to object storage. This is due to the description being re-build incorrectly i.e. `Compressed=true` instead of  `Compressed=Yes`.  The skeleton attribute was also re-built incorrectly as `DomainData=”\X-GP2GP-Skeleton:Yes\”` where the documentation states it should be `DomainData=”X-GP2GP-Skeleton: Yes`.

SA testing have requested the migration status updates to be printed to the logs. This was already present but not configurable via the environment variables. 

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

## Checklist:

- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have updated the [Changelog](/CHANGELOG.md) with details of my change in the UNRELEASED section if this change will affect end users
