### PR TITLE
NIAD-2779:  Document which permissions are required for the Object Storage

### DIFF
--- a/OPERATING.md
+++ b/OPERATING.md
@@ -205,9 +205,12 @@ the EHR Extract itself as a compressed attachment. Therefore, an incomplete / fa
 uploaded to object storage. If a transfer fails they will not be deleted by the adaptor. 
 
 ##### Complete transfers
-Assembled attachments will be uploaded to object storage. The adaptor obtains a URL for each attachment, which it inserts
-into the returned FHIR bundle. When using AWS S3 this URL is pre-signed and valid for 60 minutes. After this time, the 
-download link will be invalidated, although no files will be deleted from the S3 bucket.   
+Assembled attachments will be uploaded to object storage.
+The adaptor obtains a URL for each attachment, which it inserts into the returned FHIR bundle.
+When using AWS S3 this URL is pre-signed and valid for 60 minutes from the point at which the bundle was generated.
+After this time, the [S3 download URL will expire][presigned-url-expire], but no files will be deleted from the S3 bucket.
+
+[presigned-url-expire]: https://docs.aws.amazon.com/AmazonS3/latest/userguide/using-presigned-url.html#PresignedUrl-Expiration
 
 The pre-assembled attachment parts are removed from storage when an attachment is assembled. However, if the transfer 
 contains a compressed EHR Extract this is not removed from storage automatically.


### PR DESCRIPTION
## What

Update the object storage section of the operating document.

## Why

An issue arose where an NME had not set the access permissions appropriately for the adaptor. Therefore, this section has been added for clarity. 

The existing section has been refactored and added to to ensure the supplier is aware of what is stored in object storage and that it is their responsibility to maintain it,   

## Type of change

Please delete options that are not relevant.

- [x] Internal change (non-breaking change with no effect on the functionality affecting end users)

## Checklist:

- [x] I have performed a self-review of my code
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
