### PR TITLE
NIAD-2873: changing the way how we querying SDS service

### DIFF
--- a/gp2gp-translator/src/main/java/uk/nhs/adaptors/pss/translator/sds/SdsRequestBuilder.java
+++ b/gp2gp-translator/src/main/java/uk/nhs/adaptors/pss/translator/sds/SdsRequestBuilder.java
@@ -19,21 +19,23 @@ import uk.nhs.adaptors.pss.translator.service.RequestBuilderService;
 public class SdsRequestBuilder {
 
     private static final String ROUTING_AND_READABILITY_ENDPOINT = "/Endpoint";
+    private static final String ROUTING_AND_READABILITY_DEVICE_ENDPOINT = "/Device";
     private static final String IDENTIFIER_HEADER = "identifier";
     private static final String INTERACTION_ID_IDENTIFIER =
         "https://fhir.nhs.uk/Id/nhsServiceInteractionId|urn:nhs:names:services:gp2gp:";
     private static final String ORGANISATION_HEADER = "organization";
     private static final String ORGANISATION_CODE_IDENTIFIER = "https://fhir.nhs.uk/Id/ods-organization-code|";
+    private static final String NHS_MHS_PARTY_KEY_URL =  "https://fhir.nhs.uk/Id/nhsMhsPartyKey|";
     private static final String CORRELATION_ID = "X-Correlation-Id";
     private static final String API_KEY_HEADER = "apikey";
 
     private final RequestBuilderService requestBuilderService;
     private final SdsConfiguration sdsConfiguration;
 
-    public WebClient.RequestHeadersSpec<?> buildGetRequest(String messageType, String odsCode, String conversationId) {
-        SslContext sslContext = requestBuilderService.buildSSLContext();
-        HttpClient httpClient = HttpClient.create().secure(t -> t.sslContext(sslContext));
-        WebClient client = buildWebClient(httpClient);
+    public WebClient.RequestHeadersSpec<?> buildEndpointGetRequestWithIdentifierAndOrgParams(String messageType,
+                                                                                             String odsCode,
+                                                                                             String conversationId) {
+        WebClient client = fetchWebClient();
 
         WebClient.RequestBodySpec uri = client.method(GET).uri(
             uriBuilder -> uriBuilder
@@ -48,6 +50,49 @@ public class SdsRequestBuilder {
             .header(CORRELATION_ID, conversationId)
             .header(API_KEY_HEADER, sdsConfiguration.getApikey());
     }
+
+    public WebClient.RequestHeadersSpec<?> buildEndpointGetRequestWithDoubleIdentifierParams(String messageType,
+                                                                                             String nhsMhsPartyKey,
+                                                                                             String conversationId) {
+        WebClient client = fetchWebClient();
+
+        WebClient.RequestBodySpec uri = client.method(GET).uri(
+            uriBuilder -> uriBuilder
+                .path(ROUTING_AND_READABILITY_ENDPOINT)
+                .queryParam(IDENTIFIER_HEADER, INTERACTION_ID_IDENTIFIER.concat(messageType))
+                .queryParam(IDENTIFIER_HEADER, NHS_MHS_PARTY_KEY_URL.concat(nhsMhsPartyKey))
+                .build()
+                                                              );
+
+        return uri
+            .accept(APPLICATION_JSON)
+            .header(CORRELATION_ID, conversationId)
+            .header(API_KEY_HEADER, sdsConfiguration.getApikey());
+    }
+
+    public WebClient.RequestHeadersSpec<?> buildDeviceGetRequest(String messageType, String odsCode, String conversationId) {
+        WebClient client = fetchWebClient();
+
+        WebClient.RequestBodySpec uri = client.method(GET).uri(
+            uriBuilder -> uriBuilder
+                .path(ROUTING_AND_READABILITY_DEVICE_ENDPOINT)
+                .queryParam(IDENTIFIER_HEADER, INTERACTION_ID_IDENTIFIER.concat(messageType))
+                .queryParam(ORGANISATION_HEADER, ORGANISATION_CODE_IDENTIFIER.concat(odsCode))
+                .build()
+           );
+
+        return uri
+            .accept(APPLICATION_JSON)
+            .header(CORRELATION_ID, conversationId)
+            .header(API_KEY_HEADER, sdsConfiguration.getApikey());
+    }
+
+    private WebClient fetchWebClient() {
+        SslContext sslContext = requestBuilderService.buildSSLContext();
+        HttpClient httpClient = HttpClient.create().secure(t -> t.sslContext(sslContext));
+        return buildWebClient(httpClient);
+    }
+
 
     private WebClient buildWebClient(HttpClient httpClient) {
         return WebClient

--- a/gp2gp-translator/src/main/java/uk/nhs/adaptors/pss/translator/sds/SdsRequestBuilder.java
+++ b/gp2gp-translator/src/main/java/uk/nhs/adaptors/pss/translator/sds/SdsRequestBuilder.java
@@ -19,7 +19,7 @@ import uk.nhs.adaptors.pss.translator.service.RequestBuilderService;
 public class SdsRequestBuilder {
 
     private static final String ROUTING_AND_READABILITY_ENDPOINT = "/Endpoint";
-    private static final String ROUTING_AND_READABILITY_DEVICE_ENDPOINT = "/Device";
+    private static final String ACCREDITED_SYSTEMS_INFORMATION_DEVICE_ENDPOINT = "/Device";
     private static final String IDENTIFIER_HEADER = "identifier";
     private static final String INTERACTION_ID_IDENTIFIER =
         "https://fhir.nhs.uk/Id/nhsServiceInteractionId|urn:nhs:names:services:gp2gp:";
@@ -75,7 +75,7 @@ public class SdsRequestBuilder {
 
         WebClient.RequestBodySpec uri = client.method(GET).uri(
             uriBuilder -> uriBuilder
-                .path(ROUTING_AND_READABILITY_DEVICE_ENDPOINT)
+                .path(ACCREDITED_SYSTEMS_INFORMATION_DEVICE_ENDPOINT)
                 .queryParam(IDENTIFIER_HEADER, INTERACTION_ID_IDENTIFIER.concat(messageType))
                 .queryParam(ORGANISATION_HEADER, ORGANISATION_CODE_IDENTIFIER.concat(odsCode))
                 .build()

--- a/gp2gp-translator/src/main/java/uk/nhs/adaptors/pss/translator/service/SDSService.java
+++ b/gp2gp-translator/src/main/java/uk/nhs/adaptors/pss/translator/service/SDSService.java
@@ -1,11 +1,9 @@
 package uk.nhs.adaptors.pss.translator.service;
 
 import java.time.Duration;
-import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
 
-import org.hl7.fhir.dstu3.model.Base;
 import org.hl7.fhir.dstu3.model.Bundle;
 import org.hl7.fhir.dstu3.model.Extension;
 import org.hl7.fhir.dstu3.model.Identifier;
@@ -39,8 +37,8 @@ public class SDSService {
 
     public Duration getPersistDurationFor(String messageType, String odsCode, String conversationId) throws SdsRetrievalException {
         String sdsResponseWithNhsMhsPartyKey = getNhsMhsPartyKeyFromSds(messageType, odsCode, conversationId);
-        String NhsMhsPartyKey = parseNhsMhsPartyKey(sdsResponseWithNhsMhsPartyKey);
-        String sdsResponse = getResponseFromSds(messageType, NhsMhsPartyKey, conversationId);
+        String nhsMhsPartyKey = parseNhsMhsPartyKey(sdsResponseWithNhsMhsPartyKey);
+        String sdsResponse = getResponseFromSds(messageType, nhsMhsPartyKey, conversationId);
         Duration duration = parsePersistDuration(sdsResponse);
 
         LOGGER.debug("Retrieved persist duration of [{}] for odscode [{}] and  messageType [{}]", duration, odsCode, messageType);

--- a/gp2gp-translator/src/main/java/uk/nhs/adaptors/pss/translator/service/SDSService.java
+++ b/gp2gp-translator/src/main/java/uk/nhs/adaptors/pss/translator/service/SDSService.java
@@ -1,13 +1,17 @@
 package uk.nhs.adaptors.pss.translator.service;
 
 import java.time.Duration;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
 
+import org.hl7.fhir.dstu3.model.Base;
 import org.hl7.fhir.dstu3.model.Bundle;
 import org.hl7.fhir.dstu3.model.Extension;
+import org.hl7.fhir.dstu3.model.Identifier;
 import org.hl7.fhir.dstu3.model.Property;
 import org.hl7.fhir.dstu3.model.Resource;
+import org.jetbrains.annotations.NotNull;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 import org.springframework.web.reactive.function.client.WebClientResponseException;
@@ -25,23 +29,50 @@ import uk.nhs.adaptors.pss.translator.sds.SdsRequestBuilder;
 public class SDSService {
 
     private static final String EXTENSION_KEY_VALUE = "extension";
+    private static final String IDENTIFIER_KEY_VALUE = "identifier";
     private static final String PERSIST_DURATION_URL = "nhsMHSPersistDuration";
+    private static final String NHS_MHS_PARTY_KEY_URL =  "https://fhir.nhs.uk/Id/nhsMhsPartyKey";
 
     private final SdsRequestBuilder requestBuilder;
     private final SdsClientService sdsClientService;
     private final FhirParser fhirParser;
 
     public Duration getPersistDurationFor(String messageType, String odsCode, String conversationId) throws SdsRetrievalException {
-
-        String sdsResponse = getResponseFromSds(messageType, odsCode, conversationId);
+        String sdsResponseWithNhsMhsPartyKey = getNhsMhsPartyKeyFromSds(messageType, odsCode, conversationId);
+        String NhsMhsPartyKey = parseNhsMhsPartyKey(sdsResponseWithNhsMhsPartyKey);
+        String sdsResponse = getResponseFromSds(messageType, NhsMhsPartyKey, conversationId);
         Duration duration = parsePersistDuration(sdsResponse);
 
         LOGGER.debug("Retrieved persist duration of [{}] for odscode [{}] and  messageType [{}]", duration, odsCode, messageType);
         return duration;
     }
 
-    private String getResponseFromSds(String messageType, String odsCode, String conversationId) throws SdsRetrievalException {
-        var request = requestBuilder.buildGetRequest(messageType, odsCode, conversationId);
+    public String parseNhsMhsPartyKey(String sdsResponse) throws SdsRetrievalException {
+
+        Property identifierChildren = getResourceSubelement(sdsResponse, IDENTIFIER_KEY_VALUE);
+        return identifierChildren.getValues()
+                                 .stream()
+                                 .map(Identifier.class::cast)
+                                 .filter(identifierChild -> NHS_MHS_PARTY_KEY_URL.equals(identifierChild.getSystem()))
+                                 .findFirst()
+                                 .map(Identifier::getValue).get();
+    }
+
+    private String getNhsMhsPartyKeyFromSds(String messageType, String odsCode, String conversationId) {
+
+        var request = requestBuilder.buildDeviceGetRequest(messageType, odsCode, conversationId);
+
+        try {
+            return sdsClientService.send(request);
+        } catch (WebClientResponseException e) {
+            LOGGER.error("Received an ERROR response from SDS: [{}]", e.getMessage());
+            throw new SdsRetrievalException(String.format("Error getting messageType [%s] info from SDS", messageType));
+        }
+
+    }
+
+    private String getResponseFromSds(String messageType, String nhsMhsPartyKey, String conversationId) throws SdsRetrievalException {
+        var request = requestBuilder.buildEndpointGetRequestWithDoubleIdentifierParams(messageType, nhsMhsPartyKey, conversationId);
 
         try {
             return sdsClientService.send(request);
@@ -53,6 +84,28 @@ public class SDSService {
 
     private Duration parsePersistDuration(String sdsResponse) throws SdsRetrievalException {
 
+        Optional<Extension> extensions = getExtensions(sdsResponse);
+
+        Optional<Extension> persistDuration = extensions
+            .orElseThrow(() -> new SdsRetrievalException("Error parsing persist duration extension"))
+            .getExtensionsByUrl(PERSIST_DURATION_URL)
+            .stream().findFirst();
+
+        String isoDuration = persistDuration
+            .orElseThrow(() -> new SdsRetrievalException("Error parsing persist duration value"))
+            .getValue()
+            .toString();
+
+        return Duration.parse(isoDuration);
+    }
+
+    @NotNull
+    private Optional<Extension> getExtensions(String sdsResponse) {
+        Property matchingChildren = getResourceSubelement(sdsResponse, EXTENSION_KEY_VALUE);
+        return matchingChildren.getValues().stream().map(Extension.class::cast).findFirst();
+    }
+
+    private Property getResourceSubelement(String sdsResponse, String resourceSubelement) {
         Bundle bundle;
 
         try {
@@ -68,19 +121,6 @@ public class SDSService {
         }
 
         Resource resource = entries.get(0).getResource();
-        Property matchingChildren = resource.getChildByName(EXTENSION_KEY_VALUE);
-        Optional<Extension> extensions = matchingChildren.getValues().stream().map(child -> (Extension) child).findFirst();
-
-        Optional<Extension> persistDuration = extensions
-            .orElseThrow(() -> new SdsRetrievalException("Error parsing persist duration extension"))
-            .getExtensionsByUrl(PERSIST_DURATION_URL)
-            .stream().findFirst();
-
-        String isoDuration = persistDuration
-            .orElseThrow(() -> new SdsRetrievalException("Error parsing persist duration value"))
-            .getValue()
-            .toString();
-
-        return Duration.parse(isoDuration);
+        return resource.getChildByName(resourceSubelement);
     }
 }

--- a/gp2gp-translator/src/test/java/uk/nhs/adaptors/pss/translator/service/SDSServiceTest.java
+++ b/gp2gp-translator/src/test/java/uk/nhs/adaptors/pss/translator/service/SDSServiceTest.java
@@ -115,7 +115,7 @@ public class SDSServiceTest {
 
     @Test
     public void When_GetNhsMhsPartyKey_WhenEHRExtractValidInput_Expect_CorrectNhsMhsPartyKey() {
-        //when(sdsClientService.send(any())).thenReturn(sdsResponseEHRExtract);
+
         when(fhirParser.parseResource(any(), eq(Bundle.class))).thenReturn(ehrResponseBundle);
 
         String nhsMhsPartyKey = sdsService.parseNhsMhsPartyKey(sdsResponseEHRExtract);

--- a/gp2gp-translator/src/test/java/uk/nhs/adaptors/pss/translator/service/SDSServiceTest.java
+++ b/gp2gp-translator/src/test/java/uk/nhs/adaptors/pss/translator/service/SDSServiceTest.java
@@ -114,6 +114,16 @@ public class SDSServiceTest {
     }
 
     @Test
+    public void When_GetNhsMhsPartyKey_WhenEHRExtractValidInput_Expect_CorrectNhsMhsPartyKey() {
+        //when(sdsClientService.send(any())).thenReturn(sdsResponseEHRExtract);
+        when(fhirParser.parseResource(any(), eq(Bundle.class))).thenReturn(ehrResponseBundle);
+
+        String nhsMhsPartyKey = sdsService.parseNhsMhsPartyKey(sdsResponseEHRExtract);
+
+        assertEquals("P83007-822482", nhsMhsPartyKey);
+    }
+
+    @Test
     public void When_GetPersistDurationFor_WhenCOPCValidInput_Expect_CorrectDuration() {
         when(sdsClientService.send(any())).thenReturn(sdsResponseCopcMessage);
         when(fhirParser.parseResource(any(), eq(Bundle.class))).thenReturn(copcResponseBundle);


### PR DESCRIPTION
## What

By this PR we are adapting the way how we query SDS service to avoid getting a broken response.

## Why

When querying the SDS service and sending ODS and identifier params we get some sections  of the response empty which  causes some workflow issues. The ITOC team couldn't provide any solutions that could resolve the issue. There are some alternative endpoints that we can use and find the workaround and that's what this PR is bringing.

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Internal change (non-breaking change with no effect on the functionality affecting end users)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:

- [x] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] I have updated the [Changelog](/CHANGELOG.md) with details of my change in the UNRELEASED section if this change will affect end users
