### PR TITLE
NIAD-2869: mapping author and participant to recorder and asserter in JSON bundle

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 ## [Unreleased]
 
 * Fixed issue with some blood pressure comments not being correctly mapped.
+* Fixed issue with practitioner not being correctly populated.
 
 ## [0.14] - 2023-10-17
 

--- a/gp2gp-translator/src/integrationTest/resources/e2e-mapping/output-json/PWTP10-output.json
+++ b/gp2gp-translator/src/integrationTest/resources/e2e-mapping/output-json/PWTP10-output.json
@@ -4724,7 +4724,7 @@
           "reference": "Practitioner/C5DEFBF3-0174-BC6F-182C-B777B9C6FF43"
         },
         "asserter": {
-          "reference": "Practitioner/C5DEFBF3-0174-BC6F-182C-B777B9C6FF43"
+          "reference": "Practitioner/1E473786-E7FA-785E-C911-A8D38FB56F20"
         }
       }
     },
@@ -4795,7 +4795,7 @@
           "reference": "Practitioner/C5DEFBF3-0174-BC6F-182C-B777B9C6FF43"
         },
         "asserter": {
-          "reference": "Practitioner/C5DEFBF3-0174-BC6F-182C-B777B9C6FF43"
+          "reference": "Practitioner/1E473786-E7FA-785E-C911-A8D38FB56F20"
         }
       }
     },

--- a/gp2gp-translator/src/main/java/uk/nhs/adaptors/pss/translator/mapper/AllergyIntoleranceMapper.java
+++ b/gp2gp-translator/src/main/java/uk/nhs/adaptors/pss/translator/mapper/AllergyIntoleranceMapper.java
@@ -101,7 +101,7 @@ public class AllergyIntoleranceMapper extends AbstractMapper<AllergyIntolerance>
 
         var recorderAndAsserter = fetchRecorderAndAsserter(ehrComposition);
 
-        if(recorderAndAsserter.get(RECORDER).isPresent() && recorderAndAsserter.get(AUTHOR).isPresent()) {
+        if (recorderAndAsserter.get(RECORDER).isPresent() && recorderAndAsserter.get(AUTHOR).isPresent()) {
             allergyIntolerance
                         .setRecorder(recorderAndAsserter.get(RECORDER).get())
                         .setAsserter(recorderAndAsserter.get(AUTHOR).get());

--- a/gp2gp-translator/src/main/java/uk/nhs/adaptors/pss/translator/util/AuthorUtil.java
+++ b/gp2gp-translator/src/main/java/uk/nhs/adaptors/pss/translator/util/AuthorUtil.java
@@ -1,0 +1,22 @@
+package uk.nhs.adaptors.pss.translator.util;
+
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
+import org.hl7.fhir.dstu3.model.Reference;
+import org.hl7.v3.RCMRMT030101UK04Author;
+import org.hl7.v3.RCMRMT030101UK04EhrComposition;
+
+import java.util.Optional;
+
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+public class AuthorUtil {
+
+    private static final String PRACTITIONER_REFERENCE_PREFIX = "Practitioner/%s";
+
+    public static Optional<Reference> getAuthorReference(RCMRMT030101UK04EhrComposition ehrComposition) {
+
+        Optional<RCMRMT030101UK04Author> author = Optional.ofNullable(ehrComposition.getAuthor());
+        return author.map(a -> new Reference(PRACTITIONER_REFERENCE_PREFIX.formatted(a.getAgentRef().getId().getRoot())));
+    }
+
+}

--- a/gp2gp-translator/src/main/java/uk/nhs/adaptors/pss/translator/util/ParticipantReferenceUtil.java
+++ b/gp2gp-translator/src/main/java/uk/nhs/adaptors/pss/translator/util/ParticipantReferenceUtil.java
@@ -44,6 +44,7 @@ public class ParticipantReferenceUtil {
     }
 
     private static Optional<String> getParticipantReference(List<RCMRMT030101UK04Participant> participantList, String typeCode) {
+
         return participantList.stream()
             .filter(participant -> hasTypeCode(participant, typeCode))
             .filter(ParticipantReferenceUtil::hasAgentReference)
@@ -55,6 +56,7 @@ public class ParticipantReferenceUtil {
     }
 
     public static Reference getParticipant2Reference(RCMRMT030101UK04EhrComposition ehrComposition, String typeCode) {
+
         var participant2Reference = ehrComposition.getParticipant2().stream()
             .filter(participant2 -> participant2.getNullFlavor() == null)
             .filter(participant2 -> typeCode.equals(participant2.getTypeCode().get(0)))
@@ -63,6 +65,7 @@ public class ParticipantReferenceUtil {
             .filter(II::hasRoot)
             .map(II::getRoot)
             .findFirst();
+
         if (participant2Reference.isPresent()) {
             return new Reference(PRACTITIONER_REFERENCE_PREFIX.formatted(participant2Reference.get()));
         }

--- a/gp2gp-translator/src/main/java/uk/nhs/adaptors/pss/translator/util/ParticipantReferenceUtil.java
+++ b/gp2gp-translator/src/main/java/uk/nhs/adaptors/pss/translator/util/ParticipantReferenceUtil.java
@@ -4,6 +4,8 @@ import java.util.List;
 import java.util.Optional;
 import java.util.stream.Collectors;
 
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
 import org.hl7.fhir.dstu3.model.Reference;
 import org.hl7.v3.II;
 import org.hl7.v3.RCMRMT030101UK04AgentRef;
@@ -11,6 +13,7 @@ import org.hl7.v3.RCMRMT030101UK04EhrComposition;
 import org.hl7.v3.RCMRMT030101UK04Participant;
 import org.hl7.v3.RCMRMT030101UK04Participant2;
 
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
 public class ParticipantReferenceUtil {
     private static final String PRF_TYPE_CODE = "PRF";
     private static final String PPRF_TYPE_CODE = "PPRF";
@@ -20,7 +23,7 @@ public class ParticipantReferenceUtil {
         RCMRMT030101UK04EhrComposition ehrComposition) {
         var nonNullFlavorParticipants = participantList.stream()
             .filter(ParticipantReferenceUtil::isNotNullFlavour)
-            .collect(Collectors.toList());
+            .toList();
 
         var pprfParticipants = getParticipantReference(nonNullFlavorParticipants, PPRF_TYPE_CODE);
         if (pprfParticipants.isPresent()) {
@@ -49,6 +52,21 @@ public class ParticipantReferenceUtil {
             .filter(II::hasRoot)
             .map(II::getRoot)
             .findFirst();
+    }
+
+    public static Reference getParticipant2Reference(RCMRMT030101UK04EhrComposition ehrComposition, String typeCode) {
+        var participant2Reference = ehrComposition.getParticipant2().stream()
+            .filter(participant2 -> participant2.getNullFlavor() == null)
+            .filter(participant2 -> typeCode.equals(participant2.getTypeCode().get(0)))
+            .map(RCMRMT030101UK04Participant2::getAgentRef)
+            .map(RCMRMT030101UK04AgentRef::getId)
+            .filter(II::hasRoot)
+            .map(II::getRoot)
+            .findFirst();
+        if (participant2Reference.isPresent()) {
+            return new Reference(PRACTITIONER_REFERENCE_PREFIX.formatted(participant2Reference.get()));
+        }
+        return null;
     }
 
     private static Optional<String> getParticipant2Reference(RCMRMT030101UK04EhrComposition ehrComposition) {

--- a/gp2gp-translator/src/main/java/uk/nhs/adaptors/pss/translator/util/ParticipantReferenceUtil.java
+++ b/gp2gp-translator/src/main/java/uk/nhs/adaptors/pss/translator/util/ParticipantReferenceUtil.java
@@ -2,7 +2,6 @@ package uk.nhs.adaptors.pss.translator.util;
 
 import java.util.List;
 import java.util.Optional;
-import java.util.stream.Collectors;
 
 import lombok.AccessLevel;
 import lombok.NoArgsConstructor;

--- a/gp2gp-translator/src/test/java/uk/nhs/adaptors/pss/translator/mapper/AllergyIntoleranceMapperTest.java
+++ b/gp2gp-translator/src/test/java/uk/nhs/adaptors/pss/translator/mapper/AllergyIntoleranceMapperTest.java
@@ -6,7 +6,6 @@ import static org.hl7.fhir.dstu3.model.AllergyIntolerance.AllergyIntoleranceCate
 import static org.hl7.fhir.dstu3.model.AllergyIntolerance.AllergyIntoleranceClinicalStatus.ACTIVE;
 import static org.hl7.fhir.dstu3.model.AllergyIntolerance.AllergyIntoleranceVerificationStatus.UNCONFIRMED;
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
@@ -122,7 +121,7 @@ public class AllergyIntoleranceMapperTest {
     }
 
     @Test
-    public void testGivenAuthorAndAutParticipant2_AuthorAndRecorderPopulatedWithParticipant2() {
+    public void testGivenAuthorAndAutParticipant2AuthorAndRecorderPopulatedWithParticipant2() {
         // At this moment it is not very clear if this is the correct behavior.
         // We haven't seen a supplier send over a HL7 in this form, but we want to specify some behaviour.
         when(codeableConceptMapper.mapToCodeableConcept(any(CD.class)))
@@ -141,7 +140,7 @@ public class AllergyIntoleranceMapperTest {
     }
 
     @Test
-    public void testGivenAuthorAndMultipleParticipant2sAndOneAutParticipant2_AuthorAndRecorderPopulatedWithAuthorAndParticipant2() {
+    public void testGivenAuthorAndMultipleParticipant2sAndOneAutParticipant2AuthorAndRecorderPopulatedWithAuthorAndParticipant2() {
         // At this moment it is not very clear if this is the correct behavior with such number of participants.
         // We haven't seen a supplier send over a HL7 in this form, but we want to specify some behaviour.
         when(codeableConceptMapper.mapToCodeableConcept(any(CD.class)))

--- a/gp2gp-translator/src/test/java/uk/nhs/adaptors/pss/translator/mapper/AllergyIntoleranceMapperTest.java
+++ b/gp2gp-translator/src/test/java/uk/nhs/adaptors/pss/translator/mapper/AllergyIntoleranceMapperTest.java
@@ -105,6 +105,7 @@ public class AllergyIntoleranceMapperTest {
 
     @Test
     public void testMapAuthorAndParticipantToRecorderAndAsserterAllergyIntolerance() {
+
         when(codeableConceptMapper.mapToCodeableConcept(any(CD.class)))
             .thenReturn(defaultCodeableConcept())
             .thenReturn(secondaryCodeableConcept());
@@ -121,7 +122,9 @@ public class AllergyIntoleranceMapperTest {
     }
 
     @Test
-    public void testMapTheSameAuthorToRecorderAndAsserterInCaseOfExistingInvalidParticipant() {
+    public void testGivenAuthorAndAutParticipant2_AuthorAndRecorderPopulatedWithParticipant2() {
+        // At this moment it is not very clear if this is the correct behavior.
+        // We haven't seen a supplier send over a HL7 in this form, but we want to specify some behaviour.
         when(codeableConceptMapper.mapToCodeableConcept(any(CD.class)))
             .thenReturn(defaultCodeableConcept())
             .thenReturn(secondaryCodeableConcept());
@@ -135,6 +138,25 @@ public class AllergyIntoleranceMapperTest {
         assertExtension(allergyIntolerance);
         assertEquals("Practitioner/9F2ABD26-1682-FDFE-1E88-19673307C67A", allergyIntolerance.getRecorder().getReference());
         assertEquals("Practitioner/9F2ABD26-1682-FDFE-1E88-19673307C67A", allergyIntolerance.getAsserter().getReference());
+    }
+
+    @Test
+    public void testGivenAuthorAndMultipleParticipant2sAndOneAutParticipant2_AuthorAndRecorderPopulatedWithAuthorAndParticipant2() {
+        // At this moment it is not very clear if this is the correct behavior with such number of participants.
+        // We haven't seen a supplier send over a HL7 in this form, but we want to specify some behaviour.
+        when(codeableConceptMapper.mapToCodeableConcept(any(CD.class)))
+            .thenReturn(defaultCodeableConcept())
+            .thenReturn(secondaryCodeableConcept());
+        var ehrExtract = unmarshallEhrExtract("allergy-structure-with-author-and-multiple-participants.xml");
+        List<AllergyIntolerance> allergyIntolerances = allergyIntoleranceMapper.mapResources(ehrExtract, getPatient(),
+                                                                                             getEncounterList(), PRACTISE_CODE);
+
+        assertEquals(1, allergyIntolerances.size());
+        var allergyIntolerance = allergyIntolerances.get(0);
+
+        assertExtension(allergyIntolerance);
+        assertEquals("Practitioner/9F2ABD26-1682-FDFE-1E88-19673307C67A", allergyIntolerance.getRecorder().getReference());
+        assertEquals("Practitioner/E7E7B550-09EF-BE85-C20F-34598014166C", allergyIntolerance.getAsserter().getReference());
     }
 
     @Test

--- a/gp2gp-translator/src/test/resources/xml/AllergyIntolerance/allergy-structure-with-author-and-multiple-participants.xml
+++ b/gp2gp-translator/src/test/resources/xml/AllergyIntolerance/allergy-structure-with-author-and-multiple-participants.xml
@@ -1,0 +1,63 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<EhrExtract xmlns="urn:hl7-org:v3" classCode="EXTRACT" moodCode="EVN">
+<availabilityTime value="20200101010101" />
+<component typeCode="COMP">
+    <ehrFolder classCode="FOLDER" moodCode="EVN">
+        <component typeCode="COMP">
+            <ehrComposition classCode="COMPOSITION" moodCode="EVN">
+                <id root="62A39454-299F-432E-993E-5A6232B4E099"/>
+                <availabilityTime value="20190708143500"/>
+                <author typeCode="AUT" contextControlCode="OP">
+									<time value="20231004123014"/>
+									<agentRef classCode="AGNT">
+										<id root="E7E7B550-09EF-BE85-C20F-34598014166C"/>
+									</agentRef>
+								</author>
+								<Participant2 typeCode="RESP" contextControlCode="OP">
+                  <agentRef classCode="AGNT">
+                      <id root="9F2ABD26-1682-FDFE-1E88-19673307C67A"/>
+                    </agentRef>
+                </Participant2>
+                <Participant2 typeCode="AUT" contextControlCode="OP">
+                    <agentRef classCode="AGNT">
+                        <id root="9F2ABD26-1682-FDFE-1E88-19673307C88A"/>
+                      </agentRef>
+                </Participant2>
+                <Participant2 typeCode="PRF" contextControlCode="OP">
+                    <agentRef classCode="AGNT">
+                        <id root="9F2ABD26-1682-FDFE-1E88-19673307C99A"/>
+                      </agentRef>
+                </Participant2>
+                <component typeCode="COMP">
+                    <CompoundStatement classCode="CATEGORY" moodCode="EVN">
+                        <id root="394559384658936"/>
+                        <code code="14L..00" codeSystem="2.16.840.1.113883.2.1.6.2" displayName="H/O: drug allergy"/>
+                        <statusCode code="COMPLETE"/>
+                        <effectiveTime>
+                            <center value="19781231"/>
+                        </effectiveTime>
+                        <availabilityTime value="19781231" />
+                        <component typeCode="COMP" contextConductionInd="true">
+                            <ObservationStatement classCode="OBS" moodCode="EVN">
+                              <id root="230D3D37-99E3-450A-AE88-B5AB802B7137"/>
+                              <code code="TJ00300" codeSystem="2.16.840.1.113883.2.1.6.2" displayName="Adverse reaction to amoxycillin">
+                                <qualifier inverted="false">
+                                  <name code="255217005" codeSystem="2.16.840.1.113883.2.1.3.2.4.15" displayName="First"/>
+                                </qualifier>
+                                <translation code="292967008" codeSystem="2.16.840.1.113883.2.1.3.2.4.15"/>
+                              </code>
+                              <statusCode code="COMPLETE"/>
+                              <effectiveTime>
+                                <center nullFlavor="NI"/>
+                              </effectiveTime>
+                              <availabilityTime value="19781231"/>
+                              <value type="CD" code="ALLERGY-READ2-TJ003" codeSystem="2.16.840.1.113883.2.1.6.3" displayName="Adverse reaction to amoxycillin"/>
+                            </ObservationStatement>
+                        </component>
+                    </CompoundStatement>
+                </component>
+            </ehrComposition>
+        </component>
+    </ehrFolder>
+</component>
+</EhrExtract>

--- a/gp2gp-translator/src/test/resources/xml/AllergyIntolerance/allergy-structure-with-author-and-multiple-participants.xml
+++ b/gp2gp-translator/src/test/resources/xml/AllergyIntolerance/allergy-structure-with-author-and-multiple-participants.xml
@@ -1,63 +1,63 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <EhrExtract xmlns="urn:hl7-org:v3" classCode="EXTRACT" moodCode="EVN">
-<availabilityTime value="20200101010101" />
-<component typeCode="COMP">
+  <availabilityTime value="20200101010101" />
+  <component typeCode="COMP">
     <ehrFolder classCode="FOLDER" moodCode="EVN">
-        <component typeCode="COMP">
-            <ehrComposition classCode="COMPOSITION" moodCode="EVN">
-                <id root="62A39454-299F-432E-993E-5A6232B4E099"/>
-                <availabilityTime value="20190708143500"/>
-                <author typeCode="AUT" contextControlCode="OP">
-									<time value="20231004123014"/>
-									<agentRef classCode="AGNT">
-										<id root="E7E7B550-09EF-BE85-C20F-34598014166C"/>
-									</agentRef>
-								</author>
-								<Participant2 typeCode="RESP" contextControlCode="OP">
-                  <agentRef classCode="AGNT">
-                      <id root="9F2ABD26-1682-FDFE-1E88-19673307C67A"/>
-                    </agentRef>
-                </Participant2>
-                <Participant2 typeCode="AUT" contextControlCode="OP">
-                    <agentRef classCode="AGNT">
-                        <id root="9F2ABD26-1682-FDFE-1E88-19673307C88A"/>
-                      </agentRef>
-                </Participant2>
-                <Participant2 typeCode="PRF" contextControlCode="OP">
-                    <agentRef classCode="AGNT">
-                        <id root="9F2ABD26-1682-FDFE-1E88-19673307C99A"/>
-                      </agentRef>
-                </Participant2>
-                <component typeCode="COMP">
-                    <CompoundStatement classCode="CATEGORY" moodCode="EVN">
-                        <id root="394559384658936"/>
-                        <code code="14L..00" codeSystem="2.16.840.1.113883.2.1.6.2" displayName="H/O: drug allergy"/>
-                        <statusCode code="COMPLETE"/>
-                        <effectiveTime>
-                            <center value="19781231"/>
-                        </effectiveTime>
-                        <availabilityTime value="19781231" />
-                        <component typeCode="COMP" contextConductionInd="true">
-                            <ObservationStatement classCode="OBS" moodCode="EVN">
-                              <id root="230D3D37-99E3-450A-AE88-B5AB802B7137"/>
-                              <code code="TJ00300" codeSystem="2.16.840.1.113883.2.1.6.2" displayName="Adverse reaction to amoxycillin">
-                                <qualifier inverted="false">
-                                  <name code="255217005" codeSystem="2.16.840.1.113883.2.1.3.2.4.15" displayName="First"/>
-                                </qualifier>
-                                <translation code="292967008" codeSystem="2.16.840.1.113883.2.1.3.2.4.15"/>
-                              </code>
-                              <statusCode code="COMPLETE"/>
-                              <effectiveTime>
-                                <center nullFlavor="NI"/>
-                              </effectiveTime>
-                              <availabilityTime value="19781231"/>
-                              <value type="CD" code="ALLERGY-READ2-TJ003" codeSystem="2.16.840.1.113883.2.1.6.3" displayName="Adverse reaction to amoxycillin"/>
-                            </ObservationStatement>
-                        </component>
-                    </CompoundStatement>
-                </component>
-            </ehrComposition>
-        </component>
+      <component typeCode="COMP">
+        <ehrComposition classCode="COMPOSITION" moodCode="EVN">
+          <id root="62A39454-299F-432E-993E-5A6232B4E099" />
+          <availabilityTime value="20190708143500" />
+          <author typeCode="AUT" contextControlCode="OP">
+            <time value="20231004123014" />
+            <agentRef classCode="AGNT">
+              <id root="E7E7B550-09EF-BE85-C20F-34598014166C" />
+            </agentRef>
+          </author>
+          <Participant2 typeCode="RESP" contextControlCode="OP">
+            <agentRef classCode="AGNT">
+              <id root="9F2ABD26-1682-FDFE-1E88-19673307C67A" />
+            </agentRef>
+          </Participant2>
+          <Participant2 typeCode="AUT" contextControlCode="OP">
+            <agentRef classCode="AGNT">
+              <id root="9F2ABD26-1682-FDFE-1E88-19673307C88A" />
+            </agentRef>
+          </Participant2>
+          <Participant2 typeCode="PRF" contextControlCode="OP">
+            <agentRef classCode="AGNT">
+              <id root="9F2ABD26-1682-FDFE-1E88-19673307C99A" />
+            </agentRef>
+          </Participant2>
+          <component typeCode="COMP">
+            <CompoundStatement classCode="CATEGORY" moodCode="EVN">
+              <id root="394559384658936" />
+              <code code="14L..00" codeSystem="2.16.840.1.113883.2.1.6.2" displayName="H/O: drug allergy" />
+              <statusCode code="COMPLETE" />
+              <effectiveTime>
+                <center value="19781231" />
+              </effectiveTime>
+              <availabilityTime value="19781231" />
+              <component typeCode="COMP" contextConductionInd="true">
+                <ObservationStatement classCode="OBS" moodCode="EVN">
+                  <id root="230D3D37-99E3-450A-AE88-B5AB802B7137" />
+                  <code code="TJ00300" codeSystem="2.16.840.1.113883.2.1.6.2" displayName="Adverse reaction to amoxycillin">
+                    <qualifier inverted="false">
+                      <name code="255217005" codeSystem="2.16.840.1.113883.2.1.3.2.4.15" displayName="First" />
+                    </qualifier>
+                    <translation code="292967008" codeSystem="2.16.840.1.113883.2.1.3.2.4.15" />
+                  </code>
+                  <statusCode code="COMPLETE" />
+                  <effectiveTime>
+                    <center nullFlavor="NI" />
+                  </effectiveTime>
+                  <availabilityTime value="19781231" />
+                  <value type="CD" code="ALLERGY-READ2-TJ003" codeSystem="2.16.840.1.113883.2.1.6.3" displayName="Adverse reaction to amoxycillin" />
+                </ObservationStatement>
+              </component>
+            </CompoundStatement>
+          </component>
+        </ehrComposition>
+      </component>
     </ehrFolder>
-</component>
+  </component>
 </EhrExtract>

--- a/gp2gp-translator/src/test/resources/xml/AllergyIntolerance/allergy-structure-with-participant-of-aut-typecode.xml
+++ b/gp2gp-translator/src/test/resources/xml/AllergyIntolerance/allergy-structure-with-participant-of-aut-typecode.xml
@@ -1,0 +1,53 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<EhrExtract xmlns="urn:hl7-org:v3" classCode="EXTRACT" moodCode="EVN">
+<availabilityTime value="20200101010101" />
+<component typeCode="COMP">
+    <ehrFolder classCode="FOLDER" moodCode="EVN">
+        <component typeCode="COMP">
+            <ehrComposition classCode="COMPOSITION" moodCode="EVN">
+                <id root="62A39454-299F-432E-993E-5A6232B4E099"/>
+                <availabilityTime value="20190708143500"/>
+                <author typeCode="AUT" contextControlCode="OP">
+									<time value="20231004123014"/>
+									<agentRef classCode="AGNT">
+										<id root="E7E7B550-09EF-BE85-C20F-34598014166C"/>
+									</agentRef>
+								</author>
+								<Participant2 typeCode="AUT" contextControlCode="OP">
+                  <agentRef classCode="AGNT">
+                      <id root="9F2ABD26-1682-FDFE-1E88-19673307C67A"/>
+                    </agentRef>
+                </Participant2>
+                <component typeCode="COMP">
+                    <CompoundStatement classCode="CATEGORY" moodCode="EVN">
+                        <id root="394559384658936"/>
+                        <code code="14L..00" codeSystem="2.16.840.1.113883.2.1.6.2" displayName="H/O: drug allergy"/>
+                        <statusCode code="COMPLETE"/>
+                        <effectiveTime>
+                            <center value="19781231"/>
+                        </effectiveTime>
+                        <availabilityTime value="19781231" />
+                        <component typeCode="COMP" contextConductionInd="true">
+                            <ObservationStatement classCode="OBS" moodCode="EVN">
+                              <id root="230D3D37-99E3-450A-AE88-B5AB802B7137"/>
+                              <code code="TJ00300" codeSystem="2.16.840.1.113883.2.1.6.2" displayName="Adverse reaction to amoxycillin">
+                                <qualifier inverted="false">
+                                  <name code="255217005" codeSystem="2.16.840.1.113883.2.1.3.2.4.15" displayName="First"/>
+                                </qualifier>
+                                <translation code="292967008" codeSystem="2.16.840.1.113883.2.1.3.2.4.15"/>
+                              </code>
+                              <statusCode code="COMPLETE"/>
+                              <effectiveTime>
+                                <center nullFlavor="NI"/>
+                              </effectiveTime>
+                              <availabilityTime value="19781231"/>
+                              <value type="CD" code="ALLERGY-READ2-TJ003" codeSystem="2.16.840.1.113883.2.1.6.3" displayName="Adverse reaction to amoxycillin"/>
+                            </ObservationStatement>
+                        </component>
+                    </CompoundStatement>
+                </component>
+            </ehrComposition>
+        </component>
+    </ehrFolder>
+</component>
+</EhrExtract>

--- a/gp2gp-translator/src/test/resources/xml/AllergyIntolerance/allergy-structure-with-participant-of-aut-typecode.xml
+++ b/gp2gp-translator/src/test/resources/xml/AllergyIntolerance/allergy-structure-with-participant-of-aut-typecode.xml
@@ -1,53 +1,53 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <EhrExtract xmlns="urn:hl7-org:v3" classCode="EXTRACT" moodCode="EVN">
-<availabilityTime value="20200101010101" />
-<component typeCode="COMP">
+  <availabilityTime value="20200101010101" />
+  <component typeCode="COMP">
     <ehrFolder classCode="FOLDER" moodCode="EVN">
-        <component typeCode="COMP">
-            <ehrComposition classCode="COMPOSITION" moodCode="EVN">
-                <id root="62A39454-299F-432E-993E-5A6232B4E099"/>
-                <availabilityTime value="20190708143500"/>
-                <author typeCode="AUT" contextControlCode="OP">
-									<time value="20231004123014"/>
-									<agentRef classCode="AGNT">
-										<id root="E7E7B550-09EF-BE85-C20F-34598014166C"/>
-									</agentRef>
-								</author>
-								<Participant2 typeCode="AUT" contextControlCode="OP">
-                  <agentRef classCode="AGNT">
-                      <id root="9F2ABD26-1682-FDFE-1E88-19673307C67A"/>
-                    </agentRef>
-                </Participant2>
-                <component typeCode="COMP">
-                    <CompoundStatement classCode="CATEGORY" moodCode="EVN">
-                        <id root="394559384658936"/>
-                        <code code="14L..00" codeSystem="2.16.840.1.113883.2.1.6.2" displayName="H/O: drug allergy"/>
-                        <statusCode code="COMPLETE"/>
-                        <effectiveTime>
-                            <center value="19781231"/>
-                        </effectiveTime>
-                        <availabilityTime value="19781231" />
-                        <component typeCode="COMP" contextConductionInd="true">
-                            <ObservationStatement classCode="OBS" moodCode="EVN">
-                              <id root="230D3D37-99E3-450A-AE88-B5AB802B7137"/>
-                              <code code="TJ00300" codeSystem="2.16.840.1.113883.2.1.6.2" displayName="Adverse reaction to amoxycillin">
-                                <qualifier inverted="false">
-                                  <name code="255217005" codeSystem="2.16.840.1.113883.2.1.3.2.4.15" displayName="First"/>
-                                </qualifier>
-                                <translation code="292967008" codeSystem="2.16.840.1.113883.2.1.3.2.4.15"/>
-                              </code>
-                              <statusCode code="COMPLETE"/>
-                              <effectiveTime>
-                                <center nullFlavor="NI"/>
-                              </effectiveTime>
-                              <availabilityTime value="19781231"/>
-                              <value type="CD" code="ALLERGY-READ2-TJ003" codeSystem="2.16.840.1.113883.2.1.6.3" displayName="Adverse reaction to amoxycillin"/>
-                            </ObservationStatement>
-                        </component>
-                    </CompoundStatement>
-                </component>
-            </ehrComposition>
-        </component>
+      <component typeCode="COMP">
+        <ehrComposition classCode="COMPOSITION" moodCode="EVN">
+          <id root="62A39454-299F-432E-993E-5A6232B4E099" />
+          <availabilityTime value="20190708143500" />
+          <author typeCode="AUT" contextControlCode="OP">
+            <time value="20231004123014" />
+            <agentRef classCode="AGNT">
+              <id root="E7E7B550-09EF-BE85-C20F-34598014166C" />
+            </agentRef>
+          </author>
+          <Participant2 typeCode="AUT" contextControlCode="OP">
+            <agentRef classCode="AGNT">
+              <id root="9F2ABD26-1682-FDFE-1E88-19673307C67A" />
+            </agentRef>
+          </Participant2>
+          <component typeCode="COMP">
+            <CompoundStatement classCode="CATEGORY" moodCode="EVN">
+              <id root="394559384658936" />
+              <code code="14L..00" codeSystem="2.16.840.1.113883.2.1.6.2" displayName="H/O: drug allergy" />
+              <statusCode code="COMPLETE" />
+              <effectiveTime>
+                <center value="19781231" />
+              </effectiveTime>
+              <availabilityTime value="19781231" />
+              <component typeCode="COMP" contextConductionInd="true">
+                <ObservationStatement classCode="OBS" moodCode="EVN">
+                  <id root="230D3D37-99E3-450A-AE88-B5AB802B7137" />
+                  <code code="TJ00300" codeSystem="2.16.840.1.113883.2.1.6.2" displayName="Adverse reaction to amoxycillin">
+                    <qualifier inverted="false">
+                      <name code="255217005" codeSystem="2.16.840.1.113883.2.1.3.2.4.15" displayName="First" />
+                    </qualifier>
+                    <translation code="292967008" codeSystem="2.16.840.1.113883.2.1.3.2.4.15" />
+                  </code>
+                  <statusCode code="COMPLETE" />
+                  <effectiveTime>
+                    <center nullFlavor="NI" />
+                  </effectiveTime>
+                  <availabilityTime value="19781231" />
+                  <value type="CD" code="ALLERGY-READ2-TJ003" codeSystem="2.16.840.1.113883.2.1.6.3" displayName="Adverse reaction to amoxycillin" />
+                </ObservationStatement>
+              </component>
+            </CompoundStatement>
+          </component>
+        </ehrComposition>
+      </component>
     </ehrFolder>
-</component>
+  </component>
 </EhrExtract>

--- a/gp2gp-translator/src/test/resources/xml/AllergyIntolerance/allergy-structure-with-valid-author-and-participant2.xml
+++ b/gp2gp-translator/src/test/resources/xml/AllergyIntolerance/allergy-structure-with-valid-author-and-participant2.xml
@@ -1,53 +1,53 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <EhrExtract xmlns="urn:hl7-org:v3" classCode="EXTRACT" moodCode="EVN">
-<availabilityTime value="20200101010101" />
-<component typeCode="COMP">
+  <availabilityTime value="20200101010101" />
+  <component typeCode="COMP">
     <ehrFolder classCode="FOLDER" moodCode="EVN">
-        <component typeCode="COMP">
-            <ehrComposition classCode="COMPOSITION" moodCode="EVN">
-                <id root="62A39454-299F-432E-993E-5A6232B4E099"/>
-                <availabilityTime value="20190708143500"/>
-                <author typeCode="AUT" contextControlCode="OP">
-									<time value="20231004123014"/>
-									<agentRef classCode="AGNT">
-										<id root="E7E7B550-09EF-BE85-C20F-34598014166C"/>
-									</agentRef>
-								</author>
-								<Participant2 typeCode="RESP" contextControlCode="OP">
-									<agentRef classCode="AGNT">
-										<id root="9F2ABD26-1682-FDFE-1E88-19673307C67A"/>
-									</agentRef>
-								</Participant2>
-                <component typeCode="COMP">
-                    <CompoundStatement classCode="CATEGORY" moodCode="EVN">
-                        <id root="394559384658936"/>
-                        <code code="14L..00" codeSystem="2.16.840.1.113883.2.1.6.2" displayName="H/O: drug allergy"/>
-                        <statusCode code="COMPLETE"/>
-                        <effectiveTime>
-                            <center value="19781231"/>
-                        </effectiveTime>
-                        <availabilityTime value="19781231" />
-                        <component typeCode="COMP" contextConductionInd="true">
-                            <ObservationStatement classCode="OBS" moodCode="EVN">
-                              <id root="230D3D37-99E3-450A-AE88-B5AB802B7137"/>
-                              <code code="TJ00300" codeSystem="2.16.840.1.113883.2.1.6.2" displayName="Adverse reaction to amoxycillin">
-                                <qualifier inverted="false">
-                                  <name code="255217005" codeSystem="2.16.840.1.113883.2.1.3.2.4.15" displayName="First"/>
-                                </qualifier>
-                                <translation code="292967008" codeSystem="2.16.840.1.113883.2.1.3.2.4.15"/>
-                              </code>
-                              <statusCode code="COMPLETE"/>
-                              <effectiveTime>
-                                <center nullFlavor="NI"/>
-                              </effectiveTime>
-                              <availabilityTime value="19781231"/>
-                              <value type="CD" code="ALLERGY-READ2-TJ003" codeSystem="2.16.840.1.113883.2.1.6.3" displayName="Adverse reaction to amoxycillin"/>
-                            </ObservationStatement>
-                        </component>
-                    </CompoundStatement>
-                </component>
-            </ehrComposition>
-        </component>
+      <component typeCode="COMP">
+        <ehrComposition classCode="COMPOSITION" moodCode="EVN">
+          <id root="62A39454-299F-432E-993E-5A6232B4E099" />
+          <availabilityTime value="20190708143500" />
+          <author typeCode="AUT" contextControlCode="OP">
+            <time value="20231004123014" />
+            <agentRef classCode="AGNT">
+              <id root="E7E7B550-09EF-BE85-C20F-34598014166C" />
+            </agentRef>
+          </author>
+          <Participant2 typeCode="RESP" contextControlCode="OP">
+            <agentRef classCode="AGNT">
+              <id root="9F2ABD26-1682-FDFE-1E88-19673307C67A" />
+            </agentRef>
+          </Participant2>
+          <component typeCode="COMP">
+            <CompoundStatement classCode="CATEGORY" moodCode="EVN">
+              <id root="394559384658936" />
+              <code code="14L..00" codeSystem="2.16.840.1.113883.2.1.6.2" displayName="H/O: drug allergy" />
+              <statusCode code="COMPLETE" />
+              <effectiveTime>
+                <center value="19781231" />
+              </effectiveTime>
+              <availabilityTime value="19781231" />
+              <component typeCode="COMP" contextConductionInd="true">
+                <ObservationStatement classCode="OBS" moodCode="EVN">
+                  <id root="230D3D37-99E3-450A-AE88-B5AB802B7137" />
+                  <code code="TJ00300" codeSystem="2.16.840.1.113883.2.1.6.2" displayName="Adverse reaction to amoxycillin">
+                    <qualifier inverted="false">
+                      <name code="255217005" codeSystem="2.16.840.1.113883.2.1.3.2.4.15" displayName="First" />
+                    </qualifier>
+                    <translation code="292967008" codeSystem="2.16.840.1.113883.2.1.3.2.4.15" />
+                  </code>
+                  <statusCode code="COMPLETE" />
+                  <effectiveTime>
+                    <center nullFlavor="NI" />
+                  </effectiveTime>
+                  <availabilityTime value="19781231" />
+                  <value type="CD" code="ALLERGY-READ2-TJ003" codeSystem="2.16.840.1.113883.2.1.6.3" displayName="Adverse reaction to amoxycillin" />
+                </ObservationStatement>
+              </component>
+            </CompoundStatement>
+          </component>
+        </ehrComposition>
+      </component>
     </ehrFolder>
-</component>
+  </component>
 </EhrExtract>

--- a/gp2gp-translator/src/test/resources/xml/AllergyIntolerance/allergy-structure-with-valid-author-and-participant2.xml
+++ b/gp2gp-translator/src/test/resources/xml/AllergyIntolerance/allergy-structure-with-valid-author-and-participant2.xml
@@ -1,0 +1,53 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<EhrExtract xmlns="urn:hl7-org:v3" classCode="EXTRACT" moodCode="EVN">
+<availabilityTime value="20200101010101" />
+<component typeCode="COMP">
+    <ehrFolder classCode="FOLDER" moodCode="EVN">
+        <component typeCode="COMP">
+            <ehrComposition classCode="COMPOSITION" moodCode="EVN">
+                <id root="62A39454-299F-432E-993E-5A6232B4E099"/>
+                <availabilityTime value="20190708143500"/>
+                <author typeCode="AUT" contextControlCode="OP">
+									<time value="20231004123014"/>
+									<agentRef classCode="AGNT">
+										<id root="E7E7B550-09EF-BE85-C20F-34598014166C"/>
+									</agentRef>
+								</author>
+								<Participant2 typeCode="RESP" contextControlCode="OP">
+									<agentRef classCode="AGNT">
+										<id root="9F2ABD26-1682-FDFE-1E88-19673307C67A"/>
+									</agentRef>
+								</Participant2>
+                <component typeCode="COMP">
+                    <CompoundStatement classCode="CATEGORY" moodCode="EVN">
+                        <id root="394559384658936"/>
+                        <code code="14L..00" codeSystem="2.16.840.1.113883.2.1.6.2" displayName="H/O: drug allergy"/>
+                        <statusCode code="COMPLETE"/>
+                        <effectiveTime>
+                            <center value="19781231"/>
+                        </effectiveTime>
+                        <availabilityTime value="19781231" />
+                        <component typeCode="COMP" contextConductionInd="true">
+                            <ObservationStatement classCode="OBS" moodCode="EVN">
+                              <id root="230D3D37-99E3-450A-AE88-B5AB802B7137"/>
+                              <code code="TJ00300" codeSystem="2.16.840.1.113883.2.1.6.2" displayName="Adverse reaction to amoxycillin">
+                                <qualifier inverted="false">
+                                  <name code="255217005" codeSystem="2.16.840.1.113883.2.1.3.2.4.15" displayName="First"/>
+                                </qualifier>
+                                <translation code="292967008" codeSystem="2.16.840.1.113883.2.1.3.2.4.15"/>
+                              </code>
+                              <statusCode code="COMPLETE"/>
+                              <effectiveTime>
+                                <center nullFlavor="NI"/>
+                              </effectiveTime>
+                              <availabilityTime value="19781231"/>
+                              <value type="CD" code="ALLERGY-READ2-TJ003" codeSystem="2.16.840.1.113883.2.1.6.3" displayName="Adverse reaction to amoxycillin"/>
+                            </ObservationStatement>
+                        </component>
+                    </CompoundStatement>
+                </component>
+            </ehrComposition>
+        </component>
+    </ehrFolder>
+</component>
+</EhrExtract>


### PR DESCRIPTION
This PR maps author and participant to recorder and asserter fields in JSON bundle. 
## What

From XML input we are mapping author and participant entries (if both are present) to recorder and asserter fields in JSON bundle response otherwise it will populate recorder and asserter fields with data from participant.

## Why

This change was done to change the case when recorder and asserter fields were always populated with participants data no matter whether author were present or not.

## Type of change

Please delete options that are not relevant.

- [x ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Internal change (non-breaking change with no effect on the functionality affecting end users)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:

- [x] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] I have updated the [Changelog](/CHANGELOG.md) with details of my change in the UNRELEASED section if this change will affect end users
