### PR TITLE
NIAD-2908: bug fix - invalid state transition

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 ### Fixed
 
 * Add additional error handling for exceptions raised when processing PSS queue, and MHS queue messages.
-* Fix bug in some SQL statement which caused excessively large amounts of data to be returned, sometimes resulting in a PostgresSQL Out of Memory error.
+* Fix bug in some SQL statements which caused excessively large amounts of data to be returned, sometimes resulting in 
+a PostgresSQL Out of Memory error.
+* Fix invalid state transition bug which caused the adaptor to move from a failed state to an in-progress state when a 
+positive acknowledgement was received.  
 
 ## [0.15] - 2023-10-24
 

--- a/gp2gp-translator/src/main/java/uk/nhs/adaptors/pss/translator/task/AcknowledgmentMessageHandler.java
+++ b/gp2gp-translator/src/main/java/uk/nhs/adaptors/pss/translator/task/AcknowledgmentMessageHandler.java
@@ -89,7 +89,6 @@ public class AcknowledgmentMessageHandler {
                 case "18" -> EHR_EXTRACT_REQUEST_NEGATIVE_ACK_GP2GP_MISFORMED_REQUEST;
                 case "19" -> EHR_EXTRACT_REQUEST_NEGATIVE_ACK_GP2GP_NOT_PRIMARY_HEALTHCARE_PROVIDER;
                 case "24" -> EHR_EXTRACT_REQUEST_NEGATIVE_ACK_GP2GP_MULTI_OR_NO_RESPONSES;
-                case "99" -> EHR_EXTRACT_REQUEST_NEGATIVE_ACK_UNKNOWN;
                 default -> EHR_EXTRACT_REQUEST_NEGATIVE_ACK_UNKNOWN;
             };
             default -> null;

--- a/gp2gp-translator/src/main/java/uk/nhs/adaptors/pss/translator/task/AcknowledgmentMessageHandler.java
+++ b/gp2gp-translator/src/main/java/uk/nhs/adaptors/pss/translator/task/AcknowledgmentMessageHandler.java
@@ -89,6 +89,7 @@ public class AcknowledgmentMessageHandler {
                 case "18" -> EHR_EXTRACT_REQUEST_NEGATIVE_ACK_GP2GP_MISFORMED_REQUEST;
                 case "19" -> EHR_EXTRACT_REQUEST_NEGATIVE_ACK_GP2GP_NOT_PRIMARY_HEALTHCARE_PROVIDER;
                 case "24" -> EHR_EXTRACT_REQUEST_NEGATIVE_ACK_GP2GP_MULTI_OR_NO_RESPONSES;
+                case "99" -> EHR_EXTRACT_REQUEST_NEGATIVE_ACK_UNKNOWN;
                 default -> EHR_EXTRACT_REQUEST_NEGATIVE_ACK_UNKNOWN;
             };
             default -> null;

--- a/gp2gp-translator/src/test/java/uk/nhs/adaptors/pss/translator/task/AcknowledgmentMessageHandlerTest.java
+++ b/gp2gp-translator/src/test/java/uk/nhs/adaptors/pss/translator/task/AcknowledgmentMessageHandlerTest.java
@@ -162,7 +162,7 @@ public class AcknowledgmentMessageHandlerTest {
     }
 
     @Test
-    public void When_handleMessage_With_AckTypeCodeAndFailedStatus_Expect_MigrationStatusNotUpdated() throws SAXException {
+    public void When_HandleMessage_With_AckTypeCodeAndFailedStatus_Expect_MigrationStatusNotUpdated() throws SAXException {
         prepareFailedProcessMocks(ACK_TYPE_CODE);
 
         acknowledgmentMessageHandler.handleMessage(inboundMessage, CONVERSATION_ID);
@@ -171,7 +171,7 @@ public class AcknowledgmentMessageHandlerTest {
     }
 
     @Test
-    public void When_handleMessage_With_NackTypeCodeAndFailedStatus_Expect_MigrationStatusNotUpdated() throws SAXException {
+    public void When_HandleMessage_With_NackTypeCodeAndFailedStatus_Expect_MigrationStatusNotUpdated() throws SAXException {
         prepareFailedProcessMocks(NACK_ERROR_TYPE_CODE);
 
         acknowledgmentMessageHandler.handleMessage(inboundMessage, CONVERSATION_ID);


### PR DESCRIPTION
## What

Ignore acknowledgement messages for a migration that has entered a failed state. 

## Why

The adapter can currently transition from a failed state to an in-progress state when an acknowledgment is received. 

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [x] I have performed a self-review of my code
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have updated the [Changelog](/CHANGELOG.md) with details of my change in the UNRELEASED section if this change will affect end users
- [ ] A corresponding change has been made to the [Mapping Documentation repository][mapping-docs]

[mapping-docs]: https://github.com/NHSDigital/patient-switching-adaptors-mapping-documentation