### PR TITLE
Improve the logging information for SDS requests

### DIFF
--- a/gp2gp-translator/src/main/java/uk/nhs/adaptors/pss/translator/sds/SdsRequestBuilder.java
+++ b/gp2gp-translator/src/main/java/uk/nhs/adaptors/pss/translator/sds/SdsRequestBuilder.java
@@ -32,9 +32,7 @@ public class SdsRequestBuilder {
     private final RequestBuilderService requestBuilderService;
     private final SdsConfiguration sdsConfiguration;
 
-    public WebClient.RequestHeadersSpec<?> buildEndpointGetRequestWithDoubleIdentifierParams(String messageType,
-                                                                                             String nhsMhsPartyKey,
-                                                                                             String conversationId) {
+    public WebClient.RequestHeadersSpec<?> buildEndpointGetRequest(String messageType, String nhsMhsPartyKey, String conversationId) {
         WebClient client = fetchWebClient();
 
         WebClient.RequestBodySpec uri = client.method(GET).uri(

--- a/gp2gp-translator/src/main/java/uk/nhs/adaptors/pss/translator/sds/SdsRequestBuilder.java
+++ b/gp2gp-translator/src/main/java/uk/nhs/adaptors/pss/translator/sds/SdsRequestBuilder.java
@@ -32,25 +32,6 @@ public class SdsRequestBuilder {
     private final RequestBuilderService requestBuilderService;
     private final SdsConfiguration sdsConfiguration;
 
-    public WebClient.RequestHeadersSpec<?> buildEndpointGetRequestWithIdentifierAndOrgParams(String messageType,
-                                                                                             String odsCode,
-                                                                                             String conversationId) {
-        WebClient client = fetchWebClient();
-
-        WebClient.RequestBodySpec uri = client.method(GET).uri(
-            uriBuilder -> uriBuilder
-                .path(ROUTING_AND_READABILITY_ENDPOINT)
-                .queryParam(IDENTIFIER_HEADER, INTERACTION_ID_IDENTIFIER.concat(messageType))
-                .queryParam(ORGANISATION_HEADER, ORGANISATION_CODE_IDENTIFIER.concat(odsCode))
-                .build()
-        );
-
-        return uri
-            .accept(APPLICATION_JSON)
-            .header(CORRELATION_ID, conversationId)
-            .header(API_KEY_HEADER, sdsConfiguration.getApikey());
-    }
-
     public WebClient.RequestHeadersSpec<?> buildEndpointGetRequestWithDoubleIdentifierParams(String messageType,
                                                                                              String nhsMhsPartyKey,
                                                                                              String conversationId) {

--- a/gp2gp-translator/src/main/java/uk/nhs/adaptors/pss/translator/service/SDSService.java
+++ b/gp2gp-translator/src/main/java/uk/nhs/adaptors/pss/translator/service/SDSService.java
@@ -61,6 +61,7 @@ public class SDSService {
         var request = requestBuilder.buildDeviceGetRequest(messageType, odsCode, conversationId);
 
         try {
+            LOGGER.debug("Sending party key request to SDS");
             return sdsClientService.send(request);
         } catch (WebClientResponseException e) {
             LOGGER.error("Received an ERROR response from SDS: [{}]", e.getMessage());
@@ -73,6 +74,7 @@ public class SDSService {
         var request = requestBuilder.buildEndpointGetRequestWithDoubleIdentifierParams(messageType, nhsMhsPartyKey, conversationId);
 
         try {
+            LOGGER.debug("Sending persist duration request to SDS");
             return sdsClientService.send(request);
         } catch (WebClientResponseException e) {
             LOGGER.error("Received an ERROR response from SDS: [{}]", e.getMessage());

--- a/gp2gp-translator/src/main/java/uk/nhs/adaptors/pss/translator/service/SDSService.java
+++ b/gp2gp-translator/src/main/java/uk/nhs/adaptors/pss/translator/service/SDSService.java
@@ -75,7 +75,7 @@ public class SDSService {
             String nhsMhsPartyKey,
             String conversationId) throws SdsRetrievalException {
 
-        var request = requestBuilder.buildEndpointGetRequestWithDoubleIdentifierParams(messageType, nhsMhsPartyKey, conversationId);
+        var request = requestBuilder.buildEndpointGetRequest(messageType, nhsMhsPartyKey, conversationId);
 
         try {
             LOGGER.debug("Sending persist duration request to SDS");

--- a/gp2gp-translator/src/main/java/uk/nhs/adaptors/pss/translator/service/SDSService.java
+++ b/gp2gp-translator/src/main/java/uk/nhs/adaptors/pss/translator/service/SDSService.java
@@ -36,10 +36,10 @@ public class SDSService {
     private final FhirParser fhirParser;
 
     public Duration getPersistDurationFor(String messageType, String odsCode, String conversationId) throws SdsRetrievalException {
-        String sdsResponseWithNhsMhsPartyKey = getNhsMhsPartyKeyFromSds(messageType, odsCode, conversationId);
-        String nhsMhsPartyKey = parseNhsMhsPartyKey(sdsResponseWithNhsMhsPartyKey);
-        String sdsResponse = getResponseFromSds(messageType, nhsMhsPartyKey, conversationId);
-        Duration duration = parsePersistDuration(sdsResponse);
+        String partyKeyResponseFromSds = getPartyKeyResponseFromSds(messageType, odsCode, conversationId);
+        String partyKey = parseNhsMhsPartyKey(partyKeyResponseFromSds);
+        String persistDurationResponseFromSds = getPersistDurationResponseFromSds(messageType, partyKey, conversationId);
+        Duration duration = parsePersistDuration(persistDurationResponseFromSds);
 
         LOGGER.debug("Retrieved persist duration of [{}] for odscode [{}] and  messageType [{}]", duration, odsCode, messageType);
         return duration;
@@ -56,7 +56,7 @@ public class SDSService {
                                  .map(Identifier::getValue).get();
     }
 
-    private String getNhsMhsPartyKeyFromSds(String messageType, String odsCode, String conversationId) {
+    private String getPartyKeyResponseFromSds(String messageType, String odsCode, String conversationId) {
 
         var request = requestBuilder.buildDeviceGetRequest(messageType, odsCode, conversationId);
 
@@ -70,7 +70,11 @@ public class SDSService {
 
     }
 
-    private String getResponseFromSds(String messageType, String nhsMhsPartyKey, String conversationId) throws SdsRetrievalException {
+    private String getPersistDurationResponseFromSds(
+            String messageType,
+            String nhsMhsPartyKey,
+            String conversationId) throws SdsRetrievalException {
+
         var request = requestBuilder.buildEndpointGetRequestWithDoubleIdentifierParams(messageType, nhsMhsPartyKey, conversationId);
 
         try {

--- a/gp2gp-translator/src/main/java/uk/nhs/adaptors/pss/translator/service/SdsClientService.java
+++ b/gp2gp-translator/src/main/java/uk/nhs/adaptors/pss/translator/service/SdsClientService.java
@@ -3,14 +3,10 @@ package uk.nhs.adaptors.pss.translator.service;
 import org.springframework.stereotype.Service;
 import org.springframework.web.reactive.function.client.WebClient;
 
-import lombok.extern.slf4j.Slf4j;
-
 @Service
-@Slf4j
 public class SdsClientService {
 
     public String send(WebClient.RequestHeadersSpec<? extends WebClient.RequestHeadersSpec<?>> request) {
-        LOGGER.debug("Sending request to SDS");
         return request.retrieve().bodyToMono(String.class).block();
     }
 }


### PR DESCRIPTION
## What

Improve the logging information for SDS requests

## Why

There are now two different requests made to SDS. Previously you'd see the same line repeated twice:

```
2023-10-17 11:42:51.522 Level=DEBUG Logger=u.n.a.p.t.service.SdsClientService ConversationId=AE68494E-D91E-445B-AE9B-B164C747B985 Thread="scheduling-1" Message="Sending request to SDS"
2023-10-17 11:42:51.903 Level=DEBUG Logger=u.n.a.p.t.service.SdsClientService ConversationId=AE68494E-D91E-445B-AE9B-B164C747B985 Thread="scheduling-1" Message="Sending request to SDS"
```

This makes the two lines clearer.

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)

## Checklist:

- [x] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] I have updated the [Changelog](/CHANGELOG.md) with details of my change in the UNRELEASED section if this change will affect end users
