### PR TITLE
Add org.opencontainers.image.source label to released Dockerhub images

### DIFF
--- a/release-scripts/release.sh
+++ b/release-scripts/release.sh
@@ -9,7 +9,13 @@ git checkout $BUILD_TAG
 
 cd ..
 
-docker buildx build -f docker/gp2gp-translator/Dockerfile . --platform linux/arm64/v8,linux/amd64 --tag nhsdev/nia-ps-adaptor:${BUILD_TAG} --push
-docker buildx build -f docker/gpc-facade/Dockerfile . --platform linux/arm64/v8,linux/amd64 --tag nhsdev/nia-ps-facade:${BUILD_TAG} --push
-docker buildx build -f docker/db-migration/Dockerfile . --platform linux/arm64/v8,linux/amd64 --tag nhsdev/nia-ps-db-migration:${BUILD_TAG} --push
-docker buildx build -f docker/snomed-schema/Dockerfile . --platform linux/arm64/v8,linux/amd64 --tag nhsdev/nia-ps-snomed-schema:${BUILD_TAG} --push
+export BASE_GIT_URL="https://github.com/NHSDigital/nia-patient-switching-standard-adaptor/blob/${BUILD_TAG}/"
+
+function build() {
+  docker buildx build -f ${1} . --platform linux/arm64/v8,linux/amd64 --tag ${2}:${BUILD_TAG} --label "org.opencontainers.image.source=${BASE_GIT_URL}${1}" --push
+}
+
+build docker/gp2gp-translator/Dockerfile nhsdev/nia-ps-adaptor
+build docker/gpc-facade/Dockerfile nhsdev/nia-ps-facade
+build docker/db-migration/Dockerfile nhsdev/nia-ps-db-migration
+build docker/snomed-schema/Dockerfile nhsdev/nia-ps-snomed-schema


### PR DESCRIPTION
## What

Please include a summary of the changes and the related issue

## Why

This helps link the container back to this repoistory, and is a standardised annotation.

https://github.com/opencontainers/image-spec/blob/main/annotations.md

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Internal change (non-breaking change with no effect on the functionality affecting end users)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:

- [ ] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I have updated the [Changelog](/CHANGELOG.md) with details of my change in the UNRELEASED section if this change will affect end users
- [ ] A corresponding change has been made to the [Mapping Documentation repository][mapping-docs]

[mapping-docs]: https://github.com/NHSDigital/patient-switching-adaptors-mapping-documentation