### PR TITLE
Replace README Developer Information section with Table of contents

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,11 +17,13 @@ Adaptor consists of two main components:
 
 Both are Java Spring Boot applications, released as separate docker images.
 
-## Developer Information
 
-See [Operating The Patient Switching Adaptor](./OPERATING.md) for Guidance on operating the Patient Switching Adaptor in production.
+## Table of contents
 
-Information for contributors and running the adaptor locally is available in [Developer Information](./developer-information.md).   
+1. [Guidance for operating the adaptor as a New Market Entrant](/OPERATING.md)
+1. [Guidance on integrating with the adaptors APIs](#endpoints)
+1. [Guidance for developing the adaptor](/developer-information.md)
+1. [Guidance for developing the adaptor on Windows](/getting-started-with-windows.md)
 
 ## Endpoints
 


### PR DESCRIPTION
## What

Replace README Developer Information section with Table of contents

## Why

The existing Developer Information felt like some links out to other documents.

Having a clear table of contents feels like a clearer way of achieving the same outcome.

## Type of change

Please delete options that are not relevant.

- [x] Internal change (non-breaking change with no effect on the functionality affecting end users)

## Checklist:

- [ ] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I have updated the [Changelog](/CHANGELOG.md) with details of my change in the UNRELEASED section if this change will affect end users
- [ ] A corresponding change has been made to the [Mapping Documentation repository][mapping-docs]

[mapping-docs]: https://github.com/NHSDigital/patient-switching-adaptors-mapping-documentation