### PR TITLE
NIAD-2785: Add timeout section to operating doc

### DIFF
--- a/OPERATING.md
+++ b/OPERATING.md
@@ -20,17 +20,17 @@ yyyy-mm-dd HH:mm:ss.SSS Level=DEBUG Logger=u.n.a.p.t.s.BundleMapperService Conve
 
 ## Timeout functionality
 
-The Adaptor conforms to the GP2GP large messaging specification (NPFIT-PC-BLOD-0170.03 v1.1)
-by timing out in-progress transfers (section 2.3.6). This ensures transfers are ended gracefully
-in the scenario a GP2GP message has not been received.
+The Adaptor conforms to the GP2GP specification by timing out in-progress transfers. This ensures transfers are ended 
+gracefully in the scenario a GP2GP message has not been received.
 
-The timeout 
-datetime is calculated using the following formula and the *Persist Duration* (the minium time a message is persisted by spine) of the expected GP2GP messages.
+The timeout datetime is calculated using the following formula:
 
 ```text
 Timeout [secs] = (A x persistDuration contract property of EHR Response [secs])
                + (B x Number of COPC Common Point to Point EHR messages
                     x persistDuration contract property of COPC Common Point to Point messages [secs])
+```
+
 The formula includes adjustable weightings (A and B) to offset potential transmission delays. 
 
 From the documentation:
@@ -38,9 +38,10 @@ From the documentation:
 > A & B are weighting factors associated with general message transmission delays and volume based
 throughput times to allow adjustment if required ....
 
-The *Persist Duration* of each message is unique to the sending organisation and is obtained from the Spine Directory Service (SDS) FHIR API. Responses for an organisations message type are cached by default. 
+The *Persist Duration* of each message is unique to the sending organisation and is obtained from the [Spine Directory Service (SDS) FHIR API](https://digital.nhs.uk/developer/api-catalogue/spine-directory-service-fhir). Responses for an organisation's message type are cached by default, the frequency the cache is
+updated is configurable via the environment variable `TIMEOUT_SDS_POLL_FREQUENCY`. 
 
-The adaptor checks for transfers periodically, the default is every six hours. However, this is configurable via the environment variables.
+The adaptor checks incomplete transfers periodically, at a default frequency of every six hours. However, this is configurable via the environment variable `TIMEOUT_CRON_TIME`. 
 
 Required environment variables:
 

--- a/OPERATING.md
+++ b/OPERATING.md
@@ -28,13 +28,9 @@ The timeout
 datetime is calculated using the following formula and the *Persist Duration* (the minium time a message is persisted by spine) of the expected GP2GP messages.
 
 ```text
-
-Timeout [secs] = (A x persistDuration contract property of EHR Response
-[secs]) + (B x Number of COPC Common Point to Point EHR messages x
-persistDuration contract property of COPC Common Point to Point messages
-[secs])
-
-```
+Timeout [secs] = (A x persistDuration contract property of EHR Response [secs])
+               + (B x Number of COPC Common Point to Point EHR messages
+                    x persistDuration contract property of COPC Common Point to Point messages [secs])
 The formula includes adjustable weightings (A and B) to offset potential transmission delays. 
 
 From the documentation:

--- a/OPERATING.md
+++ b/OPERATING.md
@@ -44,18 +44,20 @@ throughput times to allow adjustment if required ....
 
 The *Persist Duration* of each message is unique to the sending organisation and is obtained from the Spine Directory Service (SDS) FHIR API. Responses for an organisations message type are cached by default. 
 
-The adaptor checks for transfers periodically, the default is every six hours. However, this is configurable via the environment variables.  
+The adaptor checks for transfers periodically, the default is every six hours. However, this is configurable via the environment variables.
 
-The following environment should be used to configure the timeout:
+Required environment variables:
 
-| Environment variable          | Required | Description                                                                                                                                                              | Default value                                        |
-|-------------------------------|----------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------|------------------------------------------------------|
-| SDS_BASE_URL                  |          | The SDS FHIR API Base URL (default is production)                                                                                                                        | `https://api.service.nhs.uk/spine-directory/FHIR/R4` |
-| SDS_API_KEY                   | Yes      | Your SDS FHIR API Key                                                                                                                                                    |                                                      |
-| TIMEOUT_CRON_TIME             |          | The frequency of the timeout check specified as a Cron expression (default is every six hours). format = `<second> <minute> <hour> <day of month> <month> <day of week>` | `0 0 */6 * * * `                                     |
-| TIMEOUT_SDS_POLL_FREQUENCY    |          | The frequency the persist duration cache is updated (default 3) i.e. 1 = send request to SDS everytime,  3 = send request to SDS on the third call                       | `3`                                                  |
-| TIMEOUT_EHR_EXTRACT_WEIGHTING |          | The weighting factor A (as described above)                                                                                                                              | `1`                                                  |
-| TIMEOUT_COPC_WEIGHTING        |          | The weighting factor B (as described above)                                                                                                                              | `1`                                                  |
+- `SDS_API_KEY`: Your SDS FHIR API Key
+
+Optional environment variables:
+
+- `SDS_BASE_URL`: The SDS FHIR API Base URL (default is production) - default = `https://api.service.nhs.uk/spine-directory/FHIR/R4`
+- `TIMEOUT_CRON_TIME`: The frequency of the timeout check specified as a Cron expression (default is every six hours). 
+format = `<second> <minute> <hour> <day of month> <month> <day of week>` - default = `0 0 */6 * * * `
+- `TIMEOUT_SDS_POLL_FREQUENCY`: The frequency the persist duration cache is updated (default 3) i.e. 1 = send request to SDS everytime,  3 = send request to SDS on the third call - default = `3`
+- `TIMEOUT_EHR_EXTRACT_WEIGHTING`: The weighting factor A (as described above) - default = `1`
+- `TIMEOUT_COPC_WEIGHTING`: The weighting factor B (as described above) - default = `1`
 
 ## Database requirements
 


### PR DESCRIPTION
## What

Add a section to OPERATING.md for the Timeout functionality

## Why

The NME must configure the timeout functionality correctly to end "stuck" transfers.

## Type of change

Please delete options that are not relevant.

- [x] Internal change (non-breaking change with no effect on the functionality affecting end users)

## Checklist:

- [x] I have performed a self-review of my code
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes