### PR TITLE
Consolidate the SNOMED database information into OPERATING.md

### DIFF
--- a/OPERATING.md
+++ b/OPERATING.md
@@ -89,7 +89,7 @@ Required environment variables:
 - PS_DB_PORT e.g. 5432
 
 The docker container has a required argument which is the path to a zipped SnomedCT RF2 file.
-The container does not come bundled with any Snomed data itself.
+The container does not come bundled with any SNOMED data itself.
 You will need to provide this file to the container.
 
 *When passing passwords into this script it is the responsibility of the supplier to ensure that passwords are being kept secure by using appropriate controls within their infrastructure.*
@@ -100,6 +100,29 @@ $ docker run --rm -e PS_DB_OWNER_NAME=postgres -e POSTGRES_PASSWORD=super5ecret 
     -v /path/to/uk_sct2mo_36.3.0_20230705000001Z.zip:/snomed/uk_sct2mo_36.3.0_20230705000001Z.zip \
     nhsdev/nia-ps-snomed-schema /snomed/uk_sct2mo_36.3.0_20230705000001Z.zip
 ```
+
+#### First installation
+
+As part of the installation of the adaptor, we do not provide the SNOMED database files as they are updated regularly under TRUD (Technology Reference Update Distribution).
+To acquire the most recent SNOMED database:-
+
+1. Head to https://isd.digital.nhs.uk/ and create a new account.
+2. Log in
+3. Search for the following: [SNOMED CT UK Monolith Edition, RF2: Snapshot](https://isd.digital.nhs.uk/trud/users/authenticated/filters/0/categories/26/items/1799/releases). We recommend the full Monolith edition, not the delta version.
+4. Subscribe to the data store.
+5. Once subscribed you will be able to download the most recent version of the SNOMED DB, at the time of writing this is release 36.0.0. (uk_sct2mo_36.0.0_20230412000001Z.zip)
+7. Now run the loader script as described above, and the SNOMED database will be installed for you.
+
+#### Updating the SNOMED Database
+
+You will now receive email notifications from TRUD once the subscribed data source is updated.
+We recommend updating your SNOMED version as soon as you receive the notification.
+To do this:-
+
+1. Log in to https://isd.digital.nhs.uk/
+2. Download the newest version of the SNOMED Monolith edition.
+3. Before continuing, please be aware that the database will be unavailable whilst being rebuilt, so this should be completed during a maintenance window.
+4. Run the loader script as described above.
 
 ## Message broker
 

--- a/README.md
+++ b/README.md
@@ -122,35 +122,6 @@ If you receive a 500 response, you can retry again at any point, however, it sho
 
 Note: To improve reliability on this endpoint we are currently looking at a polling change, the documentation will be updated once this has been updated.
 
-## Configuring the SNOMED Database
-
-### First  installation
-
-As part of the installation of the adaptor, we do not provide the SNOMED database files as they are updated regularly under TRUD (Technology Reference Update Distribution).
-To acquire the most recent SNOMED database:-
-
-1. Head to https://isd.digital.nhs.uk/ and create a new account.
-2. Log in
-3. Search for the following: SNOMED CT UK Monolith Edition, RF2: Snapshot (https://isd.digital.nhs.uk/trud/users/authenticated/filters/0/categories/26/items/1799/releases). We recommend the full Monolith edition, not the delta version.
-4. Subscribe to the data store.
-5. Once subscribed you will be able to download the most recent version of the SNOMED DB, at the time of writing this is release 36.0.0. (uk_sct2mo_36.0.0_20230412000001Z.zip)
-6. During the setup of the adaptor you will now need to set the environment variable “SNOMED_FILE_LOCATION” to the root location of the zip file that you’ve downloaded e.g. export SNOMED_FILE_LOCATION=“/root/uk_sct2mo_36.0.0_20230412000001Z.zip
-7. Now when you run our startup scripts for the first time, the SNOMED database will be installed for you.
-
-### Updating the SNOMED Database
-
-You will now receive email notifications from TRUD once the subscribed data source is updated. We recommend updating your SNOMED version as soon as you receive the notification. To do this:-
-
-1. Log in to https://isd.digital.nhs.uk/
-2. Download the newest version of the SNOMED Monolith edition.
-3. Navigate to directory 'snomed-database-loader'.
-4. Before continuing, please be aware that the database will be unavailable whilst being rebuilt, so this should be completed during a maintenance window.
-5. Execute the script 'load_release-postgresql.sh' followed by the path to the root location of the zip file that you have downloaded. For example:
-
-   ``` 
-   ./load_release_postgresql.sh /root/uk_sct2mo_36.0.0_20230412000001Z.zip
-   ```
-
 ## Licensing
 This code is dual licensed under the MIT license and the OGL (Open Government License).
 Any new work added to this repository must conform to the conditions of these licenses.

--- a/developer-information.md
+++ b/developer-information.md
@@ -17,7 +17,7 @@
     └── mhs-adaptor-mock            # Dockerfile and required files for mock of MHS Adaptor
 
 ## Snomed CT Database
-Please make sure to load the latest release of Snomed CT UK Edition. See [Configuring the SNOMED Database](./README.md#configuring-the-snomed-database) and [snomed-database-loader](https://github.com/NHSDigital/nia-patient-switching-standard-adaptor/tree/main/snomed-database-loader) for more information.
+Please make sure to load the latest release of Snomed CT UK Edition. See [Configuring the SNOMED Database](./OPERATING.md#updating-the-snomed-database) and [snomed-database-loader](/snomed-database-loader/README.md) for more information.
 
 ## Local development
 ### How to start local environment


### PR DESCRIPTION
## What

When moving the guidance, instead of referencing running shell scripts instead use the existing Docker execution guidance within the document.

## Why

This file should contain all technical operating information that an end user needs to know.

We already had some SNOMED information within OPEARTING.md, so this consolidates it into one place.

## Type of change

Please delete options that are not relevant.

- [x] Internal change (non-breaking change with no effect on the functionality affecting end users)

## Checklist:

- [ ] I have performed a self-review of my code
- [x] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I have updated the [Changelog](/CHANGELOG.md) with details of my change in the UNRELEASED section if this change will affect end users
- [ ] A corresponding change has been made to the [Mapping Documentation repository][mapping-docs]

[mapping-docs]: https://github.com/NHSDigital/patient-switching-adaptors-mapping-documentation