### PR TITLE
NIAD-2881 - Blood Pressures observations without "BATTERY" and blood pressure triple are not mapped

### DIFF
--- a/gp2gp-translator/src/integrationTest/java/uk/nhs/adaptors/pss/translator/EhrExtractHandlingIT.java
+++ b/gp2gp-translator/src/integrationTest/java/uk/nhs/adaptors/pss/translator/EhrExtractHandlingIT.java
@@ -79,7 +79,9 @@ public class EhrExtractHandlingIT {
         "entry[60].resource.id",
         "entry[60].resource.identifier[0].value",
         "entry[502].resource.id",
-        "entry[502].resource.identifier[0].value"
+        "entry[502].resource.identifier[0].value",
+        "entry[504].resource.id",
+        "entry[504].resource.identifier[0].value"
     );
 
     @Autowired

--- a/gp2gp-translator/src/integrationTest/resources/json/expectedBundle.json
+++ b/gp2gp-translator/src/integrationTest/resources/json/expectedBundle.json
@@ -28624,6 +28624,184 @@
     {
       "resource": {
         "resourceType": "Observation",
+        "id": "bp-observation-id-1",
+        "meta": {
+          "profile": [
+            "https://fhir.nhs.uk/STU3/StructureDefinition/CareConnect-GPC-Observation-1"
+          ]
+        },
+        "identifier": [
+          {
+            "system": "https://PSSAdaptor/D5445",
+            "value": "bp-observation-id-1"
+          }
+        ],
+        "status": "final",
+        "code": {
+          "coding": [
+            {
+              "extension": [
+                {
+                  "url": "https://fhir.nhs.uk/STU3/StructureDefinition/Extension-coding-sctdescid",
+                  "extension": [
+                    {
+                      "url": "descriptionId",
+                      "valueId": "120159016"
+                    },
+                    {
+                      "url": "descriptionDisplay",
+                      "valueString": "Systolic arterial pressure"
+                    }
+                  ]
+                }
+              ],
+              "system": "http://snomed.info/sct",
+              "code": "72313002",
+              "display": "Systolic arterial pressure"
+            }
+          ],
+          "text": "Systolic arterial pressure"
+        },
+        "subject": {
+          "reference": "Patient/539bd780-99a2-4eba-806c-4d45f65bff36"
+        },
+        "context": {
+          "reference": "Encounter/2485BC20-90B4-11EC-B1E5-0800200C9A66"
+        },
+        "effectiveDateTime": "2006-04-25T15:30:00+00:00",
+        "issued": "2010-01-13T15:13:32.000+00:00",
+        "performer": [
+          {
+            "reference": "Practitioner/3707E1F0-9011-11EC-B1E5-0800200C9A66"
+          }
+        ],
+        "valueQuantity": {
+          "value": 80.000,
+          "unit": "millimeter of mercury",
+          "code": "mm[Hg]"
+        },
+        "interpretation": {
+          "coding": [
+            {
+              "system": "http://hl7.org/fhir/v2/0078",
+              "code": "H",
+              "display": "High"
+            }
+          ],
+          "text": "High Text"
+        },
+        "comment": "Test systolic pressure text",
+        "referenceRange": [
+          {
+            "low": {
+              "value": 10,
+              "unit": "liter",
+              "system": "http://unitsofmeasure.org",
+              "code": "L"
+            },
+            "high": {
+              "value": 12,
+              "unit": "liter",
+              "system": "http://unitsofmeasure.org",
+              "code": "L"
+            },
+            "text": "Test Range 1"
+          }
+        ]
+      }
+    },
+    {
+      "resource": {
+        "resourceType": "Observation",
+        "id": "bp-observation-id-2",
+        "meta": {
+          "profile": [
+            "https://fhir.nhs.uk/STU3/StructureDefinition/CareConnect-GPC-Observation-1"
+          ]
+        },
+        "identifier": [
+          {
+            "system": "https://PSSAdaptor/D5445",
+            "value": "bp-observation-id-2"
+          }
+        ],
+        "status": "final",
+        "code": {
+          "coding": [
+            {
+              "extension": [
+                {
+                  "url": "https://fhir.nhs.uk/STU3/StructureDefinition/Extension-coding-sctdescid",
+                  "extension": [
+                    {
+                      "url": "descriptionId",
+                      "valueId": "2734671000000117"
+                    },
+                    {
+                      "url": "descriptionDisplay",
+                      "valueString": "Diastolic arterial pressure"
+                    }
+                  ]
+                }
+              ],
+              "system": "http://snomed.info/sct",
+              "code": "1091811000000102",
+              "display": "Diastolic arterial pressure"
+            }
+          ],
+          "text": "Diastolic arterial pressure"
+        },
+        "subject": {
+          "reference": "Patient/539bd780-99a2-4eba-806c-4d45f65bff36"
+        },
+        "context": {
+          "reference": "Encounter/2485BC20-90B4-11EC-B1E5-0800200C9A66"
+        },
+        "effectiveDateTime": "2006-04-25T15:30:00+00:00",
+        "issued": "2010-01-13T15:13:32.000+00:00",
+        "performer": [
+          {
+            "reference": "Practitioner/3707E1F0-9011-11EC-B1E5-0800200C9A66"
+          }
+        ],
+        "valueQuantity": {
+          "value": 90.000,
+          "unit": "millimeter of mercury",
+          "code": "mm[Hg]"
+        },
+        "interpretation": {
+          "coding": [
+            {
+              "system": "http://hl7.org/fhir/v2/0078",
+              "code": "L",
+              "display": "Low"
+            }
+          ],
+          "text": "Low Text"
+        },
+        "comment": "Test diastolic pressure text",
+        "referenceRange": [
+          {
+            "low": {
+              "value": 20,
+              "unit": "liter",
+              "system": "http://unitsofmeasure.org",
+              "code": "L"
+            },
+            "high": {
+              "value": 22,
+              "unit": "liter",
+              "system": "http://unitsofmeasure.org",
+              "code": "L"
+            },
+            "text": "Test Range 2"
+          }
+        ]
+      }
+    },
+    {
+      "resource": {
+        "resourceType": "Observation",
         "id": "uncategorised-observation-id",
         "meta": {
           "profile": [

--- a/gp2gp-translator/src/main/java/uk/nhs/adaptors/pss/translator/mapper/BloodPressureMapper.java
+++ b/gp2gp-translator/src/main/java/uk/nhs/adaptors/pss/translator/mapper/BloodPressureMapper.java
@@ -1,8 +1,6 @@
 package uk.nhs.adaptors.pss.translator.mapper;
 
-import static uk.nhs.adaptors.pss.translator.util.BloodPressureValidatorUtil.containsValidBloodPressureTriple;
-import static uk.nhs.adaptors.pss.translator.util.BloodPressureValidatorUtil.isDiastolicBloodPressure;
-import static uk.nhs.adaptors.pss.translator.util.BloodPressureValidatorUtil.isSystolicBloodPressure;
+import static uk.nhs.adaptors.pss.translator.util.BloodPressureValidatorUtil.*;
 import static uk.nhs.adaptors.pss.translator.util.CDUtil.extractSnomedCode;
 import static uk.nhs.adaptors.pss.translator.util.ObservationUtil.getEffective;
 import static uk.nhs.adaptors.pss.translator.util.ObservationUtil.getInterpretation;
@@ -44,13 +42,13 @@ import org.hl7.v3.RCMRMT030101UK04PertinentInformation02;
 import org.springframework.stereotype.Service;
 
 import lombok.AllArgsConstructor;
+import uk.nhs.adaptors.pss.translator.util.BloodPressureValidatorUtil;
 import uk.nhs.adaptors.pss.translator.util.DegradedCodeableConcepts;
 
 @Service
 @AllArgsConstructor
 public class BloodPressureMapper extends AbstractMapper<Observation> {
     private static final String META_PROFILE = "https://fhir.nhs.uk/STU3/StructureDefinition/CareConnect-GPC-Observation-1";
-    private static final String BATTERY_VALUE = "BATTERY";
     private static final String SYSTOLIC_NOTE = "Systolic Note: ";
     private static final String DIASTOLIC_NOTE = "Diastolic Note: ";
     private static final String BP_NOTE = "BP Note: ";
@@ -62,8 +60,7 @@ public class BloodPressureMapper extends AbstractMapper<Observation> {
         return mapEhrExtractToFhirResource(ehrExtract, (extract, composition, component) ->
             extractAllCompoundStatements(component)
                 .filter(Objects::nonNull)
-                .filter(compoundStatement -> BATTERY_VALUE.equals(compoundStatement.getClassCode().get(0))
-                    && containsValidBloodPressureTriple(compoundStatement))
+                .filter(BloodPressureValidatorUtil::isBloodPressureWithBatteryAndBloodPressureTriple)
                 .filter(compoundStatement -> !isDiagnosticReport(compoundStatement)
                     && !hasDiagnosticReportParent(ehrExtract, compoundStatement))
                 .map(compoundStatement -> mapObservation(extract, composition, compoundStatement, patient, encounters, practiseCode)))

--- a/gp2gp-translator/src/main/java/uk/nhs/adaptors/pss/translator/util/BloodPressureValidatorUtil.java
+++ b/gp2gp-translator/src/main/java/uk/nhs/adaptors/pss/translator/util/BloodPressureValidatorUtil.java
@@ -41,6 +41,8 @@ public class BloodPressureValidatorUtil {
         Arrays.asList(HEADER_5, SYSTOLIC_4, DIASTOLIC_4),
         Arrays.asList(HEADER_6, SYSTOLIC_5, DIASTOLIC_5));
 
+    private static final String BATTERY_VALUE = "BATTERY";
+
     public static boolean validateBloodPressureTriple(String header, String observationStatement1, String observationStatement2) {
         return validateTriple(header, observationStatement1, observationStatement2);
     }
@@ -93,5 +95,11 @@ public class BloodPressureValidatorUtil {
         }
 
         return false;
+    }
+
+    public static boolean isBloodPressureWithBatteryAndBloodPressureTriple(
+        RCMRMT030101UK04CompoundStatement compoundStatement) {
+        return BATTERY_VALUE.equals(compoundStatement.getClassCode().get(0))
+            && containsValidBloodPressureTriple(compoundStatement);
     }
 }

--- a/gp2gp-translator/src/main/java/uk/nhs/adaptors/pss/translator/util/CompoundStatementResourceExtractors.java
+++ b/gp2gp-translator/src/main/java/uk/nhs/adaptors/pss/translator/util/CompoundStatementResourceExtractors.java
@@ -81,7 +81,7 @@ public class CompoundStatementResourceExtractors {
         return Stream.concat(
             Stream.of(component4.getObservationStatement()),
             component4.hasCompoundStatement()
-                ? CompoundStatementUtil.extractResourcesFromCompound(component4.getCompoundStatement(),
+                ? CompoundStatementUtil.extractResourcesFromCompoundWithoutBloodPressures(component4.getCompoundStatement(),
                     RCMRMT030101UK04Component02::hasObservationStatement, RCMRMT030101UK04Component02::getObservationStatement,
                     CompoundStatementResourceExtractors::isNotAllergy)
                 .stream()

--- a/gp2gp-translator/src/main/java/uk/nhs/adaptors/pss/translator/util/CompoundStatementUtil.java
+++ b/gp2gp-translator/src/main/java/uk/nhs/adaptors/pss/translator/util/CompoundStatementUtil.java
@@ -7,6 +7,8 @@ import java.util.stream.Stream;
 import org.hl7.v3.RCMRMT030101UK04Component02;
 import org.hl7.v3.RCMRMT030101UK04CompoundStatement;
 
+import static uk.nhs.adaptors.pss.translator.util.BloodPressureValidatorUtil.containsValidBloodPressureTriple;
+
 public class CompoundStatementUtil {
 
     public static List<RCMRMT030101UK04CompoundStatement> extractCompoundsFromCompound(
@@ -67,6 +69,30 @@ public class CompoundStatementUtil {
                 .filter(checker::apply)
                 .map(extractor)
                 .toList();
+        }
+
+        return List.of();
+    }
+
+    public static List<?> extractResourcesFromCompoundWithoutBloodPressures(
+            RCMRMT030101UK04CompoundStatement compoundStatement,
+            Function<RCMRMT030101UK04Component02, Boolean> checker,
+            Function<RCMRMT030101UK04Component02, ?> extractor,
+            Function<RCMRMT030101UK04CompoundStatement, Boolean> compoundStatementChecker
+    ) {
+        if (compoundStatementChecker.apply(compoundStatement)) {
+            if("BATTERY".equals(compoundStatement.getClassCode().get(0))
+                    && containsValidBloodPressureTriple(compoundStatement)) {
+                return List.of();
+            }
+
+            return compoundStatement
+                    .getComponent()
+                    .stream()
+                    .flatMap(component02 -> flatten(component02, compoundStatementChecker))
+                    .filter(checker::apply)
+                    .map(extractor)
+                    .toList();
         }
 
         return List.of();

--- a/gp2gp-translator/src/main/java/uk/nhs/adaptors/pss/translator/util/CompoundStatementUtil.java
+++ b/gp2gp-translator/src/main/java/uk/nhs/adaptors/pss/translator/util/CompoundStatementUtil.java
@@ -8,6 +8,7 @@ import org.hl7.v3.RCMRMT030101UK04Component02;
 import org.hl7.v3.RCMRMT030101UK04CompoundStatement;
 
 import static uk.nhs.adaptors.pss.translator.util.BloodPressureValidatorUtil.containsValidBloodPressureTriple;
+import static uk.nhs.adaptors.pss.translator.util.BloodPressureValidatorUtil.isBloodPressureWithBatteryAndBloodPressureTriple;
 
 public class CompoundStatementUtil {
 
@@ -81,18 +82,17 @@ public class CompoundStatementUtil {
             Function<RCMRMT030101UK04CompoundStatement, Boolean> compoundStatementChecker
     ) {
         if (compoundStatementChecker.apply(compoundStatement)) {
-            if("BATTERY".equals(compoundStatement.getClassCode().get(0))
-                    && containsValidBloodPressureTriple(compoundStatement)) {
+            if (isBloodPressureWithBatteryAndBloodPressureTriple(compoundStatement)) {
                 return List.of();
             }
 
             return compoundStatement
-                    .getComponent()
-                    .stream()
-                    .flatMap(component02 -> flatten(component02, compoundStatementChecker))
-                    .filter(checker::apply)
-                    .map(extractor)
-                    .toList();
+                .getComponent()
+                .stream()
+                .flatMap(component02 -> flatten(component02, compoundStatementChecker))
+                .filter(checker::apply)
+                .map(extractor)
+                .toList();
         }
 
         return List.of();

--- a/gp2gp-translator/src/test/java/uk/nhs/adaptors/pss/translator/mapper/ObservationMapperTest.java
+++ b/gp2gp-translator/src/test/java/uk/nhs/adaptors/pss/translator/mapper/ObservationMapperTest.java
@@ -119,6 +119,24 @@ public class ObservationMapperTest {
     }
 
     @Test
+    public void mapObservationWhichIsBloodPressureWithoutBatteryOrBloodPressureTriple_Expect_ObservationMapped() {
+        var ehrExtract = unmarshallEhrExtractElement(
+                "observation_is_blood_pressure_without_battery_or_triple.xml");
+        var observations = observationMapper.mapResources(ehrExtract, patient, ENCOUNTER_LIST, PRACTISE_CODE);
+
+        assertThat(observations).isNotEmpty();
+    }
+
+    @Test
+    public void When_mappingObservation_Which_isBloodPressure_Expect_ObservationNotMapped() {
+        var ehrExtract = unmarshallEhrExtractElement(
+                "observation_is_blood_pressure.xml");
+        var observations = observationMapper.mapResources(ehrExtract, patient, ENCOUNTER_LIST, PRACTISE_CODE);
+
+        assertThat(observations).isEmpty();
+    }
+
+    @Test
     public void mapObservationWithNoOptionalData() {
         //when(codeableConceptMapper.mapToCodeableConcept(any())).thenReturn(CODEABLE_CONCEPT);
         var ehrExtract = unmarshallEhrExtractElement("no_optional_data_observation_example.xml");

--- a/gp2gp-translator/src/test/resources/xml/Observation/observation_is_blood_pressure.xml
+++ b/gp2gp-translator/src/test/resources/xml/Observation/observation_is_blood_pressure.xml
@@ -1,0 +1,138 @@
+<EhrExtract xmlns="urn:hl7-org:v3" classCode="EXTRACT" moodCode="EVN">
+    <id root="4971E7E0-693C-11EE-9D98-00155D78C707"/>
+    <statusCode code="COMPLETE"/>
+    <availabilityTime value="20231012211654"/>
+    <recordTarget typeCode="RCT">
+        <patient classCode="PAT">
+            <id root="2.16.840.1.113883.2.1.4.1" extension="9726911192"/>
+        </patient>
+    </recordTarget>
+    <author typeCode="AUT">
+        <time value="20231012211654"/>
+        <AgentOrgSDS classCode="AGNT">
+            <agentOrganizationSDS classCode="ORG" determinerCode="INSTANCE">
+                <id root="1.2.826.0.1285.0.1.10" extension="P84009"/>
+            </agentOrganizationSDS>
+        </AgentOrgSDS>
+    </author>
+    <destination typeCode="DST">
+        <AgentOrgSDS classCode="AGNT">
+            <agentOrganizationSDS classCode="ORG" determinerCode="INSTANCE">
+                <id root="1.2.826.0.1285.0.1.10" extension="B84012"/>
+            </agentOrganizationSDS>
+        </AgentOrgSDS>
+    </destination>
+    <component typeCode="COMP">
+        <ehrFolder classCode="FOLDER" moodCode="EVN">
+            <id root="4976CA5F-693C-11EE-9D98-00155D78C707"/>
+            <statusCode code="COMPLETE"/>
+            <effectiveTime>
+                <low value="20000101000000"/>
+                <high value="20231010135228"/>
+            </effectiveTime>
+            <availabilityTime value="20231012211654"/>
+            <author typeCode="AUT">
+                <time value="20231012211654"/>
+                <AgentOrgSDS classCode="AGNT">
+                    <agentOrganizationSDS classCode="ORG" determinerCode="INSTANCE">
+                        <id root="1.2.826.0.1285.0.1.10" extension="P84009"/>
+                    </agentOrganizationSDS>
+                </AgentOrgSDS>
+            </author>
+            <component typeCode="COMP">
+                <ehrComposition classCode="COMPOSITION" moodCode="EVN">
+                    <id root="4971E7E9-693C-11EE-9D98-00155D78C707"/>
+                    <code code="25671000000102" codeSystem="2.16.840.1.113883.2.1.3.2.4.15"
+                          displayName="Surgery Consultation Note"/>
+                    <statusCode code="COMPLETE"/>
+                    <effectiveTime>
+                        <center value="20101216000000"/>
+                    </effectiveTime>
+                    <availabilityTime value="20101216000000"/>
+                    <author typeCode="AUT" contextControlCode="OP">
+                        <time value="20220713152232"/>
+                        <agentRef classCode="AGNT">
+                            <id root="4971E7E5-693C-11EE-9D98-00155D78C707"/>
+                        </agentRef>
+                    </author>
+                    <location typeCode="LOC">
+                        <locatedEntity classCode="LOCE">
+                            <locatedPlace classCode="PLC" determinerCode="INSTANCE">
+                                <name>Testvale Surgery, GP2GPTEST</name>
+                            </locatedPlace>
+                        </locatedEntity>
+                    </location>
+                    <Participant2 typeCode="PRF" contextControlCode="OP">
+                        <agentRef classCode="AGNT">
+                            <id root="4971E7E8-693C-11EE-9D98-00155D78C707"/>
+                        </agentRef>
+                    </Participant2>
+                    <component typeCode="COMP">
+                        <CompoundStatement xmlns="urn:hl7-org:v3" classCode="BATTERY" moodCode="EVN">
+                            <id root="384DBA09-B72E-11ED-808B-AC162D1F16F0"/>
+                            <code code="163020007" codeSystem="2.16.840.1.113883.2.1.3.2.4.15" displayName="O/E - blood pressure reading">
+                                <translation code="246..00" codeSystem="2.16.840.1.113883.2.1.6.2" displayName="O/E - blood pressure reading"/>
+                                <translation code="246.." codeSystem="2.16.840.1.113883.2.1.3.2.4.14" displayName="O/E - blood pressure reading"/>
+                            </code>
+                            <statusCode code="COMPLETE"/>
+                            <effectiveTime>
+                                <center value="20101216100132"/>
+                            </effectiveTime>
+                            <availabilityTime value="20101216100132"/>
+                            <component typeCode="COMP" contextConductionInd="true">
+                                <ObservationStatement classCode="OBS" moodCode="EVN">
+                                    <id root="384DBA0A-B72E-11ED-808B-AC162D1F16F0"/>
+                                    <code code="72313002" codeSystem="2.16.840.1.113883.2.1.3.2.4.15" displayName="Systolic arterial pressure">
+                                        <originalText>O/E - Systolic BP reading</originalText>
+                                        <translation code="2469.00" codeSystem="2.16.840.1.113883.2.1.6.2" displayName="O/E - Systolic BP reading"/>
+                                        <translation code="2469." codeSystem="2.16.840.1.113883.2.1.3.2.4.14" displayName="O/E - Systolic BP reading"/>
+                                    </code>
+                                    <statusCode code="COMPLETE"/>
+                                    <effectiveTime>
+                                        <center nullFlavor="NI"/>
+                                    </effectiveTime>
+                                    <availabilityTime value="20101216100132"/>
+                                    <value type="PQ" value="120" unit="mm[Hg]"/>
+                                </ObservationStatement>
+                            </component>
+                            <component typeCode="COMP" contextConductionInd="true">
+                                <ObservationStatement classCode="OBS" moodCode="EVN">
+                                    <id root="384DBA0B-B72E-11ED-808B-AC162D1F16F0"/>
+                                    <code code="1091811000000102" codeSystem="2.16.840.1.113883.2.1.3.2.4.15" displayName="Diastolic arterial pressure">
+                                        <originalText>O/E - Diastolic BP reading</originalText>
+                                        <translation code="246A." codeSystem="2.16.840.1.113883.2.1.3.2.4.14" displayName="O/E - Diastolic BP reading"/>
+                                        <translation code="246A.00" codeSystem="2.16.840.1.113883.2.1.6.2" displayName="O/E - Diastolic BP reading"/>
+                                    </code>
+                                    <statusCode code="COMPLETE"/>
+                                    <effectiveTime>
+                                        <center nullFlavor="NI"/>
+                                    </effectiveTime>
+                                    <availabilityTime value="20101216100132"/>
+                                    <value type="PQ" value="90" unit="mm[Hg]"/>
+                                    <pertinentInformation typeCode="PERT">
+                                        <sequenceNumber value="+1"/>
+                                        <pertinentAnnotation classCode="OBS" moodCode="EVN">
+                                            <text>L</text>
+                                        </pertinentAnnotation>
+                                    </pertinentInformation>
+                                </ObservationStatement>
+                            </component>
+                        </CompoundStatement>
+                    </component>
+                </ehrComposition>
+            </component>
+        </ehrFolder>
+    </component>
+    <inFulfillmentOf typeCode="FLFS">
+        <priorEhrRequest classCode="EXTRACT" moodCode="RQO">
+            <id root="E1B78523-7E3D-4F08-8CEB-6589B83BBFF8"/>
+        </priorEhrRequest>
+    </inFulfillmentOf>
+    <limitation typeCode="LIMIT" inversionInd="true">
+        <limitingEhrExtractSpecification classCode="OBS" moodCode="DEF">
+            <id root="4976CA60-693C-11EE-9D98-00155D78C707"/>
+            <code code="37241000000102" codeSystem="2.16.840.1.113883.2.1.3.2.4.15"
+                  displayName="Entire record available to originator (administrative concept)"/>
+        </limitingEhrExtractSpecification>
+    </limitation>
+</EhrExtract>

--- a/gp2gp-translator/src/test/resources/xml/Observation/observation_is_blood_pressure_without_battery_or_triple.xml
+++ b/gp2gp-translator/src/test/resources/xml/Observation/observation_is_blood_pressure_without_battery_or_triple.xml
@@ -1,0 +1,134 @@
+<EhrExtract xmlns="urn:hl7-org:v3" classCode="EXTRACT" moodCode="EVN">
+    <id root="4971E7E0-693C-11EE-9D98-00155D78C707"/>
+    <statusCode code="COMPLETE"/>
+    <availabilityTime value="20231012211654"/>
+    <recordTarget typeCode="RCT">
+        <patient classCode="PAT">
+            <id root="2.16.840.1.113883.2.1.4.1" extension="9726911192"/>
+        </patient>
+    </recordTarget>
+    <author typeCode="AUT">
+        <time value="20231012211654"/>
+        <AgentOrgSDS classCode="AGNT">
+            <agentOrganizationSDS classCode="ORG" determinerCode="INSTANCE">
+                <id root="1.2.826.0.1285.0.1.10" extension="P84009"/>
+            </agentOrganizationSDS>
+        </AgentOrgSDS>
+    </author>
+    <destination typeCode="DST">
+        <AgentOrgSDS classCode="AGNT">
+            <agentOrganizationSDS classCode="ORG" determinerCode="INSTANCE">
+                <id root="1.2.826.0.1285.0.1.10" extension="B84012"/>
+            </agentOrganizationSDS>
+        </AgentOrgSDS>
+    </destination>
+    <component typeCode="COMP">
+        <ehrFolder classCode="FOLDER" moodCode="EVN">
+            <id root="4976CA5F-693C-11EE-9D98-00155D78C707"/>
+            <statusCode code="COMPLETE"/>
+            <effectiveTime>
+                <low value="20000101000000"/>
+                <high value="20231010135228"/>
+            </effectiveTime>
+            <availabilityTime value="20231012211654"/>
+            <author typeCode="AUT">
+                <time value="20231012211654"/>
+                <AgentOrgSDS classCode="AGNT">
+                    <agentOrganizationSDS classCode="ORG" determinerCode="INSTANCE">
+                        <id root="1.2.826.0.1285.0.1.10" extension="P84009"/>
+                    </agentOrganizationSDS>
+                </AgentOrgSDS>
+            </author>
+            <component typeCode="COMP">
+                <ehrComposition classCode="COMPOSITION" moodCode="EVN">
+                    <id root="4971E7E9-693C-11EE-9D98-00155D78C707"/>
+                    <code code="25671000000102" codeSystem="2.16.840.1.113883.2.1.3.2.4.15"
+                          displayName="Surgery Consultation Note"/>
+                    <statusCode code="COMPLETE"/>
+                    <effectiveTime>
+                        <center value="20101216000000"/>
+                    </effectiveTime>
+                    <availabilityTime value="20101216000000"/>
+                    <author typeCode="AUT" contextControlCode="OP">
+                        <time value="20220713152232"/>
+                        <agentRef classCode="AGNT">
+                            <id root="4971E7E5-693C-11EE-9D98-00155D78C707"/>
+                        </agentRef>
+                    </author>
+                    <location typeCode="LOC">
+                        <locatedEntity classCode="LOCE">
+                            <locatedPlace classCode="PLC" determinerCode="INSTANCE">
+                                <name>Testvale Surgery, GP2GPTEST</name>
+                            </locatedPlace>
+                        </locatedEntity>
+                    </location>
+                    <Participant2 typeCode="PRF" contextControlCode="OP">
+                        <agentRef classCode="AGNT">
+                            <id root="4971E7E8-693C-11EE-9D98-00155D78C707"/>
+                        </agentRef>
+                    </Participant2>
+                    <component typeCode="COMP">
+                        <ObservationStatement classCode="OBS" moodCode="EVN">
+                            <id root="4976CA1E-693C-11EE-9D98-00155D78C707"/>
+                            <code code="2469." codeSystem="2.16.840.1.113883.2.1.3.2.4.14"
+                                  displayName="O/E - Systolic BP reading">
+                                <originalText>O/E - Systolic BP reading</originalText>
+                                <translation code="72313002" codeSystem="2.16.840.1.113883.2.1.3.2.4.15"
+                                             displayName="Systolic arterial pressure"/>
+                                <translation code="2469.00" codeSystem="2.16.840.1.113883.2.1.6.2"
+                                             displayName="O/E - Systolic BP reading"/>
+                            </code>
+                            <statusCode code="COMPLETE"/>
+                            <effectiveTime>
+                                <center nullFlavor="NI"/>
+                            </effectiveTime>
+                            <availabilityTime value="20101216000000"/>
+                            <pertinentInformation typeCode="PERT">
+                                <sequenceNumber value="+1"/>
+                                <pertinentAnnotation classCode="OBS" moodCode="EVN">
+                                    <text>Value: 120.0 mm[Hg]</text>
+                                </pertinentAnnotation>
+                            </pertinentInformation>
+                        </ObservationStatement>
+                    </component>
+                    <component typeCode="COMP">
+                        <ObservationStatement classCode="OBS" moodCode="EVN">
+                            <id root="4976CA1F-693C-11EE-9D98-00155D78C707"/>
+                            <code code="246A." codeSystem="2.16.840.1.113883.2.1.3.2.4.14"
+                                  displayName="O/E - Diastolic BP reading">
+                                <originalText>O/E - Diastolic BP reading</originalText>
+                                <translation code="1091811000000102" codeSystem="2.16.840.1.113883.2.1.3.2.4.15"
+                                             displayName="Diastolic arterial pressure"/>
+                                <translation code="246A.00" codeSystem="2.16.840.1.113883.2.1.6.2"
+                                             displayName="O/E - Diastolic BP reading"/>
+                            </code>
+                            <statusCode code="COMPLETE"/>
+                            <effectiveTime>
+                                <center nullFlavor="NI"/>
+                            </effectiveTime>
+                            <availabilityTime value="20101216000000"/>
+                            <pertinentInformation typeCode="PERT">
+                                <sequenceNumber value="+1"/>
+                                <pertinentAnnotation classCode="OBS" moodCode="EVN">
+                                    <text>O/E - Diastolic BP reading L&#10;Value: 90.0 mm[Hg]</text>
+                                </pertinentAnnotation>
+                            </pertinentInformation>
+                        </ObservationStatement>
+                    </component>
+                </ehrComposition>
+            </component>
+        </ehrFolder>
+    </component>
+    <inFulfillmentOf typeCode="FLFS">
+        <priorEhrRequest classCode="EXTRACT" moodCode="RQO">
+            <id root="E1B78523-7E3D-4F08-8CEB-6589B83BBFF8"/>
+        </priorEhrRequest>
+    </inFulfillmentOf>
+    <limitation typeCode="LIMIT" inversionInd="true">
+        <limitingEhrExtractSpecification classCode="OBS" moodCode="DEF">
+            <id root="4976CA60-693C-11EE-9D98-00155D78C707"/>
+            <code code="37241000000102" codeSystem="2.16.840.1.113883.2.1.3.2.4.15"
+                  displayName="Entire record available to originator (administrative concept)"/>
+        </limitingEhrExtractSpecification>
+    </limitation>
+</EhrExtract>


### PR DESCRIPTION
## What

Blood Pressure details were missing in the output bundle json.  However the details are present in XML.
These previously were ignored as they were not matching the requirements for being mapped by the Blood Pressure mapper, and were ignored by the Observation Mapper as they matched the requirements for that mapper.

## Why

The blood pressures comments were not being received by the consumer and so there was data loss. 

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes 
- [ ] I have updated the [Changelog](/CHANGELOG.md) with details of my change in the UNRELEASED section if this change will affect end users
