### PR TITLE
test-suite: Avoid importing SNOMED data where possible

### DIFF
--- a/test-suite/README.md
+++ b/test-suite/README.md
@@ -36,6 +36,10 @@
     ```
 </details>
 
+The test-suite creates a Docker volume called `test-suite_pgdata` to store PostgreSQL data between executions of `start-test-environment.sh`.
+This is especially useful for the SNOMED data which takes a long time to import.
+If you want to start from a fresh DB, delete the volume with `docker volume rm test-suite_pgdata` and then run `./start-test-environment.sh`.
+
 ## Running the translator and facade in your IDE for debugging
 1. Ensure test-suite environment is setup from steps above
 2. Turn off both the `ps_gp2gp_transaltor-1` and `gpc_facade-1` in docker desktop

--- a/test-suite/docker-compose.yml
+++ b/test-suite/docker-compose.yml
@@ -145,6 +145,8 @@ services:
       - PS_DB_OWNER_NAME
     networks:
       - nia-ps
+    volumes:
+      - pgdata:/var/lib/postgresql/data
 
   db_migration:
     image: ${PS_DB_MIGRATION_VERSION}
@@ -200,3 +202,6 @@ services:
       - MOCK_SPINE_MHS_OUTBOUND_LOG_LEVEL
     networks:
       - nia-ps
+
+volumes:
+  pgdata:


### PR DESCRIPTION
## What

Importing the SNOMED data takes a very long time.

Avoid this by:
- Storing PostgreSQL data within a docker volume.
- Checking the existance of the data before importing the SNOMED data

**Could I ask that a reviewer checks that the behaviour works on Windows too? I have tested on Mac fine.**

## Why

<img src="https://i.kym-cdn.com/photos/images/newsfeed/000/615/826/8ba.gif">

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Internal change (non-breaking change with no effect on the functionality affecting end users)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:

- [ ] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I have updated the [Changelog](/CHANGELOG.md) with details of my change in the UNRELEASED section if this change will affect end users
- [ ] A corresponding change has been made to the [Mapping Documentation repository][mapping-docs]

[mapping-docs]: https://github.com/NHSDigital/patient-switching-adaptors-mapping-documentation