### PR TITLE
increase JmsListenerErrorHandler log severity to error

### DIFF
--- a/gp2gp-translator/src/main/java/uk/nhs/adaptors/pss/translator/amqp/JmsListenerErrorHandler.java
+++ b/gp2gp-translator/src/main/java/uk/nhs/adaptors/pss/translator/amqp/JmsListenerErrorHandler.java
@@ -26,7 +26,7 @@ public class JmsListenerErrorHandler implements ErrorHandler {
     @Override
     public void handleError(Throwable t) {
 
-        LOGGER.warn("Handling JMS message error due to [{}] with message [{}]", t.getClass(), t.getMessage());
+        LOGGER.error("Handling JMS message error due to [{}] with message [{}]", t.getClass(), t.getMessage());
         t.printStackTrace();
 
         Throwable cause = t.getCause();
@@ -35,7 +35,7 @@ public class JmsListenerErrorHandler implements ErrorHandler {
         }
 
         Class<? extends Throwable> classOfCause = cause.getClass();
-        LOGGER.warn("Caught Error cause of type: [{}], with message: [{}]", classOfCause.toString(), cause.getMessage());
+        LOGGER.error("Caught Error cause of type: [{}], with message: [{}]", classOfCause.toString(), cause.getMessage());
 
         // Rety these specific exceptions continuously until they stop happening.
         // These retries will happen until the associated transfer times out.


### PR DESCRIPTION
## What

increase `JmsListenerErrorHandler` log severity to error

## Why

An severity of error is more appropriate. 

## Type of change

Please delete options that are not relevant.

- [x] Internal change (non-breaking change with no effect on the functionality affecting end users)

## Checklist:

- [x] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] I have updated the [Changelog](/CHANGELOG.md) with details of my change in the UNRELEASED section if this change will affect end users
- [ ] A corresponding change has been made to the [Mapping Documentation repository][mapping-docs]

[mapping-docs]: https://github.com/NHSDigital/patient-switching-adaptors-mapping-documentation