### PR TITLE
Niad 2858: storing negative ack error code in DB

### DIFF
--- a/db-connector/changelog/migration/14-add-error-code-column-to-migration_status_log-table.xml
+++ b/db-connector/changelog/migration/14-add-error-code-column-to-migration_status_log-table.xml
@@ -12,7 +12,7 @@
 
     <changeSet id="14" author="ole4ryb">
         <addColumn schemaName="public" tableName="migration_status_log">
-            <column name="error_code" type="varchar(255)">
+            <column name="gp2gp_error_code" type="varchar(255)">
                 <constraints nullable="true"/>
             </column>
         </addColumn>

--- a/db-connector/changelog/migration/14-add-error-code-column-to-migration_status_log-table.xml
+++ b/db-connector/changelog/migration/14-add-error-code-column-to-migration_status_log-table.xml
@@ -1,0 +1,20 @@
+<databaseChangeLog
+        xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xmlns:ext="http://www.liquibase.org/xml/ns/dbchangelog-ext"
+        xmlns:pro="http://www.liquibase.org/xml/ns/pro"
+        xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+	http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-4.1.xsd
+	http://www.liquibase.org/xml/ns/dbchangelog-ext
+	http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-ext.xsd
+    http://www.liquibase.org/xml/ns/pro
+	http://www.liquibase.org/xml/ns/pro/liquibase-pro-4.1.xsd">
+
+    <changeSet id="14" author="ole4ryb">
+        <addColumn schemaName="public" tableName="migration_status_log">
+            <column name="error_code" type="varchar(255)">
+                <constraints nullable="true"/>
+            </column>
+        </addColumn>
+    </changeSet>
+</databaseChangeLog>

--- a/db-connector/src/main/java/uk/nhs/adaptors/connector/dao/MigrationStatusLogDao.java
+++ b/db-connector/src/main/java/uk/nhs/adaptors/connector/dao/MigrationStatusLogDao.java
@@ -17,7 +17,7 @@ public interface MigrationStatusLogDao {
     @UseClasspathSqlLocator
     void addMigrationStatusLog(@Bind("status") MigrationStatus status,
         @Bind("date") OffsetDateTime date, @Bind("migrationRequestId") int migrationRequestId,
-        @Bind("messageId") String messageId, @Bind("errorCode") String errorCode
+        @Bind("messageId") String messageId, @Bind("gp2gpErrorCode") String gp2gpErrorCode
     );
 
     @SqlQuery("select_migration_status_log")

--- a/db-connector/src/main/java/uk/nhs/adaptors/connector/dao/MigrationStatusLogDao.java
+++ b/db-connector/src/main/java/uk/nhs/adaptors/connector/dao/MigrationStatusLogDao.java
@@ -16,7 +16,8 @@ public interface MigrationStatusLogDao {
     @SqlUpdate("insert_migration_status_log")
     @UseClasspathSqlLocator
     void addMigrationStatusLog(@Bind("status") MigrationStatus status,
-        @Bind("date") OffsetDateTime date, @Bind("migrationRequestId") int migrationRequestId, @Bind("messageId") String messageId
+        @Bind("date") OffsetDateTime date, @Bind("migrationRequestId") int migrationRequestId,
+        @Bind("messageId") String messageId, @Bind("errorCode") String errorCode
     );
 
     @SqlQuery("select_migration_status_log")

--- a/db-connector/src/main/java/uk/nhs/adaptors/connector/model/MigrationStatusLog.java
+++ b/db-connector/src/main/java/uk/nhs/adaptors/connector/model/MigrationStatusLog.java
@@ -13,11 +13,12 @@ import uk.nhs.adaptors.common.enums.MigrationStatus;
 @Setter
 @Builder
 public class MigrationStatusLog {
+
     private int id;
     @EnumByName
     private MigrationStatus migrationStatus;
     private OffsetDateTime date;
     private int migrationRequestId;
     private String messageId;
-    private String errorCode;
+    private String gp2gpErrorCode;
 }

--- a/db-connector/src/main/java/uk/nhs/adaptors/connector/model/MigrationStatusLog.java
+++ b/db-connector/src/main/java/uk/nhs/adaptors/connector/model/MigrationStatusLog.java
@@ -19,4 +19,5 @@ public class MigrationStatusLog {
     private OffsetDateTime date;
     private int migrationRequestId;
     private String messageId;
+    private String errorCode;
 }

--- a/db-connector/src/main/java/uk/nhs/adaptors/connector/service/MigrationStatusLogService.java
+++ b/db-connector/src/main/java/uk/nhs/adaptors/connector/service/MigrationStatusLogService.java
@@ -17,18 +17,22 @@ import java.util.List;
 @Service
 @AllArgsConstructor(onConstructor = @__(@Autowired))
 public class MigrationStatusLogService {
+
     private final PatientMigrationRequestDao patientMigrationRequestDao;
     private final MigrationStatusLogDao migrationStatusLogDao;
     private final DateUtils dateUtils;
 
-    public void addMigrationStatusLog(MigrationStatus migrationStatus, String conversationId, String messageId) {
+    public void addMigrationStatusLog(MigrationStatus migrationStatus, String conversationId, String messageId, String errorCode) {
+
         int migrationRequestId = patientMigrationRequestDao.getMigrationRequestId(conversationId);
         migrationStatusLogDao.addMigrationStatusLog(
             migrationStatus,
             dateUtils.getCurrentOffsetDateTime(),
             migrationRequestId,
-            messageId
+            messageId,
+            errorCode
         );
+
         LOGGER.debug("Changed MigrationStatus of PatientMigrationRequest with id=[{}] to [{}]", migrationRequestId, migrationStatus.name());
     }
 
@@ -45,6 +49,6 @@ public class MigrationStatusLogService {
     public void updatePatientMigrationRequestAndAddMigrationStatusLog(String conversationId, String bundle, String inboundMessage,
         MigrationStatus migrationStatus, String messageId) {
         patientMigrationRequestDao.saveBundleAndInboundMessageData(conversationId, bundle, inboundMessage);
-        addMigrationStatusLog(migrationStatus, conversationId, messageId);
+        addMigrationStatusLog(migrationStatus, conversationId, messageId, null);
     }
 }

--- a/db-connector/src/main/java/uk/nhs/adaptors/connector/service/MigrationStatusLogService.java
+++ b/db-connector/src/main/java/uk/nhs/adaptors/connector/service/MigrationStatusLogService.java
@@ -22,7 +22,7 @@ public class MigrationStatusLogService {
     private final MigrationStatusLogDao migrationStatusLogDao;
     private final DateUtils dateUtils;
 
-    public void addMigrationStatusLog(MigrationStatus migrationStatus, String conversationId, String messageId, String errorCode) {
+    public void addMigrationStatusLog(MigrationStatus migrationStatus, String conversationId, String messageId, String gp2gpErrorCode) {
 
         int migrationRequestId = patientMigrationRequestDao.getMigrationRequestId(conversationId);
         migrationStatusLogDao.addMigrationStatusLog(
@@ -30,7 +30,7 @@ public class MigrationStatusLogService {
             dateUtils.getCurrentOffsetDateTime(),
             migrationRequestId,
             messageId,
-            errorCode
+            gp2gpErrorCode
         );
 
         LOGGER.debug("Changed MigrationStatus of PatientMigrationRequest with id=[{}] to [{}]", migrationRequestId, migrationStatus.name());

--- a/db-connector/src/main/resources/uk/nhs/adaptors/connector/dao/MigrationStatusLogDao/insert_migration_status_log.sql
+++ b/db-connector/src/main/resources/uk/nhs/adaptors/connector/dao/MigrationStatusLogDao/insert_migration_status_log.sql
@@ -1,2 +1,2 @@
-INSERT INTO migration_status_log(status, date, migration_request_id, message_id)
-VALUES (:status, :date, :migrationRequestId, :messageId);
+INSERT INTO migration_status_log(status, date, migration_request_id, message_id, error_code)
+VALUES (:status, :date, :migrationRequestId, :messageId, :errorCode);

--- a/db-connector/src/main/resources/uk/nhs/adaptors/connector/dao/MigrationStatusLogDao/insert_migration_status_log.sql
+++ b/db-connector/src/main/resources/uk/nhs/adaptors/connector/dao/MigrationStatusLogDao/insert_migration_status_log.sql
@@ -1,2 +1,2 @@
-INSERT INTO migration_status_log(status, date, migration_request_id, message_id, error_code)
-VALUES (:status, :date, :migrationRequestId, :messageId, :errorCode);
+INSERT INTO migration_status_log(status, date, migration_request_id, message_id, gp2gp_error_code)
+VALUES (:status, :date, :migrationRequestId, :messageId, :gp2gpErrorCode);

--- a/db-connector/src/test/java/uk/nhs/adaptors/connector/service/MigrationStatusLogServiceTest.java
+++ b/db-connector/src/test/java/uk/nhs/adaptors/connector/service/MigrationStatusLogServiceTest.java
@@ -42,6 +42,6 @@ public class MigrationStatusLogServiceTest {
 
         migrationStatusLogService.addMigrationStatusLog(MigrationStatus.MIGRATION_COMPLETED, nhsNumber, null, null);
 
-        verify(migrationStatusLogDao).addMigrationStatusLog(MigrationStatus.MIGRATION_COMPLETED, now, MIGRATION_REQUEST_ID, null);
+        verify(migrationStatusLogDao).addMigrationStatusLog(MigrationStatus.MIGRATION_COMPLETED, now, MIGRATION_REQUEST_ID, null, null);
     }
 }

--- a/db-connector/src/test/java/uk/nhs/adaptors/connector/service/MigrationStatusLogServiceTest.java
+++ b/db-connector/src/test/java/uk/nhs/adaptors/connector/service/MigrationStatusLogServiceTest.java
@@ -40,7 +40,7 @@ public class MigrationStatusLogServiceTest {
         when(patientMigrationRequestDao.getMigrationRequestId(nhsNumber)).thenReturn(MIGRATION_REQUEST_ID);
         when(dateUtils.getCurrentOffsetDateTime()).thenReturn(now);
 
-        migrationStatusLogService.addMigrationStatusLog(MigrationStatus.MIGRATION_COMPLETED, nhsNumber, null);
+        migrationStatusLogService.addMigrationStatusLog(MigrationStatus.MIGRATION_COMPLETED, nhsNumber, null, null);
 
         verify(migrationStatusLogDao).addMigrationStatusLog(MigrationStatus.MIGRATION_COMPLETED, now, MIGRATION_REQUEST_ID, null);
     }

--- a/gp2gp-translator/src/integrationTest/java/uk/nhs/adaptors/pss/translator/AcknowledgeMessageHandlingIT.java
+++ b/gp2gp-translator/src/integrationTest/java/uk/nhs/adaptors/pss/translator/AcknowledgeMessageHandlingIT.java
@@ -52,6 +52,7 @@ public class AcknowledgeMessageHandlingIT {
     private static final String ERROR_REASON_MESSAGE_PLACEHOLDER = "{{reasonMessage}}";
     private static final String LOSING_ODS_CODE = "K547";
     private static final String WINNING_ODS_CODE = "ABC";
+    public static final String TEST_ERROR_MESSAGE = "Test Error Message";
 
     @Autowired
     private PatientMigrationRequestDao patientMigrationRequestDao;
@@ -72,7 +73,7 @@ public class AcknowledgeMessageHandlingIT {
     public void setUp() {
         conversationId = generateConversationId().toUpperCase(Locale.ROOT);
         patientMigrationRequestDao.addNewRequest(generatePatientNhsNumber(), conversationId, LOSING_ODS_CODE, WINNING_ODS_CODE);
-        migrationStatusLogService.addMigrationStatusLog(EHR_EXTRACT_REQUEST_ACCEPTED, conversationId, null);
+        migrationStatusLogService.addMigrationStatusLog(EHR_EXTRACT_REQUEST_ACCEPTED, conversationId, null, null);
     }
 
     @Test
@@ -93,7 +94,7 @@ public class AcknowledgeMessageHandlingIT {
 
     @Test
     public void handleNegativeAcknowledgeMessageWithUndeclairedErrorReasonFromQueue() {
-        sendAcknowledgementMessageToQueue("AE", "101", "Test Error Message");
+        sendAcknowledgementMessageToQueue("AE", "101", TEST_ERROR_MESSAGE);
 
         // verify if correct status is set in the DB
         await().until(() -> isCorrectStatusSet(EHR_EXTRACT_REQUEST_NEGATIVE_ACK_UNKNOWN));
@@ -101,7 +102,7 @@ public class AcknowledgeMessageHandlingIT {
 
     @Test
     public void handleNegativeAcknowledgeMessageWithUnknownErrorReasonFromQueue() {
-        sendAcknowledgementMessageToQueue("AE", "99", "Test Error Message");
+        sendAcknowledgementMessageToQueue("AE", "99", TEST_ERROR_MESSAGE);
 
         // verify if correct status is set in the DB
         await().until(() -> isCorrectStatusSet(EHR_EXTRACT_REQUEST_NEGATIVE_ACK_UNKNOWN));
@@ -109,7 +110,7 @@ public class AcknowledgeMessageHandlingIT {
 
     @Test
     public void handleNegativeAcknowledgeMessageWithPatientNotRegisteredErrorReasonFromQueue() {
-        sendAcknowledgementMessageToQueue("AE", "06", "Test Error Message");
+        sendAcknowledgementMessageToQueue("AE", "06", TEST_ERROR_MESSAGE);
 
         // verify if correct status is set in the DB
         await().until(() -> isCorrectStatusSet(EHR_EXTRACT_REQUEST_NEGATIVE_ACK_GP2GP_PATIENT_NOT_REGISTERED));
@@ -117,7 +118,7 @@ public class AcknowledgeMessageHandlingIT {
 
     @Test
     public void handleNegativeAcknowledgeMessageWithSENDERNOTCONFIGUREDErrorReasonFromQueue() {
-        sendAcknowledgementMessageToQueue("AE", "07", "Test Error Message");
+        sendAcknowledgementMessageToQueue("AE", "07", TEST_ERROR_MESSAGE);
 
         // verify if correct status is set in the DB
         await().until(() -> isCorrectStatusSet(EHR_EXTRACT_REQUEST_NEGATIVE_ACK_GP2GP_SENDER_NOT_CONFIGURED));
@@ -125,7 +126,7 @@ public class AcknowledgeMessageHandlingIT {
 
     @Test
     public void handleNegativeAcknowledgeMessageWithEHRGENERATIONErrorReasonFromQueue() {
-        sendAcknowledgementMessageToQueue("AE", "10", "Test Error Message");
+        sendAcknowledgementMessageToQueue("AE", "10", TEST_ERROR_MESSAGE);
 
         // verify if correct status is set in the DB
         await().until(() -> isCorrectStatusSet(EHR_EXTRACT_REQUEST_NEGATIVE_ACK_GP2GP_EHR_GENERATION_ERROR));
@@ -133,7 +134,7 @@ public class AcknowledgeMessageHandlingIT {
 
     @Test
     public void handleNegativeAcknowledgeMessageWithMISFORMEDREQUESTErrorReasonFromQueue() {
-        sendAcknowledgementMessageToQueue("AE", "18", "Test Error Message");
+        sendAcknowledgementMessageToQueue("AE", "18", TEST_ERROR_MESSAGE);
 
         // verify if correct status is set in the DB
         await().until(() -> isCorrectStatusSet(EHR_EXTRACT_REQUEST_NEGATIVE_ACK_GP2GP_MISFORMED_REQUEST));
@@ -141,7 +142,7 @@ public class AcknowledgeMessageHandlingIT {
 
     @Test
     public void handleNegativeAcknowledgeMessageWithNOTPRIMARYHEALTHCAREPROVIDERErrorReasonFromQueue() {
-        sendAcknowledgementMessageToQueue("AE", "19", "Test Error Message");
+        sendAcknowledgementMessageToQueue("AE", "19", TEST_ERROR_MESSAGE);
 
         // verify if correct status is set in the DB
         await().until(() -> isCorrectStatusSet(EHR_EXTRACT_REQUEST_NEGATIVE_ACK_GP2GP_NOT_PRIMARY_HEALTHCARE_PROVIDER));
@@ -149,7 +150,7 @@ public class AcknowledgeMessageHandlingIT {
 
     @Test
     public void handleNegativeAcknowledgeMessageWithMULTIORNORESPONSESErrorReasonFromQueue() {
-        sendAcknowledgementMessageToQueue("AE", "24", "Test Error Message");
+        sendAcknowledgementMessageToQueue("AE", "24", TEST_ERROR_MESSAGE);
 
         // verify if correct status is set in the DB
         await().until(() -> isCorrectStatusSet(EHR_EXTRACT_REQUEST_NEGATIVE_ACK_GP2GP_MULTI_OR_NO_RESPONSES));

--- a/gp2gp-translator/src/integrationTest/java/uk/nhs/adaptors/pss/translator/E2EMappingIT.java
+++ b/gp2gp-translator/src/integrationTest/java/uk/nhs/adaptors/pss/translator/E2EMappingIT.java
@@ -1,14 +1,11 @@
 package uk.nhs.adaptors.pss.translator;
 
-import static org.assertj.core.api.Assertions.fail;
 import static org.awaitility.Awaitility.await;
 
 import static uk.nhs.adaptors.common.util.FileUtil.readResourceAsString;
 import static uk.nhs.adaptors.pss.translator.util.XmlUnmarshallUtil.unmarshallString;
 import static uk.nhs.adaptors.pss.util.JsonPathIgnoreGeneratorUtil.generateJsonPathIgnores;
 
-import java.io.PrintWriter;
-import java.nio.charset.StandardCharsets;
 import java.util.List;
 import java.util.Locale;
 import java.util.stream.Stream;
@@ -21,10 +18,6 @@ import org.json.JSONException;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
-import org.skyscreamer.jsonassert.Customization;
-import org.skyscreamer.jsonassert.JSONAssert;
-import org.skyscreamer.jsonassert.JSONCompareMode;
-import org.skyscreamer.jsonassert.comparator.CustomComparator;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;

--- a/gp2gp-translator/src/integrationTest/java/uk/nhs/adaptors/pss/translator/E2EMappingIT.java
+++ b/gp2gp-translator/src/integrationTest/java/uk/nhs/adaptors/pss/translator/E2EMappingIT.java
@@ -47,7 +47,6 @@ import uk.nhs.adaptors.pss.util.BaseEhrHandler;
 public class E2EMappingIT extends BaseEhrHandler {
 
     private static final boolean OVERWRITE_EXPECTED_JSON = false;
-    private static final int NHS_NUMBER_MIN_MAX_LENGTH = 10;
     private static final String PSS_ADAPTOR_URL = "https://PSSAdaptor/";
     private static final String EBXML_PART_PATH = "/xml/RCMR_IN030000UK06/ebxml_part.xml";
     //these are programming language special characters, not to be confused with line endings
@@ -348,28 +347,4 @@ public class E2EMappingIT extends BaseEhrHandler {
         return expectedBundle.substring(startIndex, endIndex);
     }
 
-    private String getLocationToBeReplaced(String expectedBundle) {
-        var startIndex = expectedBundle.toLowerCase().indexOf(PSS_ADAPTOR_URL.toLowerCase()) + PSS_ADAPTOR_URL.length();
-        var endIndex = expectedBundle.toLowerCase().indexOf("\"", startIndex);
-
-        return expectedBundle.substring(startIndex, endIndex);
-    }
-
-    @SneakyThrows
-    private void overwriteExpectJson(String newExpected) {
-        try (PrintWriter printWriter = new PrintWriter("src/integrationTest/resources/json/expectedBundle.json", StandardCharsets.UTF_8)) {
-            printWriter.print(newExpected);
-        }
-        fail("Re-run the tests with OVERWRITE_EXPECTED_JSON=false");
-    }
-
-    private void assertBundleContent(String actual, String expected, List<String> ignoredPaths) throws JSONException {
-        // when comparing json objects, this will ignore various json paths that contain random values like ids or timestamps
-        var customizations = ignoredPaths.stream()
-                .map(jsonPath -> new Customization(jsonPath, (o1, o2) -> true))
-                .toArray(Customization[]::new);
-
-        JSONAssert.assertEquals(expected, actual,
-                new CustomComparator(JSONCompareMode.STRICT, customizations));
-    }
 }

--- a/gp2gp-translator/src/integrationTest/java/uk/nhs/adaptors/pss/translator/EhrExtractHandlingIT.java
+++ b/gp2gp-translator/src/integrationTest/java/uk/nhs/adaptors/pss/translator/EhrExtractHandlingIT.java
@@ -138,7 +138,7 @@ public class EhrExtractHandlingIT {
 
     private void startPatientMigrationJourney() {
         patientMigrationRequestDao.addNewRequest(patientNhsNumber, conversationId, LOSING_ODS_CODE, WINNING_ODS_CODE);
-        migrationStatusLogService.addMigrationStatusLog(EHR_EXTRACT_REQUEST_ACCEPTED, conversationId, null);
+        migrationStatusLogService.addMigrationStatusLog(EHR_EXTRACT_REQUEST_ACCEPTED, conversationId, null, null);
     }
 
     private String generatePatientNhsNumber() {

--- a/gp2gp-translator/src/integrationTest/java/uk/nhs/adaptors/pss/translator/FailedProcessHandingIT.java
+++ b/gp2gp-translator/src/integrationTest/java/uk/nhs/adaptors/pss/translator/FailedProcessHandingIT.java
@@ -107,7 +107,7 @@ public class FailedProcessHandingIT extends BaseEhrHandler {
 
     @Test
     public void When_ProcessFailedByNME_With_EhrExtract_Expect_NotProcessed() {
-        migrationStatusLogService.addMigrationStatusLog(EHR_GENERAL_PROCESSING_ERROR, getConversationId(), null);
+        migrationStatusLogService.addMigrationStatusLog(EHR_GENERAL_PROCESSING_ERROR, getConversationId(), null, "99");
 
         sendEhrExtractToQueue();
 
@@ -133,7 +133,7 @@ public class FailedProcessHandingIT extends BaseEhrHandler {
 
         await().until(this::isContinueRequestAccepted);
 
-        migrationStatusLogService.addMigrationStatusLog(preCopcMigrationStatus, getConversationId(), null);
+        migrationStatusLogService.addMigrationStatusLog(preCopcMigrationStatus, getConversationId(), null, null);
 
         sendCopcToQueue();
 

--- a/gp2gp-translator/src/integrationTest/java/uk/nhs/adaptors/pss/translator/amqp/ServiceFailureIT.java
+++ b/gp2gp-translator/src/integrationTest/java/uk/nhs/adaptors/pss/translator/amqp/ServiceFailureIT.java
@@ -319,7 +319,7 @@ public class ServiceFailureIT extends BaseEhrHandler {
         getPatientMigrationRequestDao()
             .addNewRequest(patientNhsNumber, conversationId, getLosingODSCode(), getWiningODSCode());
         getMigrationStatusLogService()
-            .addMigrationStatusLog(REQUEST_RECEIVED, conversationId, null);
+            .addMigrationStatusLog(REQUEST_RECEIVED, conversationId, null, null);
 
         var transferRequestMessage = TransferRequestMessage.builder()
             .patientNhsNumber(patientNhsNumber)

--- a/gp2gp-translator/src/integrationTest/java/uk/nhs/adaptors/pss/util/BaseEhrHandler.java
+++ b/gp2gp-translator/src/integrationTest/java/uk/nhs/adaptors/pss/util/BaseEhrHandler.java
@@ -118,14 +118,14 @@ public abstract class BaseEhrHandler {
     }
 
     @SneakyThrows
-    private void overwriteExpectJson(String newExpected) {
+    protected void overwriteExpectJson(String newExpected) {
         try (PrintWriter printWriter = new PrintWriter("src/integrationTest/resources/json/expectedBundle.json", StandardCharsets.UTF_8)) {
             printWriter.print(newExpected);
         }
         fail("Re-run the tests with OVERWRITE_EXPECTED_JSON=false");
     }
 
-    private void assertBundleContent(String actual, String expected, List<String> ignoredPaths) throws JSONException {
+    protected void assertBundleContent(String actual, String expected, List<String> ignoredPaths) throws JSONException {
         // when comparing json objects, this will ignore various json paths that contain random values like ids or timestamps
         var customizations = ignoredPaths.stream()
             .map(jsonPath -> new Customization(jsonPath, (o1, o2) -> true))

--- a/gp2gp-translator/src/integrationTest/java/uk/nhs/adaptors/pss/util/BaseEhrHandler.java
+++ b/gp2gp-translator/src/integrationTest/java/uk/nhs/adaptors/pss/util/BaseEhrHandler.java
@@ -83,7 +83,7 @@ public abstract class BaseEhrHandler {
 
     protected void startPatientMigrationJourney() {
         patientMigrationRequestDao.addNewRequest(patientNhsNumber, conversationId, losingODSCode, winingODSCode);
-        migrationStatusLogService.addMigrationStatusLog(EHR_EXTRACT_REQUEST_ACCEPTED, conversationId, null);
+        migrationStatusLogService.addMigrationStatusLog(EHR_EXTRACT_REQUEST_ACCEPTED, conversationId, null, null);
     }
 
     protected boolean isEhrExtractTranslated() {

--- a/gp2gp-translator/src/main/java/uk/nhs/adaptors/pss/translator/model/NACKReason.java
+++ b/gp2gp-translator/src/main/java/uk/nhs/adaptors/pss/translator/model/NACKReason.java
@@ -17,6 +17,7 @@ import uk.nhs.adaptors.common.enums.MigrationStatus;
 
 @RequiredArgsConstructor
 public enum NACKReason {
+
     LARGE_MESSAGE_REASSEMBLY_FAILURE("29"),
     LARGE_MESSAGE_ATTACHMENTS_NOT_RECEIVED("31"),
     LARGE_MESSAGE_GENERAL_FAILURE("30"),

--- a/gp2gp-translator/src/main/java/uk/nhs/adaptors/pss/translator/model/NACKReason.java
+++ b/gp2gp-translator/src/main/java/uk/nhs/adaptors/pss/translator/model/NACKReason.java
@@ -4,6 +4,7 @@ import static uk.nhs.adaptors.common.enums.MigrationStatus.EHR_EXTRACT_NEGATIVE_
 import static uk.nhs.adaptors.common.enums.MigrationStatus.EHR_EXTRACT_NEGATIVE_ACK_FAILED_TO_INTEGRATE;
 import static uk.nhs.adaptors.common.enums.MigrationStatus.EHR_EXTRACT_NEGATIVE_ACK_NON_ABA_INCORRECT_PATIENT;
 import static uk.nhs.adaptors.common.enums.MigrationStatus.EHR_EXTRACT_NEGATIVE_ACK_SUPPRESSED;
+import static uk.nhs.adaptors.common.enums.MigrationStatus.EHR_EXTRACT_REQUEST_NEGATIVE_ACK_GP2GP_PATIENT_NOT_REGISTERED;
 import static uk.nhs.adaptors.common.enums.MigrationStatus.EHR_GENERAL_PROCESSING_ERROR;
 import static uk.nhs.adaptors.common.enums.MigrationStatus.ERROR_EXTRACT_CANNOT_BE_PROCESSED;
 import static uk.nhs.adaptors.common.enums.MigrationStatus.ERROR_LRG_MSG_ATTACHMENTS_NOT_RECEIVED;
@@ -27,6 +28,7 @@ public enum NACKReason {
     UNEXPECTED_CONDITION("99"),
     ABA_EHR_EXTRACT_REJECTED_WRONG_PATIENT("17"),
     ABA_EHR_EXTRACT_SUPPRESSED("15"),
+    PATIENT_NOT_AT_SURGERY("06"),
     NON_ABA_EHR_EXTRACT_REJECTED_WRONG_PATIENT("28");
 
     @Getter
@@ -44,6 +46,7 @@ public enum NACKReason {
             case ABA_EHR_EXTRACT_SUPPRESSED  ->  EHR_EXTRACT_NEGATIVE_ACK_SUPPRESSED;
             case ABA_EHR_EXTRACT_REJECTED_WRONG_PATIENT -> EHR_EXTRACT_NEGATIVE_ACK_ABA_INCORRECT_PATIENT;
             case NON_ABA_EHR_EXTRACT_REJECTED_WRONG_PATIENT -> EHR_EXTRACT_NEGATIVE_ACK_NON_ABA_INCORRECT_PATIENT;
+            case PATIENT_NOT_AT_SURGERY -> EHR_EXTRACT_REQUEST_NEGATIVE_ACK_GP2GP_PATIENT_NOT_REGISTERED;
         };
     }
 }

--- a/gp2gp-translator/src/main/java/uk/nhs/adaptors/pss/translator/service/InboundMessageMergingService.java
+++ b/gp2gp-translator/src/main/java/uk/nhs/adaptors/pss/translator/service/InboundMessageMergingService.java
@@ -114,7 +114,7 @@ public class InboundMessageMergingService {
                     EHR_EXTRACT_TRANSLATED,
                     null
             );
-            migrationStatusLogService.addMigrationStatusLog(MIGRATION_COMPLETED, conversationId, null);
+            migrationStatusLogService.addMigrationStatusLog(MIGRATION_COMPLETED, conversationId, null, null);
 
         } catch (InlineAttachmentProcessingException | SAXException | TransformerException
                  | JAXBException | AttachmentNotFoundException | JsonProcessingException e) {

--- a/gp2gp-translator/src/main/java/uk/nhs/adaptors/pss/translator/service/NackAckPreparationService.java
+++ b/gp2gp-translator/src/main/java/uk/nhs/adaptors/pss/translator/service/NackAckPreparationService.java
@@ -33,7 +33,7 @@ public class NackAckPreparationService {
         LOGGER.debug("Sending Final ACK message for Conversation ID: [{}]", conversationId);
 
         migrationStatusLogService.
-                addMigrationStatusLog(FINAL_ACK_SENT, conversationId, null);
+                addMigrationStatusLog(FINAL_ACK_SENT, conversationId, null, null);
 
         return sendACKMessageHandler.prepareAndSendMessage(prepareAckMessageData(
                 payload,
@@ -46,7 +46,7 @@ public class NackAckPreparationService {
         LOGGER.debug("Sending ACK message for COPC message with Conversation ID: [{}]", conversationId);
 
         migrationStatusLogService.
-                addMigrationStatusLog(COPC_ACKNOWLEDGED, conversationId, null);
+                addMigrationStatusLog(COPC_ACKNOWLEDGED, conversationId, null, null);
 
         return sendACKMessageHandler.prepareAndSendMessage(prepareAckMessageData(
                 payload,
@@ -132,7 +132,7 @@ public class NackAckPreparationService {
         LOGGER.debug("Sending NACK message with acknowledgement code [{}] for message EHR Extract message [{}]", reason.getCode(),
                 payload.getId().getRoot());
 
-        migrationStatusLogService.addMigrationStatusLog(reason.getMigrationStatus(), conversationId, null);
+        migrationStatusLogService.addMigrationStatusLog(reason.getMigrationStatus(), conversationId, null, reason.getCode());
 
         return sendNACKMessageHandler.prepareAndSendMessage(prepareNackMessageData(
                 reason,
@@ -146,7 +146,7 @@ public class NackAckPreparationService {
         LOGGER.debug("Sending NACK message with acknowledgement code [{}] for message COPC message [{}]", reason.getCode(),
                 payload.getId().getRoot());
 
-        migrationStatusLogService.addMigrationStatusLog(reason.getMigrationStatus(), conversationId, null);
+        migrationStatusLogService.addMigrationStatusLog(reason.getMigrationStatus(), conversationId, null, reason.getCode());
 
         return sendNACKMessageHandler.prepareAndSendMessage(prepareNackMessageData(
                 reason,

--- a/gp2gp-translator/src/main/java/uk/nhs/adaptors/pss/translator/task/AcknowledgmentMessageHandler.java
+++ b/gp2gp-translator/src/main/java/uk/nhs/adaptors/pss/translator/task/AcknowledgmentMessageHandler.java
@@ -78,7 +78,7 @@ public class AcknowledgmentMessageHandler {
             return;
         }
 
-        if(negativeAckError) {
+        if (negativeAckError) {
             migrationStatusLogService.addMigrationStatusLog(newMigrationStatus, conversationId, null, nackReasonCode);
         } else {
             migrationStatusLogService.addMigrationStatusLog(newMigrationStatus, conversationId, null, null);

--- a/gp2gp-translator/src/main/java/uk/nhs/adaptors/pss/translator/task/AcknowledgmentMessageHandler.java
+++ b/gp2gp-translator/src/main/java/uk/nhs/adaptors/pss/translator/task/AcknowledgmentMessageHandler.java
@@ -51,7 +51,8 @@ public class AcknowledgmentMessageHandler {
             return;
         }
 
-        if (NACK_ERROR_TYPE_CODE.equals(ackTypeCode) || NACK_REJECT_TYPE_CODE.equals(ackTypeCode)) {
+        var negativeAckError = isNegativeAckError(ackTypeCode);
+        if (negativeAckError) {
             nackReasonCode = xPathService.getNodeValue(document, NACK_REASON_CODE_PATH);
             if (nackReasonCode == null) {
                 nackReasonCode = "";
@@ -77,7 +78,15 @@ public class AcknowledgmentMessageHandler {
             return;
         }
 
-        migrationStatusLogService.addMigrationStatusLog(newMigrationStatus, conversationId, null);
+        if(negativeAckError) {
+            migrationStatusLogService.addMigrationStatusLog(newMigrationStatus, conversationId, null, nackReasonCode);
+        } else {
+            migrationStatusLogService.addMigrationStatusLog(newMigrationStatus, conversationId, null, null);
+        }
+    }
+
+    private static boolean isNegativeAckError(String ackTypeCode) {
+        return NACK_ERROR_TYPE_CODE.equals(ackTypeCode) || NACK_REJECT_TYPE_CODE.equals(ackTypeCode);
     }
 
     private MigrationStatus getMigrationStatus(String ackTypeCode, String reasonCode) {

--- a/gp2gp-translator/src/main/java/uk/nhs/adaptors/pss/translator/task/AcknowledgmentMessageHandler.java
+++ b/gp2gp-translator/src/main/java/uk/nhs/adaptors/pss/translator/task/AcknowledgmentMessageHandler.java
@@ -41,6 +41,7 @@ public class AcknowledgmentMessageHandler {
     private final FailedProcessHandlingService failedProcessHandlingService;
 
     public void handleMessage(InboundMessage inboundMessage, String conversationId) throws SAXException {
+
         Document document = xPathService.parseDocumentFromXml(inboundMessage.getPayload());
         String ackTypeCode = xPathService.getNodeValue(document, ACK_TYPE_CODE_XPATH);
         String nackReasonCode = null;
@@ -50,7 +51,7 @@ public class AcknowledgmentMessageHandler {
             return;
         }
 
-        if (ackTypeCode.equals(NACK_ERROR_TYPE_CODE) || ackTypeCode.equals(NACK_REJECT_TYPE_CODE)) {
+        if (NACK_ERROR_TYPE_CODE.equals(ackTypeCode) || NACK_REJECT_TYPE_CODE.equals(ackTypeCode)) {
             nackReasonCode = xPathService.getNodeValue(document, NACK_REASON_CODE_PATH);
             if (nackReasonCode == null) {
                 nackReasonCode = "";
@@ -65,10 +66,10 @@ public class AcknowledgmentMessageHandler {
             return;
         }
 
-        if (currentMigrationStatus.equals(FINAL_ACK_SENT) || currentMigrationStatus.equals(MIGRATION_COMPLETED)) {
+        if (FINAL_ACK_SENT.equals(currentMigrationStatus) || MIGRATION_COMPLETED.equals(currentMigrationStatus)) {
             var loggerMessage = "Received an ack with type code {}, but the migration is complete";
 
-            if (currentMigrationStatus.equals(FINAL_ACK_SENT)) {
+            if (FINAL_ACK_SENT.equals(currentMigrationStatus)) {
                 loggerMessage = loggerMessage + " and the EHR has been accepted";
             }
 

--- a/gp2gp-translator/src/main/java/uk/nhs/adaptors/pss/translator/task/COPCMessageHandler.java
+++ b/gp2gp-translator/src/main/java/uk/nhs/adaptors/pss/translator/task/COPCMessageHandler.java
@@ -149,8 +149,10 @@ public class COPCMessageHandler {
                 failMigration(conversationId, UNEXPECTED_CONDITION);
             } else {
                 failMigration(conversationId, LARGE_MESSAGE_ATTACHMENTS_NOT_RECEIVED);
-                migrationStatusLogService.addMigrationStatusLog(
-                    LARGE_MESSAGE_ATTACHMENTS_NOT_RECEIVED.getMigrationStatus(), conversationId, null, "31");
+                migrationStatusLogService.addMigrationStatusLog(LARGE_MESSAGE_ATTACHMENTS_NOT_RECEIVED.getMigrationStatus(),
+                                                                conversationId,
+                                                                null,
+                                                                LARGE_MESSAGE_ATTACHMENTS_NOT_RECEIVED.getCode());
             }
 
         } catch (ExternalAttachmentProcessingException e) {

--- a/gp2gp-translator/src/main/java/uk/nhs/adaptors/pss/translator/task/COPCMessageHandler.java
+++ b/gp2gp-translator/src/main/java/uk/nhs/adaptors/pss/translator/task/COPCMessageHandler.java
@@ -90,13 +90,13 @@ public class COPCMessageHandler {
         }
 
         PatientMigrationRequest migrationRequest = migrationRequestDao.getMigrationRequest(conversationId);
-        migrationStatusLogService.addMigrationStatusLog(COPC_MESSAGE_RECEIVED, conversationId, null);
+        migrationStatusLogService.addMigrationStatusLog(COPC_MESSAGE_RECEIVED, conversationId, null, null);
 
         try {
             Document ebXmlDocument = getEbXmlDocument(inboundMessage);
             String messageId = xPathService.getNodeValue(ebXmlDocument, MESSAGE_ID_PATH);
             PatientAttachmentLog patientAttachmentLog = patientAttachmentLogService.findAttachmentLog(messageId, conversationId);
-            migrationStatusLogService.addMigrationStatusLog(COPC_MESSAGE_PROCESSING, conversationId, messageId);
+            migrationStatusLogService.addMigrationStatusLog(COPC_MESSAGE_PROCESSING, conversationId, messageId, null);
 
             // If there is no PatientAttachmentLog for this message then we have received a message out of order
             if (patientAttachmentLog == null) {
@@ -150,7 +150,7 @@ public class COPCMessageHandler {
             } else {
                 failMigration(conversationId, LARGE_MESSAGE_ATTACHMENTS_NOT_RECEIVED);
                 migrationStatusLogService.addMigrationStatusLog(
-                    LARGE_MESSAGE_ATTACHMENTS_NOT_RECEIVED.getMigrationStatus(), conversationId, null);
+                    LARGE_MESSAGE_ATTACHMENTS_NOT_RECEIVED.getMigrationStatus(), conversationId, null, "31");
             }
 
         } catch (ExternalAttachmentProcessingException e) {

--- a/gp2gp-translator/src/main/java/uk/nhs/adaptors/pss/translator/task/EhrExtractMessageHandler.java
+++ b/gp2gp-translator/src/main/java/uk/nhs/adaptors/pss/translator/task/EhrExtractMessageHandler.java
@@ -95,7 +95,7 @@ public class EhrExtractMessageHandler {
             return;
         }
 
-        migrationStatusLogService.addMigrationStatusLog(EHR_EXTRACT_RECEIVED, conversationId, null);
+        migrationStatusLogService.addMigrationStatusLog(EHR_EXTRACT_RECEIVED, conversationId, null, null);
 
         try {
             Document ebXmlDocument = getEbXmlDocument(inboundMessage);
@@ -211,7 +211,7 @@ public class EhrExtractMessageHandler {
             messageId
         );
 
-        migrationStatusLogService.addMigrationStatusLog(MIGRATION_COMPLETED, conversationId, null);
+        migrationStatusLogService.addMigrationStatusLog(MIGRATION_COMPLETED, conversationId, null, null);
     }
 
     private void processExternalAttachmentsAndSendContinueMessage(InboundMessage inboundMessage,

--- a/gp2gp-translator/src/main/java/uk/nhs/adaptors/pss/translator/task/MhsQueueMessageHandler.java
+++ b/gp2gp-translator/src/main/java/uk/nhs/adaptors/pss/translator/task/MhsQueueMessageHandler.java
@@ -94,7 +94,7 @@ public class MhsQueueMessageHandler {
             // Current child try catch blocks do not detect this condition so no failed migration log is added...
             // We are however unlikely to have a payload at this point so cannot send a NACK
             if (conversationId != null && !conversationId.isEmpty()) {
-                migrationStatusLogService.addMigrationStatusLog(EHR_GENERAL_PROCESSING_ERROR, conversationId, null);
+                migrationStatusLogService.addMigrationStatusLog(EHR_GENERAL_PROCESSING_ERROR, conversationId, null, "99");
             }
             return false;
         } catch (JsonProcessingException | DataFormatException e) {

--- a/gp2gp-translator/src/main/java/uk/nhs/adaptors/pss/translator/task/MhsQueueMessageHandler.java
+++ b/gp2gp-translator/src/main/java/uk/nhs/adaptors/pss/translator/task/MhsQueueMessageHandler.java
@@ -33,6 +33,7 @@ import uk.nhs.adaptors.pss.translator.exception.UnsupportedFileTypeException;
 import uk.nhs.adaptors.pss.translator.mhs.model.InboundMessage;
 import uk.nhs.adaptors.pss.translator.service.XPathService;
 import uk.nhs.adaptors.connector.service.MigrationStatusLogService;
+import static uk.nhs.adaptors.pss.translator.model.NACKReason.UNEXPECTED_CONDITION;
 
 import java.text.ParseException;
 import java.util.Locale;
@@ -94,7 +95,10 @@ public class MhsQueueMessageHandler {
             // Current child try catch blocks do not detect this condition so no failed migration log is added...
             // We are however unlikely to have a payload at this point so cannot send a NACK
             if (conversationId != null && !conversationId.isEmpty()) {
-                migrationStatusLogService.addMigrationStatusLog(EHR_GENERAL_PROCESSING_ERROR, conversationId, null, "99");
+                migrationStatusLogService.addMigrationStatusLog(EHR_GENERAL_PROCESSING_ERROR,
+                                                                conversationId,
+                                                                null,
+                                                                UNEXPECTED_CONDITION.getCode());
             }
             return false;
         } catch (JsonProcessingException | DataFormatException e) {

--- a/gp2gp-translator/src/main/java/uk/nhs/adaptors/pss/translator/task/SendContinueRequestHandler.java
+++ b/gp2gp-translator/src/main/java/uk/nhs/adaptors/pss/translator/task/SendContinueRequestHandler.java
@@ -41,7 +41,7 @@ public class SendContinueRequestHandler {
             mhsClientService.send(request);
         } catch (WebClientResponseException webClientResponseException) {
             LOGGER.error("Received an ERROR response from MHS: [{}]", webClientResponseException.getMessage());
-            migrationStatusLogService.addMigrationStatusLog(MigrationStatus.CONTINUE_REQUEST_ERROR, data.getConversationId(), null);
+            migrationStatusLogService.addMigrationStatusLog(MigrationStatus.CONTINUE_REQUEST_ERROR, data.getConversationId(), null, "8");
 
             if (webClientResponseException.getStatusCode().is5xxServerError()) {
                 throw new MhsServerErrorException("Unable to sent continue message");
@@ -51,6 +51,10 @@ public class SendContinueRequestHandler {
         }
 
         LOGGER.info("Got response from MHS - 202 Accepted");
-        migrationStatusLogService.addMigrationStatusLog(MigrationStatus.CONTINUE_REQUEST_ACCEPTED, data.getConversationId(), null);
+        migrationStatusLogService.addMigrationStatusLog(
+                MigrationStatus.CONTINUE_REQUEST_ACCEPTED,
+                data.getConversationId(),
+                null,
+                null);
     }
 }

--- a/gp2gp-translator/src/main/java/uk/nhs/adaptors/pss/translator/task/SendContinueRequestHandler.java
+++ b/gp2gp-translator/src/main/java/uk/nhs/adaptors/pss/translator/task/SendContinueRequestHandler.java
@@ -16,6 +16,7 @@ import uk.nhs.adaptors.pss.translator.model.ContinueRequestData;
 import uk.nhs.adaptors.pss.translator.service.ContinueRequestService;
 import uk.nhs.adaptors.pss.translator.service.IdGeneratorService;
 import uk.nhs.adaptors.pss.translator.service.MhsClientService;
+import static uk.nhs.adaptors.pss.translator.model.NACKReason.UNEXPECTED_CONDITION;
 
 @Slf4j
 @Component
@@ -41,7 +42,10 @@ public class SendContinueRequestHandler {
             mhsClientService.send(request);
         } catch (WebClientResponseException webClientResponseException) {
             LOGGER.error("Received an ERROR response from MHS: [{}]", webClientResponseException.getMessage());
-            migrationStatusLogService.addMigrationStatusLog(MigrationStatus.CONTINUE_REQUEST_ERROR, data.getConversationId(), null, "8");
+            migrationStatusLogService.addMigrationStatusLog(MigrationStatus.CONTINUE_REQUEST_ERROR,
+                                                            data.getConversationId(),
+                                                            null,
+                                                            UNEXPECTED_CONDITION.getCode());
 
             if (webClientResponseException.getStatusCode().is5xxServerError()) {
                 throw new MhsServerErrorException("Unable to sent continue message");

--- a/gp2gp-translator/src/main/java/uk/nhs/adaptors/pss/translator/task/SendEhrExtractRequestHandler.java
+++ b/gp2gp-translator/src/main/java/uk/nhs/adaptors/pss/translator/task/SendEhrExtractRequestHandler.java
@@ -15,6 +15,7 @@ import uk.nhs.adaptors.pss.translator.mhs.model.OutboundMessage;
 import uk.nhs.adaptors.pss.translator.service.EhrExtractRequestService;
 import uk.nhs.adaptors.pss.translator.service.IdGeneratorService;
 import uk.nhs.adaptors.pss.translator.service.MhsClientService;
+import static uk.nhs.adaptors.pss.translator.model.NACKReason.UNEXPECTED_CONDITION;
 
 @Slf4j
 @Component
@@ -43,7 +44,10 @@ public class SendEhrExtractRequestHandler {
             LOGGER.debug(response);
         } catch (WebClientResponseException wcre) {
             LOGGER.error("Received an ERROR response from MHS: [{}]", wcre.getMessage());
-            migrationStatusLogService.addMigrationStatusLog(MigrationStatus.EHR_EXTRACT_REQUEST_ERROR, conversationId, null, "2");
+            migrationStatusLogService.addMigrationStatusLog(MigrationStatus.EHR_EXTRACT_REQUEST_ERROR,
+                                                            conversationId,
+                                                            null,
+                                                            UNEXPECTED_CONDITION.getCode());
             return false;
         }
 

--- a/gp2gp-translator/src/main/java/uk/nhs/adaptors/pss/translator/task/SendEhrExtractRequestHandler.java
+++ b/gp2gp-translator/src/main/java/uk/nhs/adaptors/pss/translator/task/SendEhrExtractRequestHandler.java
@@ -43,12 +43,12 @@ public class SendEhrExtractRequestHandler {
             LOGGER.debug(response);
         } catch (WebClientResponseException wcre) {
             LOGGER.error("Received an ERROR response from MHS: [{}]", wcre.getMessage());
-            migrationStatusLogService.addMigrationStatusLog(MigrationStatus.EHR_EXTRACT_REQUEST_ERROR, conversationId, null);
+            migrationStatusLogService.addMigrationStatusLog(MigrationStatus.EHR_EXTRACT_REQUEST_ERROR, conversationId, null, "2");
             return false;
         }
 
         LOGGER.info("Got response from MHS - 202 Accepted");
-        migrationStatusLogService.addMigrationStatusLog(MigrationStatus.EHR_EXTRACT_REQUEST_ACCEPTED, conversationId, null);
+        migrationStatusLogService.addMigrationStatusLog(MigrationStatus.EHR_EXTRACT_REQUEST_ACCEPTED, conversationId, null, null);
         return true;
     }
 }

--- a/gp2gp-translator/src/main/java/uk/nhs/adaptors/pss/translator/task/scheduled/EHRTimeoutHandler.java
+++ b/gp2gp-translator/src/main/java/uk/nhs/adaptors/pss/translator/task/scheduled/EHRTimeoutHandler.java
@@ -124,7 +124,7 @@ public class EHRTimeoutHandler {
 
             if (timeoutDateTime.isBefore(currentTime)) {
                 LOGGER.info("Migration Request timed out at [{}]", timeoutDateTime);
-                migrationStatusLogService.addMigrationStatusLog(ERROR_REQUEST_TIMEOUT, conversationId, null);
+                migrationStatusLogService.addMigrationStatusLog(ERROR_REQUEST_TIMEOUT, conversationId, null, null);
             }
 
         } catch (SdsRetrievalException e) {
@@ -171,7 +171,7 @@ public class EHRTimeoutHandler {
             LOGGER.error("Error retrieving persist duration: [{}]", e.getMessage());
         } catch (JsonProcessingException | SAXException | DateTimeParseException | JAXBException e) {
             LOGGER.error("Error parsing inbound message from database");
-            migrationStatusLogService.addMigrationStatusLog(EHR_GENERAL_PROCESSING_ERROR, conversationId, null);
+            migrationStatusLogService.addMigrationStatusLog(EHR_GENERAL_PROCESSING_ERROR, conversationId, null, "99");
         } finally {
             mdcService.applyConversationId("");
         }
@@ -196,9 +196,9 @@ public class EHRTimeoutHandler {
 
             if (reason == LARGE_MESSAGE_ATTACHMENTS_NOT_RECEIVED) {
                 migrationStatusLogService
-                    .addMigrationStatusLog(LARGE_MESSAGE_TIMEOUT.getMigrationStatus(), conversationId, null);
+                    .addMigrationStatusLog(LARGE_MESSAGE_TIMEOUT.getMigrationStatus(), conversationId, null, reason.getCode());
             } else {
-                migrationStatusLogService.addMigrationStatusLog(reason.getMigrationStatus(), conversationId, null);
+                migrationStatusLogService.addMigrationStatusLog(reason.getMigrationStatus(), conversationId, null, reason.getCode());
             }
         }
     }

--- a/gp2gp-translator/src/main/java/uk/nhs/adaptors/pss/translator/task/scheduled/EHRTimeoutHandler.java
+++ b/gp2gp-translator/src/main/java/uk/nhs/adaptors/pss/translator/task/scheduled/EHRTimeoutHandler.java
@@ -171,7 +171,8 @@ public class EHRTimeoutHandler {
             LOGGER.error("Error retrieving persist duration: [{}]", e.getMessage());
         } catch (JsonProcessingException | SAXException | DateTimeParseException | JAXBException e) {
             LOGGER.error("Error parsing inbound message from database");
-            migrationStatusLogService.addMigrationStatusLog(EHR_GENERAL_PROCESSING_ERROR, conversationId, null, "99");
+            migrationStatusLogService
+                .addMigrationStatusLog(EHR_GENERAL_PROCESSING_ERROR, conversationId, null, UNEXPECTED_CONDITION.getCode());
         } finally {
             mdcService.applyConversationId("");
         }

--- a/gp2gp-translator/src/test/java/uk/nhs/adaptors/pss/translator/service/NackAckPreparationServiceTest.java
+++ b/gp2gp-translator/src/test/java/uk/nhs/adaptors/pss/translator/service/NackAckPreparationServiceTest.java
@@ -14,7 +14,14 @@ import static org.mockito.Mockito.when;
 import static uk.nhs.adaptors.common.enums.MigrationStatus.ERROR_EXTRACT_CANNOT_BE_PROCESSED;
 import static uk.nhs.adaptors.common.enums.MigrationStatus.ERROR_LRG_MSG_GENERAL_FAILURE;
 import static uk.nhs.adaptors.common.util.FileUtil.readResourceAsString;
+import static uk.nhs.adaptors.pss.translator.model.NACKReason.UNEXPECTED_CONDITION;
 import static uk.nhs.adaptors.pss.translator.util.XmlUnmarshallUtil.unmarshallString;
+import static uk.nhs.adaptors.pss.translator.model.NACKReason.LARGE_MESSAGE_GENERAL_FAILURE;
+import static uk.nhs.adaptors.pss.translator.model.NACKReason.LARGE_MESSAGE_TIMEOUT;
+import static uk.nhs.adaptors.pss.translator.model.NACKReason.CLINICAL_SYSTEM_INTEGRATION_FAILURE;
+import static uk.nhs.adaptors.pss.translator.model.NACKReason.EHR_EXTRACT_CANNOT_BE_PROCESSED;
+import static uk.nhs.adaptors.pss.translator.model.NACKReason.LARGE_MESSAGE_REASSEMBLY_FAILURE;
+import static uk.nhs.adaptors.pss.translator.model.NACKReason.LARGE_MESSAGE_ATTACHMENTS_NOT_RECEIVED;
 
 import javax.xml.bind.JAXBException;
 
@@ -37,6 +44,7 @@ import uk.nhs.adaptors.pss.translator.task.SendNACKMessageHandler;
 
 @ExtendWith(MockitoExtension.class)
 class NackAckPreparationServiceTest {
+
     private static final String NHS_NUMBER = "123456";
     private static final String CONVERSATION_ID = randomUUID().toString();
     private static final String TEST_TO_ODS = "M85019";
@@ -67,8 +75,9 @@ class NackAckPreparationServiceTest {
 
         when(sendNACKMessageHandler.prepareAndSendMessage(any(NACKMessageData.class))).thenReturn(true);
 
-        assertTrue(nackAckPreparationService.sendNackMessage(NACKReason.LARGE_MESSAGE_GENERAL_FAILURE, payload, CONVERSATION_ID));
-        verify(migrationStatusLogService).addMigrationStatusLog(ERROR_LRG_MSG_GENERAL_FAILURE, CONVERSATION_ID, null, "30");
+        assertTrue(nackAckPreparationService.sendNackMessage(LARGE_MESSAGE_GENERAL_FAILURE, payload, CONVERSATION_ID));
+        verify(migrationStatusLogService)
+            .addMigrationStatusLog(ERROR_LRG_MSG_GENERAL_FAILURE, CONVERSATION_ID, null, LARGE_MESSAGE_GENERAL_FAILURE.getCode());
     }
 
     @Test
@@ -79,7 +88,8 @@ class NackAckPreparationServiceTest {
         when(sendNACKMessageHandler.prepareAndSendMessage(any(NACKMessageData.class))).thenReturn(false);
 
         assertFalse(nackAckPreparationService.sendNackMessage(NACKReason.LARGE_MESSAGE_GENERAL_FAILURE, payload, CONVERSATION_ID));
-        verify(migrationStatusLogService).addMigrationStatusLog(ERROR_LRG_MSG_GENERAL_FAILURE, CONVERSATION_ID, null, "30");
+        verify(migrationStatusLogService)
+            .addMigrationStatusLog(ERROR_LRG_MSG_GENERAL_FAILURE, CONVERSATION_ID, null, LARGE_MESSAGE_GENERAL_FAILURE.getCode());
     }
 
     @Test
@@ -145,7 +155,7 @@ class NackAckPreparationServiceTest {
                 CONVERSATION_ID);
 
         verify(sendNACKMessageHandler).prepareAndSendMessage(ackMessageDataCaptor.capture());
-        assertEquals("30", ackMessageDataCaptor.getValue().getNackCode());
+        assertEquals(LARGE_MESSAGE_GENERAL_FAILURE.getCode(), ackMessageDataCaptor.getValue().getNackCode());
     }
 
     @Test
@@ -159,7 +169,7 @@ class NackAckPreparationServiceTest {
                 CONVERSATION_ID);
 
         verify(sendNACKMessageHandler).prepareAndSendMessage(ackMessageDataCaptor.capture());
-        assertEquals("25", ackMessageDataCaptor.getValue().getNackCode());
+        assertEquals(LARGE_MESSAGE_TIMEOUT.getCode(), ackMessageDataCaptor.getValue().getNackCode());
     }
 
     @Test
@@ -173,7 +183,7 @@ class NackAckPreparationServiceTest {
                 CONVERSATION_ID);
 
         verify(sendNACKMessageHandler).prepareAndSendMessage(ackMessageDataCaptor.capture());
-        assertEquals("11", ackMessageDataCaptor.getValue().getNackCode());
+        assertEquals(CLINICAL_SYSTEM_INTEGRATION_FAILURE.getCode(), ackMessageDataCaptor.getValue().getNackCode());
     }
 
     @Test
@@ -187,7 +197,7 @@ class NackAckPreparationServiceTest {
                 CONVERSATION_ID);
 
         verify(sendNACKMessageHandler).prepareAndSendMessage(ackMessageDataCaptor.capture());
-        assertEquals("21", ackMessageDataCaptor.getValue().getNackCode());
+        assertEquals(EHR_EXTRACT_CANNOT_BE_PROCESSED.getCode(), ackMessageDataCaptor.getValue().getNackCode());
     }
 
     @Test
@@ -201,7 +211,7 @@ class NackAckPreparationServiceTest {
                 CONVERSATION_ID);
 
         verify(sendNACKMessageHandler).prepareAndSendMessage(ackMessageDataCaptor.capture());
-        assertEquals("99", ackMessageDataCaptor.getValue().getNackCode());
+        assertEquals(UNEXPECTED_CONDITION.getCode(), ackMessageDataCaptor.getValue().getNackCode());
     }
 
     @Test
@@ -228,7 +238,8 @@ class NackAckPreparationServiceTest {
         when(sendNACKMessageHandler.prepareAndSendMessage(any(NACKMessageData.class))).thenReturn(true);
 
         assertTrue(nackAckPreparationService.sendNackMessage(NACKReason.LARGE_MESSAGE_GENERAL_FAILURE, payload, CONVERSATION_ID));
-        verify(migrationStatusLogService).addMigrationStatusLog(ERROR_LRG_MSG_GENERAL_FAILURE, CONVERSATION_ID, null, "30");
+        verify(migrationStatusLogService)
+            .addMigrationStatusLog(ERROR_LRG_MSG_GENERAL_FAILURE, CONVERSATION_ID, null, LARGE_MESSAGE_GENERAL_FAILURE.getCode());
     }
 
     @Test
@@ -239,7 +250,8 @@ class NackAckPreparationServiceTest {
         when(sendNACKMessageHandler.prepareAndSendMessage(any(NACKMessageData.class))).thenReturn(false);
 
         assertFalse(nackAckPreparationService.sendNackMessage(NACKReason.LARGE_MESSAGE_GENERAL_FAILURE, payload, CONVERSATION_ID));
-        verify(migrationStatusLogService).addMigrationStatusLog(ERROR_LRG_MSG_GENERAL_FAILURE, CONVERSATION_ID, null, "30");
+        verify(migrationStatusLogService)
+            .addMigrationStatusLog(ERROR_LRG_MSG_GENERAL_FAILURE, CONVERSATION_ID, null, LARGE_MESSAGE_GENERAL_FAILURE.getCode());
     }
 
     @Test
@@ -277,7 +289,7 @@ class NackAckPreparationServiceTest {
                 CONVERSATION_ID);
 
         verify(sendNACKMessageHandler).prepareAndSendMessage(ackMessageDataCaptor.capture());
-        assertEquals("29", ackMessageDataCaptor.getValue().getNackCode());
+        assertEquals(LARGE_MESSAGE_REASSEMBLY_FAILURE.getCode(), ackMessageDataCaptor.getValue().getNackCode());
     }
 
     @Test
@@ -291,7 +303,7 @@ class NackAckPreparationServiceTest {
                 CONVERSATION_ID);
 
         verify(sendNACKMessageHandler).prepareAndSendMessage(ackMessageDataCaptor.capture());
-        assertEquals("31", ackMessageDataCaptor.getValue().getNackCode());
+        assertEquals(LARGE_MESSAGE_ATTACHMENTS_NOT_RECEIVED.getCode(), ackMessageDataCaptor.getValue().getNackCode());
     }
 
     @Test
@@ -305,7 +317,7 @@ class NackAckPreparationServiceTest {
                 CONVERSATION_ID);
 
         verify(sendNACKMessageHandler).prepareAndSendMessage(ackMessageDataCaptor.capture());
-        assertEquals("30", ackMessageDataCaptor.getValue().getNackCode());
+        assertEquals(LARGE_MESSAGE_GENERAL_FAILURE.getCode(), ackMessageDataCaptor.getValue().getNackCode());
     }
 
     @Test
@@ -319,7 +331,7 @@ class NackAckPreparationServiceTest {
                 CONVERSATION_ID);
 
         verify(sendNACKMessageHandler).prepareAndSendMessage(ackMessageDataCaptor.capture());
-        assertEquals("25", ackMessageDataCaptor.getValue().getNackCode());
+        assertEquals(LARGE_MESSAGE_TIMEOUT.getCode(), ackMessageDataCaptor.getValue().getNackCode());
     }
 
     @Test
@@ -333,7 +345,7 @@ class NackAckPreparationServiceTest {
                 CONVERSATION_ID);
 
         verify(sendNACKMessageHandler).prepareAndSendMessage(ackMessageDataCaptor.capture());
-        assertEquals("11", ackMessageDataCaptor.getValue().getNackCode());
+        assertEquals(CLINICAL_SYSTEM_INTEGRATION_FAILURE.getCode(), ackMessageDataCaptor.getValue().getNackCode());
     }
 
     @Test
@@ -347,7 +359,7 @@ class NackAckPreparationServiceTest {
                 CONVERSATION_ID);
 
         verify(sendNACKMessageHandler).prepareAndSendMessage(ackMessageDataCaptor.capture());
-        assertEquals("21", ackMessageDataCaptor.getValue().getNackCode());
+        assertEquals(EHR_EXTRACT_CANNOT_BE_PROCESSED.getCode(), ackMessageDataCaptor.getValue().getNackCode());
     }
 
     @Test
@@ -361,7 +373,7 @@ class NackAckPreparationServiceTest {
                 CONVERSATION_ID);
 
         verify(sendNACKMessageHandler).prepareAndSendMessage(ackMessageDataCaptor.capture());
-        assertEquals("99", ackMessageDataCaptor.getValue().getNackCode());
+        assertEquals(UNEXPECTED_CONDITION.getCode(), ackMessageDataCaptor.getValue().getNackCode());
     }
 
     @Test

--- a/gp2gp-translator/src/test/java/uk/nhs/adaptors/pss/translator/service/NackAckPreparationServiceTest.java
+++ b/gp2gp-translator/src/test/java/uk/nhs/adaptors/pss/translator/service/NackAckPreparationServiceTest.java
@@ -6,6 +6,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.isNull;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -67,7 +68,7 @@ class NackAckPreparationServiceTest {
         when(sendNACKMessageHandler.prepareAndSendMessage(any(NACKMessageData.class))).thenReturn(true);
 
         assertTrue(nackAckPreparationService.sendNackMessage(NACKReason.LARGE_MESSAGE_GENERAL_FAILURE, payload, CONVERSATION_ID));
-        verify(migrationStatusLogService).addMigrationStatusLog(ERROR_LRG_MSG_GENERAL_FAILURE, CONVERSATION_ID, null);
+        verify(migrationStatusLogService).addMigrationStatusLog(ERROR_LRG_MSG_GENERAL_FAILURE, CONVERSATION_ID, null, "30");
     }
 
     @Test
@@ -78,7 +79,7 @@ class NackAckPreparationServiceTest {
         when(sendNACKMessageHandler.prepareAndSendMessage(any(NACKMessageData.class))).thenReturn(false);
 
         assertFalse(nackAckPreparationService.sendNackMessage(NACKReason.LARGE_MESSAGE_GENERAL_FAILURE, payload, CONVERSATION_ID));
-        verify(migrationStatusLogService).addMigrationStatusLog(ERROR_LRG_MSG_GENERAL_FAILURE, CONVERSATION_ID, null);
+        verify(migrationStatusLogService).addMigrationStatusLog(ERROR_LRG_MSG_GENERAL_FAILURE, CONVERSATION_ID, null, "30");
     }
 
     @Test
@@ -214,7 +215,7 @@ class NackAckPreparationServiceTest {
                 payload,
                 CONVERSATION_ID);
 
-        verify(migrationStatusLogService).addMigrationStatusLog(migrationStatusCaptor.capture(), any(), isNull());
+        verify(migrationStatusLogService).addMigrationStatusLog(migrationStatusCaptor.capture(), any(), isNull(), anyString());
 
         assertEquals(MigrationStatus.ERROR_EXTRACT_CANNOT_BE_PROCESSED, migrationStatusCaptor.getValue());
     }
@@ -227,7 +228,7 @@ class NackAckPreparationServiceTest {
         when(sendNACKMessageHandler.prepareAndSendMessage(any(NACKMessageData.class))).thenReturn(true);
 
         assertTrue(nackAckPreparationService.sendNackMessage(NACKReason.LARGE_MESSAGE_GENERAL_FAILURE, payload, CONVERSATION_ID));
-        verify(migrationStatusLogService).addMigrationStatusLog(ERROR_LRG_MSG_GENERAL_FAILURE, CONVERSATION_ID, null);
+        verify(migrationStatusLogService).addMigrationStatusLog(ERROR_LRG_MSG_GENERAL_FAILURE, CONVERSATION_ID, null, "30");
     }
 
     @Test
@@ -238,7 +239,7 @@ class NackAckPreparationServiceTest {
         when(sendNACKMessageHandler.prepareAndSendMessage(any(NACKMessageData.class))).thenReturn(false);
 
         assertFalse(nackAckPreparationService.sendNackMessage(NACKReason.LARGE_MESSAGE_GENERAL_FAILURE, payload, CONVERSATION_ID));
-        verify(migrationStatusLogService).addMigrationStatusLog(ERROR_LRG_MSG_GENERAL_FAILURE, CONVERSATION_ID, null);
+        verify(migrationStatusLogService).addMigrationStatusLog(ERROR_LRG_MSG_GENERAL_FAILURE, CONVERSATION_ID, null, "30");
     }
 
     @Test
@@ -374,7 +375,7 @@ class NackAckPreparationServiceTest {
                 payload,
                 CONVERSATION_ID);
 
-        verify(migrationStatusLogService).addMigrationStatusLog(migrationStatusCaptor.capture(), any(), isNull());
+        verify(migrationStatusLogService).addMigrationStatusLog(migrationStatusCaptor.capture(), any(), isNull(), anyString());
 
         assertEquals(ERROR_EXTRACT_CANNOT_BE_PROCESSED, migrationStatusCaptor.getValue());
     }

--- a/gp2gp-translator/src/test/java/uk/nhs/adaptors/pss/translator/task/AcknowledgmentMessageHandlerTest.java
+++ b/gp2gp-translator/src/test/java/uk/nhs/adaptors/pss/translator/task/AcknowledgmentMessageHandlerTest.java
@@ -104,7 +104,7 @@ public class AcknowledgmentMessageHandlerTest {
 
         acknowledgmentMessageHandler.handleMessage(inboundMessage, CONVERSATION_ID);
 
-        verify(migrationStatusLogService).addMigrationStatusLog(EHR_EXTRACT_REQUEST_NEGATIVE_ACK_UNKNOWN, CONVERSATION_ID, null,"");
+        verify(migrationStatusLogService).addMigrationStatusLog(EHR_EXTRACT_REQUEST_NEGATIVE_ACK_UNKNOWN, CONVERSATION_ID, null, "");
     }
 
     @Test

--- a/gp2gp-translator/src/test/java/uk/nhs/adaptors/pss/translator/task/AcknowledgmentMessageHandlerTest.java
+++ b/gp2gp-translator/src/test/java/uk/nhs/adaptors/pss/translator/task/AcknowledgmentMessageHandlerTest.java
@@ -3,6 +3,7 @@ package uk.nhs.adaptors.pss.translator.task;
 import static java.util.UUID.randomUUID;
 
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -126,7 +127,7 @@ public class AcknowledgmentMessageHandlerTest {
 
         acknowledgmentMessageHandler.handleMessage(inboundMessage, CONVERSATION_ID);
 
-        verify(migrationStatusLogService, times(0)).addMigrationStatusLog(any(), any(), any(), any());
+        verify(migrationStatusLogService, times(0)).addMigrationStatusLog(any(), any(), any(), anyString());
     }
 
     @Test
@@ -137,7 +138,7 @@ public class AcknowledgmentMessageHandlerTest {
 
         acknowledgmentMessageHandler.handleMessage(inboundMessage, CONVERSATION_ID);
 
-        verify(migrationStatusLogService, times(0)).addMigrationStatusLog(any(), any(), any(), any());
+        verify(migrationStatusLogService, times(0)).addMigrationStatusLog(any(), any(), any(), anyString());
     }
 
     @Test
@@ -148,7 +149,7 @@ public class AcknowledgmentMessageHandlerTest {
 
         acknowledgmentMessageHandler.handleMessage(inboundMessage, CONVERSATION_ID);
 
-        verify(migrationStatusLogService, times(0)).addMigrationStatusLog(any(), any(), any(), any());
+        verify(migrationStatusLogService, times(0)).addMigrationStatusLog(any(), any(), any(), anyString());
     }
 
     @Test
@@ -159,7 +160,7 @@ public class AcknowledgmentMessageHandlerTest {
 
         acknowledgmentMessageHandler.handleMessage(inboundMessage, CONVERSATION_ID);
 
-        verify(migrationStatusLogService, times(0)).addMigrationStatusLog(any(), any(), any(), any());
+        verify(migrationStatusLogService, times(0)).addMigrationStatusLog(any(), any(), any(), anyString());
     }
 
     @Test
@@ -168,7 +169,7 @@ public class AcknowledgmentMessageHandlerTest {
 
         acknowledgmentMessageHandler.handleMessage(inboundMessage, CONVERSATION_ID);
 
-        verify(migrationStatusLogService, times(0)).addMigrationStatusLog(any(), any(), any(), any());
+        verify(migrationStatusLogService, times(0)).addMigrationStatusLog(any(), any(), any(), anyString());
     }
 
     @Test
@@ -177,7 +178,7 @@ public class AcknowledgmentMessageHandlerTest {
 
         acknowledgmentMessageHandler.handleMessage(inboundMessage, CONVERSATION_ID);
 
-        verify(migrationStatusLogService, times(0)).addMigrationStatusLog(any(), any(), any(), any());
+        verify(migrationStatusLogService, times(0)).addMigrationStatusLog(any(), any(), any(), anyString());
     }
 
     @SneakyThrows

--- a/gp2gp-translator/src/test/java/uk/nhs/adaptors/pss/translator/task/AcknowledgmentMessageHandlerTest.java
+++ b/gp2gp-translator/src/test/java/uk/nhs/adaptors/pss/translator/task/AcknowledgmentMessageHandlerTest.java
@@ -13,6 +13,7 @@ import static uk.nhs.adaptors.common.enums.MigrationStatus.EHR_EXTRACT_REQUEST_A
 import static uk.nhs.adaptors.common.enums.MigrationStatus.EHR_EXTRACT_REQUEST_NEGATIVE_ACK_GP2GP_PATIENT_NOT_REGISTERED;
 import static uk.nhs.adaptors.common.enums.MigrationStatus.EHR_EXTRACT_REQUEST_NEGATIVE_ACK_UNKNOWN;
 import static uk.nhs.adaptors.common.enums.MigrationStatus.FINAL_ACK_SENT;
+import static uk.nhs.adaptors.pss.translator.model.NACKReason.PATIENT_NOT_AT_SURGERY;
 
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -87,13 +88,16 @@ public class AcknowledgmentMessageHandlerTest {
     public void handleMessageWithNackErrorTypeCodeAndErrorCode() throws SAXException {
 
         inboundMessage = new InboundMessage();
-        prepareXPathServiceMocks(NACK_ERROR_TYPE_CODE, "06");
+        prepareXPathServiceMocks(NACK_ERROR_TYPE_CODE, PATIENT_NOT_AT_SURGERY.getCode());
         prepareMigrationStatusMocks(EHR_EXTRACT_REQUEST_ACCEPTED);
 
         acknowledgmentMessageHandler.handleMessage(inboundMessage, CONVERSATION_ID);
 
         verify(migrationStatusLogService)
-            .addMigrationStatusLog(EHR_EXTRACT_REQUEST_NEGATIVE_ACK_GP2GP_PATIENT_NOT_REGISTERED, CONVERSATION_ID, null, "06");
+            .addMigrationStatusLog(EHR_EXTRACT_REQUEST_NEGATIVE_ACK_GP2GP_PATIENT_NOT_REGISTERED,
+                                   CONVERSATION_ID,
+                                   null,
+                                   PATIENT_NOT_AT_SURGERY.getCode());
     }
 
     @Test
@@ -110,13 +114,16 @@ public class AcknowledgmentMessageHandlerTest {
     @Test
     public void handleMessageWithNackRejectTypeCodeAndErrorCode() throws SAXException {
         inboundMessage = new InboundMessage();
-        prepareXPathServiceMocks(NACK_REJECT_TYPE_CODE, "06");
+        prepareXPathServiceMocks(NACK_REJECT_TYPE_CODE, PATIENT_NOT_AT_SURGERY.getCode());
         prepareMigrationStatusMocks(EHR_EXTRACT_REQUEST_ACCEPTED);
 
         acknowledgmentMessageHandler.handleMessage(inboundMessage, CONVERSATION_ID);
 
         verify(migrationStatusLogService)
-            .addMigrationStatusLog(EHR_EXTRACT_REQUEST_NEGATIVE_ACK_GP2GP_PATIENT_NOT_REGISTERED, CONVERSATION_ID, null, "06");
+            .addMigrationStatusLog(EHR_EXTRACT_REQUEST_NEGATIVE_ACK_GP2GP_PATIENT_NOT_REGISTERED,
+                                   CONVERSATION_ID,
+                                   null,
+                                   PATIENT_NOT_AT_SURGERY.getCode());
     }
 
     @Test

--- a/gp2gp-translator/src/test/java/uk/nhs/adaptors/pss/translator/task/AcknowledgmentMessageHandlerTest.java
+++ b/gp2gp-translator/src/test/java/uk/nhs/adaptors/pss/translator/task/AcknowledgmentMessageHandlerTest.java
@@ -68,7 +68,7 @@ public class AcknowledgmentMessageHandlerTest {
         acknowledgmentMessageHandler.handleMessage(inboundMessage, CONVERSATION_ID);
 
         verify(migrationStatusLogService)
-            .addMigrationStatusLog(EHR_EXTRACT_REQUEST_ACKNOWLEDGED, CONVERSATION_ID, null);
+            .addMigrationStatusLog(EHR_EXTRACT_REQUEST_ACKNOWLEDGED, CONVERSATION_ID, null, null);
     }
 
     @Test
@@ -79,11 +79,12 @@ public class AcknowledgmentMessageHandlerTest {
 
         acknowledgmentMessageHandler.handleMessage(inboundMessage, CONVERSATION_ID);
 
-        verify(migrationStatusLogService).addMigrationStatusLog(EHR_EXTRACT_REQUEST_NEGATIVE_ACK_UNKNOWN, CONVERSATION_ID, null);
+        verify(migrationStatusLogService).addMigrationStatusLog(EHR_EXTRACT_REQUEST_NEGATIVE_ACK_UNKNOWN, CONVERSATION_ID, null, "");
     }
 
     @Test
     public void handleMessageWithNackErrorTypeCodeAndErrorCode() throws SAXException {
+
         inboundMessage = new InboundMessage();
         prepareXPathServiceMocks(NACK_ERROR_TYPE_CODE, "06");
         prepareMigrationStatusMocks(EHR_EXTRACT_REQUEST_ACCEPTED);
@@ -91,7 +92,7 @@ public class AcknowledgmentMessageHandlerTest {
         acknowledgmentMessageHandler.handleMessage(inboundMessage, CONVERSATION_ID);
 
         verify(migrationStatusLogService)
-            .addMigrationStatusLog(EHR_EXTRACT_REQUEST_NEGATIVE_ACK_GP2GP_PATIENT_NOT_REGISTERED, CONVERSATION_ID, null);
+            .addMigrationStatusLog(EHR_EXTRACT_REQUEST_NEGATIVE_ACK_GP2GP_PATIENT_NOT_REGISTERED, CONVERSATION_ID, null, "06");
     }
 
     @Test
@@ -102,7 +103,7 @@ public class AcknowledgmentMessageHandlerTest {
 
         acknowledgmentMessageHandler.handleMessage(inboundMessage, CONVERSATION_ID);
 
-        verify(migrationStatusLogService).addMigrationStatusLog(EHR_EXTRACT_REQUEST_NEGATIVE_ACK_UNKNOWN, CONVERSATION_ID, null);
+        verify(migrationStatusLogService).addMigrationStatusLog(EHR_EXTRACT_REQUEST_NEGATIVE_ACK_UNKNOWN, CONVERSATION_ID, null,"");
     }
 
     @Test
@@ -114,7 +115,7 @@ public class AcknowledgmentMessageHandlerTest {
         acknowledgmentMessageHandler.handleMessage(inboundMessage, CONVERSATION_ID);
 
         verify(migrationStatusLogService)
-            .addMigrationStatusLog(EHR_EXTRACT_REQUEST_NEGATIVE_ACK_GP2GP_PATIENT_NOT_REGISTERED, CONVERSATION_ID, null);
+            .addMigrationStatusLog(EHR_EXTRACT_REQUEST_NEGATIVE_ACK_GP2GP_PATIENT_NOT_REGISTERED, CONVERSATION_ID, null, "06");
     }
 
     @Test
@@ -125,7 +126,7 @@ public class AcknowledgmentMessageHandlerTest {
 
         acknowledgmentMessageHandler.handleMessage(inboundMessage, CONVERSATION_ID);
 
-        verify(migrationStatusLogService, times(0)).addMigrationStatusLog(any(), any(), any());
+        verify(migrationStatusLogService, times(0)).addMigrationStatusLog(any(), any(), any(), any());
     }
 
     @Test
@@ -136,7 +137,7 @@ public class AcknowledgmentMessageHandlerTest {
 
         acknowledgmentMessageHandler.handleMessage(inboundMessage, CONVERSATION_ID);
 
-        verify(migrationStatusLogService, times(0)).addMigrationStatusLog(any(), any(), any());
+        verify(migrationStatusLogService, times(0)).addMigrationStatusLog(any(), any(), any(), any());
     }
 
     @Test
@@ -147,7 +148,7 @@ public class AcknowledgmentMessageHandlerTest {
 
         acknowledgmentMessageHandler.handleMessage(inboundMessage, CONVERSATION_ID);
 
-        verify(migrationStatusLogService, times(0)).addMigrationStatusLog(any(), any(), any());
+        verify(migrationStatusLogService, times(0)).addMigrationStatusLog(any(), any(), any(), any());
     }
 
     @Test
@@ -158,7 +159,7 @@ public class AcknowledgmentMessageHandlerTest {
 
         acknowledgmentMessageHandler.handleMessage(inboundMessage, CONVERSATION_ID);
 
-        verify(migrationStatusLogService, times(0)).addMigrationStatusLog(any(), any(), any());
+        verify(migrationStatusLogService, times(0)).addMigrationStatusLog(any(), any(), any(), any());
     }
 
     @Test
@@ -167,7 +168,7 @@ public class AcknowledgmentMessageHandlerTest {
 
         acknowledgmentMessageHandler.handleMessage(inboundMessage, CONVERSATION_ID);
 
-        verify(migrationStatusLogService, times(0)).addMigrationStatusLog(any(), any(), any());
+        verify(migrationStatusLogService, times(0)).addMigrationStatusLog(any(), any(), any(), any());
     }
 
     @Test
@@ -176,7 +177,7 @@ public class AcknowledgmentMessageHandlerTest {
 
         acknowledgmentMessageHandler.handleMessage(inboundMessage, CONVERSATION_ID);
 
-        verify(migrationStatusLogService, times(0)).addMigrationStatusLog(any(), any(), any());
+        verify(migrationStatusLogService, times(0)).addMigrationStatusLog(any(), any(), any(), any());
     }
 
     @SneakyThrows

--- a/gp2gp-translator/src/test/java/uk/nhs/adaptors/pss/translator/task/COPCMessageHandlerTest.java
+++ b/gp2gp-translator/src/test/java/uk/nhs/adaptors/pss/translator/task/COPCMessageHandlerTest.java
@@ -1277,11 +1277,13 @@ class COPCMessageHandlerTest {
                 .sendNackMessage(LARGE_MESSAGE_GENERAL_FAILURE, mockCOPCMessage, CONVERSATION_ID);
 
             verify(sendNACKMessageHandler).prepareAndSendMessage(nackMessageDataCaptor.capture());
-            assertThat(nackMessageDataCaptor.getValue().getNackCode()).isEqualTo(LARGE_MESSAGE_ATTACHMENTS_NOT_RECEIVED.getCode());
+            assertEquals(LARGE_MESSAGE_ATTACHMENTS_NOT_RECEIVED.getCode(), nackMessageDataCaptor.getValue().getNackCode());
 
             verify(migrationStatusLogService, times(1))
-                .addMigrationStatusLog(LARGE_MESSAGE_ATTACHMENTS_NOT_RECEIVED.getMigrationStatus(), CONVERSATION_ID, null, "31");
-
+                .addMigrationStatusLog(LARGE_MESSAGE_ATTACHMENTS_NOT_RECEIVED.getMigrationStatus(),
+                                       CONVERSATION_ID,
+                                       null,
+                                       LARGE_MESSAGE_ATTACHMENTS_NOT_RECEIVED.getCode());
         } finally {
             mockedXmlUnmarshall.close();
         }

--- a/gp2gp-translator/src/test/java/uk/nhs/adaptors/pss/translator/task/COPCMessageHandlerTest.java
+++ b/gp2gp-translator/src/test/java/uk/nhs/adaptors/pss/translator/task/COPCMessageHandlerTest.java
@@ -1095,7 +1095,7 @@ class COPCMessageHandlerTest {
             .handleFailedProcess(any(COPCIN000001UK01Message.class), eq(CONVERSATION_ID));
 
         verify(migrationStatusLogService, times(0))
-            .addMigrationStatusLog(COPC_MESSAGE_RECEIVED, CONVERSATION_ID, null);
+            .addMigrationStatusLog(COPC_MESSAGE_RECEIVED, CONVERSATION_ID, null, null);
     }
 
     @Test
@@ -1280,7 +1280,7 @@ class COPCMessageHandlerTest {
             assertThat(nackMessageDataCaptor.getValue().getNackCode()).isEqualTo(LARGE_MESSAGE_ATTACHMENTS_NOT_RECEIVED.getCode());
 
             verify(migrationStatusLogService, times(1))
-                .addMigrationStatusLog(LARGE_MESSAGE_ATTACHMENTS_NOT_RECEIVED.getMigrationStatus(), CONVERSATION_ID, null);
+                .addMigrationStatusLog(LARGE_MESSAGE_ATTACHMENTS_NOT_RECEIVED.getMigrationStatus(), CONVERSATION_ID, null, "31");
 
         } finally {
             mockedXmlUnmarshall.close();

--- a/gp2gp-translator/src/test/java/uk/nhs/adaptors/pss/translator/task/EhrExtractMessageHandlerTest.java
+++ b/gp2gp-translator/src/test/java/uk/nhs/adaptors/pss/translator/task/EhrExtractMessageHandlerTest.java
@@ -157,7 +157,7 @@ public class EhrExtractMessageHandlerTest {
 
         ehrExtractMessageHandler.handleMessage(inboundMessage, CONVERSATION_ID, RCMRIN030000UK06Message.class);
 
-        verify(migrationStatusLogService).addMigrationStatusLog(EHR_EXTRACT_RECEIVED, CONVERSATION_ID, null);
+        verify(migrationStatusLogService).addMigrationStatusLog(EHR_EXTRACT_RECEIVED, CONVERSATION_ID, null, null);
 
         verify(migrationStatusLogService).updatePatientMigrationRequestAndAddMigrationStatusLog(
             CONVERSATION_ID,
@@ -782,7 +782,7 @@ public class EhrExtractMessageHandlerTest {
             .handleFailedProcess(any(RCMRIN030000UK06Message.class), eq(CONVERSATION_ID));
 
         verify(migrationStatusLogService, times(0))
-            .addMigrationStatusLog(EHR_EXTRACT_RECEIVED, CONVERSATION_ID, null);
+            .addMigrationStatusLog(EHR_EXTRACT_RECEIVED, CONVERSATION_ID, null, null);
     }
 
     @SneakyThrows

--- a/gp2gp-translator/src/test/java/uk/nhs/adaptors/pss/translator/task/MhsQueueMessageHandlerTest.java
+++ b/gp2gp-translator/src/test/java/uk/nhs/adaptors/pss/translator/task/MhsQueueMessageHandlerTest.java
@@ -164,7 +164,7 @@ public class MhsQueueMessageHandlerTest {
         boolean result = mhsQueueMessageHandler.handleMessage(message);
 
         assertFalse(result);
-        verify(migrationStatusLogService).addMigrationStatusLog(MigrationStatus.EHR_GENERAL_PROCESSING_ERROR, CONVERSATION_ID_UPPER, null);
+        verify(migrationStatusLogService).addMigrationStatusLog(MigrationStatus.EHR_GENERAL_PROCESSING_ERROR, CONVERSATION_ID_UPPER, null, "99");
 
     }
 

--- a/gp2gp-translator/src/test/java/uk/nhs/adaptors/pss/translator/task/MhsQueueMessageHandlerTest.java
+++ b/gp2gp-translator/src/test/java/uk/nhs/adaptors/pss/translator/task/MhsQueueMessageHandlerTest.java
@@ -12,6 +12,7 @@ import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 
 import static uk.nhs.adaptors.common.util.FileUtil.readResourceAsString;
+import static uk.nhs.adaptors.pss.translator.model.NACKReason.UNEXPECTED_CONDITION;
 
 import java.text.ParseException;
 import java.util.Locale;
@@ -50,6 +51,7 @@ import uk.nhs.adaptors.pss.translator.service.XPathService;
 
 @ExtendWith(MockitoExtension.class)
 public class MhsQueueMessageHandlerTest {
+
     private static final String NHS_NUMBER = "123456";
     private static final String INBOUND_MESSAGE_STRING = "{hi i'm inbound message}";
     private static final String EHR_EXTRACT_INTERACTION_ID = "RCMR_IN030000UK06";
@@ -165,7 +167,10 @@ public class MhsQueueMessageHandlerTest {
 
         assertFalse(result);
         verify(migrationStatusLogService)
-            .addMigrationStatusLog(MigrationStatus.EHR_GENERAL_PROCESSING_ERROR, CONVERSATION_ID_UPPER, null, "99");
+            .addMigrationStatusLog(MigrationStatus.EHR_GENERAL_PROCESSING_ERROR,
+                                   CONVERSATION_ID_UPPER,
+                                   null,
+                                   UNEXPECTED_CONDITION.getCode());
 
     }
 

--- a/gp2gp-translator/src/test/java/uk/nhs/adaptors/pss/translator/task/MhsQueueMessageHandlerTest.java
+++ b/gp2gp-translator/src/test/java/uk/nhs/adaptors/pss/translator/task/MhsQueueMessageHandlerTest.java
@@ -164,7 +164,8 @@ public class MhsQueueMessageHandlerTest {
         boolean result = mhsQueueMessageHandler.handleMessage(message);
 
         assertFalse(result);
-        verify(migrationStatusLogService).addMigrationStatusLog(MigrationStatus.EHR_GENERAL_PROCESSING_ERROR, CONVERSATION_ID_UPPER, null, "99");
+        verify(migrationStatusLogService)
+            .addMigrationStatusLog(MigrationStatus.EHR_GENERAL_PROCESSING_ERROR, CONVERSATION_ID_UPPER, null, "99");
 
     }
 

--- a/gp2gp-translator/src/test/java/uk/nhs/adaptors/pss/translator/task/SendContinueRequestHandlerTest.java
+++ b/gp2gp-translator/src/test/java/uk/nhs/adaptors/pss/translator/task/SendContinueRequestHandlerTest.java
@@ -25,7 +25,6 @@ import uk.nhs.adaptors.pss.translator.service.MhsClientService;
 import static org.assertj.core.api.AssertionsForClassTypes.assertThatThrownBy;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;

--- a/gp2gp-translator/src/test/java/uk/nhs/adaptors/pss/translator/task/SendContinueRequestHandlerTest.java
+++ b/gp2gp-translator/src/test/java/uk/nhs/adaptors/pss/translator/task/SendContinueRequestHandlerTest.java
@@ -38,6 +38,7 @@ import java.nio.charset.Charset;
 @Slf4j
 @ExtendWith(MockitoExtension.class)
 public class SendContinueRequestHandlerTest {
+
     private static final String NHS_NUMBER = "9446363101";
     private static final String CONVERSATION_ID = "6E242658-3D8E-11E3-A7DC-172BDA00FA67";
     private static final String LOSING_ODS_CODE = "B83002"; //to odds code
@@ -118,7 +119,7 @@ public class SendContinueRequestHandlerTest {
         } catch (Exception e) {
         }
 
-        verify(migrationStatusLogService).addMigrationStatusLog(MigrationStatus.CONTINUE_REQUEST_ERROR, CONVERSATION_ID, null);
+        verify(migrationStatusLogService).addMigrationStatusLog(MigrationStatus.CONTINUE_REQUEST_ERROR, CONVERSATION_ID, null, "8");
     }
 
     @Test
@@ -171,7 +172,7 @@ public class SendContinueRequestHandlerTest {
                 .build();
 
         sendContinueRequestHandler.prepareAndSendRequest(continueRequestData);
-        verify(migrationStatusLogService).addMigrationStatusLog(MigrationStatus.CONTINUE_REQUEST_ACCEPTED, CONVERSATION_ID, null);
+        verify(migrationStatusLogService).addMigrationStatusLog(MigrationStatus.CONTINUE_REQUEST_ACCEPTED, CONVERSATION_ID, null, null);
     }
 
     @Test
@@ -219,8 +220,7 @@ public class SendContinueRequestHandlerTest {
         when(continueRequestService.buildContinueRequest(any(), any())).thenReturn(testPayload);
 
         sendContinueRequestHandler.prepareAndSendRequest(continueRequestData);
-        verify(continueRequestService).buildContinueRequest(eq(continueRequestData), eq(MESSAGE_ID.toUpperCase()));
-        verify(requestBuilder).buildSendContinueRequest(eq(CONVERSATION_ID), eq(LOSING_ODS_CODE), eq(outboundMessage),
-            eq(MESSAGE_ID.toUpperCase()));
+        verify(continueRequestService).buildContinueRequest(continueRequestData, MESSAGE_ID.toUpperCase());
+        verify(requestBuilder).buildSendContinueRequest(CONVERSATION_ID, LOSING_ODS_CODE, outboundMessage, MESSAGE_ID.toUpperCase());
     }
 }

--- a/gp2gp-translator/src/test/java/uk/nhs/adaptors/pss/translator/task/SendContinueRequestHandlerTest.java
+++ b/gp2gp-translator/src/test/java/uk/nhs/adaptors/pss/translator/task/SendContinueRequestHandlerTest.java
@@ -30,6 +30,7 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static org.springframework.http.HttpStatus.BAD_REQUEST;
 import static org.springframework.http.HttpStatus.INTERNAL_SERVER_ERROR;
+import static uk.nhs.adaptors.pss.translator.model.NACKReason.UNEXPECTED_CONDITION;
 
 import java.io.IOException;
 import java.nio.charset.Charset;
@@ -118,7 +119,11 @@ public class SendContinueRequestHandlerTest {
         } catch (Exception e) {
         }
 
-        verify(migrationStatusLogService).addMigrationStatusLog(MigrationStatus.CONTINUE_REQUEST_ERROR, CONVERSATION_ID, null, "8");
+        verify(migrationStatusLogService)
+            .addMigrationStatusLog(MigrationStatus.CONTINUE_REQUEST_ERROR,
+                                   CONVERSATION_ID,
+                                   null,
+                                   UNEXPECTED_CONDITION.getCode());
     }
 
     @Test

--- a/gp2gp-translator/src/test/java/uk/nhs/adaptors/pss/translator/task/SendEhrExtractRequestHandlerTest.java
+++ b/gp2gp-translator/src/test/java/uk/nhs/adaptors/pss/translator/task/SendEhrExtractRequestHandlerTest.java
@@ -19,6 +19,7 @@ import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
 import org.springframework.web.reactive.function.client.WebClient;
 import org.springframework.web.reactive.function.client.WebClientResponseException;
+import static uk.nhs.adaptors.pss.translator.model.NACKReason.UNEXPECTED_CONDITION;
 
 import lombok.SneakyThrows;
 import uk.nhs.adaptors.common.enums.MigrationStatus;
@@ -109,7 +110,7 @@ public class SendEhrExtractRequestHandlerTest {
             MigrationStatus.EHR_EXTRACT_REQUEST_ERROR,
             CONVERSATION_ID,
             null,
-            "2"
+            UNEXPECTED_CONDITION.getCode()
         );
     }
 }

--- a/gp2gp-translator/src/test/java/uk/nhs/adaptors/pss/translator/task/SendEhrExtractRequestHandlerTest.java
+++ b/gp2gp-translator/src/test/java/uk/nhs/adaptors/pss/translator/task/SendEhrExtractRequestHandlerTest.java
@@ -86,6 +86,7 @@ public class SendEhrExtractRequestHandlerTest {
         verify(migrationStatusLogService).addMigrationStatusLog(
             MigrationStatus.EHR_EXTRACT_REQUEST_ACCEPTED,
             CONVERSATION_ID,
+            null,
             null
         );
     }
@@ -107,7 +108,8 @@ public class SendEhrExtractRequestHandlerTest {
         verify(migrationStatusLogService).addMigrationStatusLog(
             MigrationStatus.EHR_EXTRACT_REQUEST_ERROR,
             CONVERSATION_ID,
-            null
+            null,
+            "2"
         );
     }
 }

--- a/gp2gp-translator/src/test/java/uk/nhs/adaptors/pss/translator/task/scheduled/EHRTimeoutHandlerTest.java
+++ b/gp2gp-translator/src/test/java/uk/nhs/adaptors/pss/translator/task/scheduled/EHRTimeoutHandlerTest.java
@@ -26,6 +26,8 @@ import static uk.nhs.adaptors.common.enums.MigrationStatus.EHR_GENERAL_PROCESSIN
 import static uk.nhs.adaptors.common.enums.MigrationStatus.ERROR_REQUEST_TIMEOUT;
 import static uk.nhs.adaptors.common.enums.MigrationStatus.REQUEST_RECEIVED;
 import static uk.nhs.adaptors.pss.translator.model.NACKReason.LARGE_MESSAGE_TIMEOUT;
+import static uk.nhs.adaptors.pss.translator.model.NACKReason.LARGE_MESSAGE_ATTACHMENTS_NOT_RECEIVED;
+import static uk.nhs.adaptors.pss.translator.model.NACKReason.UNEXPECTED_CONDITION;
 
 import java.time.Duration;
 import java.time.LocalDateTime;
@@ -228,7 +230,10 @@ public class EHRTimeoutHandlerTest {
 
         callCheckForTimeoutsWithOneRequest(EHR_EXTRACT_PROCESSING, TEN_DAYS_AGO, 0, conversationId);
         verify(migrationStatusLogService, times(0))
-            .addMigrationStatusLog(LARGE_MESSAGE_TIMEOUT.getMigrationStatus(), conversationId, null, "25");
+            .addMigrationStatusLog(LARGE_MESSAGE_TIMEOUT.getMigrationStatus(),
+                                   conversationId,
+                                   null,
+                                   LARGE_MESSAGE_TIMEOUT.getCode());
     }
 
     @Test
@@ -242,7 +247,10 @@ public class EHRTimeoutHandlerTest {
             .isInstanceOf(MhsServerErrorException.class);
 
         verify(migrationStatusLogService, times(0))
-            .addMigrationStatusLog(LARGE_MESSAGE_TIMEOUT.getMigrationStatus(), conversationId, null, "25");
+            .addMigrationStatusLog(LARGE_MESSAGE_TIMEOUT.getMigrationStatus(),
+                                   conversationId,
+                                   null,
+                                   LARGE_MESSAGE_TIMEOUT.getCode());
     }
 
     @Test
@@ -253,7 +261,10 @@ public class EHRTimeoutHandlerTest {
 
         callCheckForTimeoutsWithOneRequest(EHR_EXTRACT_PROCESSING, TEN_DAYS_AGO, 0, conversationId);
         verify(migrationStatusLogService, times(1))
-            .addMigrationStatusLog(LARGE_MESSAGE_TIMEOUT.getMigrationStatus(), conversationId, null, "31");
+            .addMigrationStatusLog(LARGE_MESSAGE_TIMEOUT.getMigrationStatus(),
+                                   conversationId,
+                                   null,
+                                   LARGE_MESSAGE_ATTACHMENTS_NOT_RECEIVED.getCode());
     }
 
     @Test
@@ -264,7 +275,10 @@ public class EHRTimeoutHandlerTest {
 
         callCheckForTimeoutsWithOneRequest(COPC_MESSAGE_RECEIVED, TEN_DAYS_AGO, 2, conversationId);
         verify(migrationStatusLogService, times(1))
-            .addMigrationStatusLog(LARGE_MESSAGE_TIMEOUT.getMigrationStatus(), conversationId, null, "31");
+            .addMigrationStatusLog(LARGE_MESSAGE_TIMEOUT.getMigrationStatus(),
+                                   conversationId,
+                                   null,
+                                   LARGE_MESSAGE_ATTACHMENTS_NOT_RECEIVED.getCode());
     }
 
     @Test
@@ -275,7 +289,10 @@ public class EHRTimeoutHandlerTest {
 
         callCheckForTimeoutsWithOneRequest(COPC_MESSAGE_PROCESSING, TEN_DAYS_AGO, 2, conversationId);
         verify(migrationStatusLogService, times(1))
-            .addMigrationStatusLog(LARGE_MESSAGE_TIMEOUT.getMigrationStatus(), conversationId, null, "31");
+            .addMigrationStatusLog(LARGE_MESSAGE_TIMEOUT.getMigrationStatus(),
+                                   conversationId,
+                                   null,
+                                   LARGE_MESSAGE_ATTACHMENTS_NOT_RECEIVED.getCode());
     }
 
     @Test
@@ -286,7 +303,10 @@ public class EHRTimeoutHandlerTest {
 
         callCheckForTimeoutsWithOneRequest(COPC_ACKNOWLEDGED, TEN_DAYS_AGO, 2, conversationId);
         verify(migrationStatusLogService, times(1))
-            .addMigrationStatusLog(LARGE_MESSAGE_TIMEOUT.getMigrationStatus(), conversationId, null, "31");
+            .addMigrationStatusLog(LARGE_MESSAGE_TIMEOUT.getMigrationStatus(),
+                                   conversationId,
+                                   null,
+                                   LARGE_MESSAGE_ATTACHMENTS_NOT_RECEIVED.getCode());
     }
 
     @Test
@@ -297,7 +317,10 @@ public class EHRTimeoutHandlerTest {
 
         callCheckForTimeoutsWithOneRequest(EHR_EXTRACT_PROCESSING, TEN_DAYS_AGO, 2, conversationId);
         verify(migrationStatusLogService, times(1))
-            .addMigrationStatusLog(LARGE_MESSAGE_TIMEOUT.getMigrationStatus(), conversationId, null, "31");
+            .addMigrationStatusLog(LARGE_MESSAGE_TIMEOUT.getMigrationStatus(),
+                                   conversationId,
+                                   null,
+                                   LARGE_MESSAGE_ATTACHMENTS_NOT_RECEIVED.getCode());
     }
 
     @Test
@@ -358,7 +381,10 @@ public class EHRTimeoutHandlerTest {
         ehrTimeoutHandler.checkForTimeouts();
 
         verify(migrationStatusLogService, times(1))
-                                    .addMigrationStatusLog(EHR_GENERAL_PROCESSING_ERROR, conversationId, null, "99");
+                                    .addMigrationStatusLog(EHR_GENERAL_PROCESSING_ERROR,
+                                                           conversationId,
+                                                           null,
+                                                           UNEXPECTED_CONDITION.getCode());
     }
 
     @Test
@@ -375,7 +401,10 @@ public class EHRTimeoutHandlerTest {
         ehrTimeoutHandler.checkForTimeouts();
 
         verify(migrationStatusLogService, times(1))
-                                    .addMigrationStatusLog(EHR_GENERAL_PROCESSING_ERROR, conversationId, null, "99");
+                                    .addMigrationStatusLog(EHR_GENERAL_PROCESSING_ERROR,
+                                                           conversationId,
+                                                           null,
+                                                           UNEXPECTED_CONDITION_CODE);
     }
 
     @Test
@@ -392,7 +421,10 @@ public class EHRTimeoutHandlerTest {
         ehrTimeoutHandler.checkForTimeouts();
 
         verify(migrationStatusLogService, times(1))
-                                                 .addMigrationStatusLog(EHR_GENERAL_PROCESSING_ERROR, conversationId, null, "99");
+                                                 .addMigrationStatusLog(EHR_GENERAL_PROCESSING_ERROR,
+                                                                        conversationId,
+                                                                        null,
+                                                                        UNEXPECTED_CONDITION_CODE);
     }
 
     private void callCheckForTimeoutsWithOneRequest(MigrationStatus migrationStatus, ZonedDateTime requestTimestamp,

--- a/gp2gp-translator/src/test/java/uk/nhs/adaptors/pss/translator/task/scheduled/EHRTimeoutHandlerTest.java
+++ b/gp2gp-translator/src/test/java/uk/nhs/adaptors/pss/translator/task/scheduled/EHRTimeoutHandlerTest.java
@@ -216,7 +216,7 @@ public class EHRTimeoutHandlerTest {
         verify(sendNACKMessageHandler, times(0)).prepareAndSendMessage(any());
 
         verify(migrationStatusLogService, times(1))
-            .addMigrationStatusLog(eq(ERROR_REQUEST_TIMEOUT), eq(conversationId), eq(null));
+            .addMigrationStatusLog(ERROR_REQUEST_TIMEOUT, conversationId, null, null);
     }
 
     @Test
@@ -227,7 +227,7 @@ public class EHRTimeoutHandlerTest {
 
         callCheckForTimeoutsWithOneRequest(EHR_EXTRACT_PROCESSING, TEN_DAYS_AGO, 0, conversationId);
         verify(migrationStatusLogService, times(0))
-            .addMigrationStatusLog(LARGE_MESSAGE_TIMEOUT.getMigrationStatus(), conversationId, null);
+            .addMigrationStatusLog(LARGE_MESSAGE_TIMEOUT.getMigrationStatus(), conversationId, null, "25");
     }
 
     @Test
@@ -241,7 +241,7 @@ public class EHRTimeoutHandlerTest {
             .isInstanceOf(MhsServerErrorException.class);
 
         verify(migrationStatusLogService, times(0))
-            .addMigrationStatusLog(LARGE_MESSAGE_TIMEOUT.getMigrationStatus(), conversationId, null);
+            .addMigrationStatusLog(LARGE_MESSAGE_TIMEOUT.getMigrationStatus(), conversationId, null, "25");
     }
 
     @Test
@@ -252,7 +252,7 @@ public class EHRTimeoutHandlerTest {
 
         callCheckForTimeoutsWithOneRequest(EHR_EXTRACT_PROCESSING, TEN_DAYS_AGO, 0, conversationId);
         verify(migrationStatusLogService, times(1))
-            .addMigrationStatusLog(LARGE_MESSAGE_TIMEOUT.getMigrationStatus(), conversationId, null);
+            .addMigrationStatusLog(LARGE_MESSAGE_TIMEOUT.getMigrationStatus(), conversationId, null, "31");
     }
 
     @Test
@@ -263,7 +263,7 @@ public class EHRTimeoutHandlerTest {
 
         callCheckForTimeoutsWithOneRequest(COPC_MESSAGE_RECEIVED, TEN_DAYS_AGO, 2, conversationId);
         verify(migrationStatusLogService, times(1))
-            .addMigrationStatusLog(LARGE_MESSAGE_TIMEOUT.getMigrationStatus(), conversationId, null);
+            .addMigrationStatusLog(LARGE_MESSAGE_TIMEOUT.getMigrationStatus(), conversationId, null, "31");
     }
 
     @Test
@@ -274,7 +274,7 @@ public class EHRTimeoutHandlerTest {
 
         callCheckForTimeoutsWithOneRequest(COPC_MESSAGE_PROCESSING, TEN_DAYS_AGO, 2, conversationId);
         verify(migrationStatusLogService, times(1))
-            .addMigrationStatusLog(LARGE_MESSAGE_TIMEOUT.getMigrationStatus(), conversationId, null);
+            .addMigrationStatusLog(LARGE_MESSAGE_TIMEOUT.getMigrationStatus(), conversationId, null, "31");
     }
 
     @Test
@@ -285,7 +285,7 @@ public class EHRTimeoutHandlerTest {
 
         callCheckForTimeoutsWithOneRequest(COPC_ACKNOWLEDGED, TEN_DAYS_AGO, 2, conversationId);
         verify(migrationStatusLogService, times(1))
-            .addMigrationStatusLog(LARGE_MESSAGE_TIMEOUT.getMigrationStatus(), conversationId, null);
+            .addMigrationStatusLog(LARGE_MESSAGE_TIMEOUT.getMigrationStatus(), conversationId, null, "31");
     }
 
     @Test
@@ -296,7 +296,7 @@ public class EHRTimeoutHandlerTest {
 
         callCheckForTimeoutsWithOneRequest(EHR_EXTRACT_PROCESSING, TEN_DAYS_AGO, 2, conversationId);
         verify(migrationStatusLogService, times(1))
-            .addMigrationStatusLog(LARGE_MESSAGE_TIMEOUT.getMigrationStatus(), conversationId, null);
+            .addMigrationStatusLog(LARGE_MESSAGE_TIMEOUT.getMigrationStatus(), conversationId, null, "31");
     }
 
     @Test
@@ -341,7 +341,7 @@ public class EHRTimeoutHandlerTest {
 
         ehrTimeoutHandler.checkForTimeouts();
 
-        verify(migrationStatusLogService, times(0)).addMigrationStatusLog(any(), any(), isNull());
+        verify(migrationStatusLogService, times(0)).addMigrationStatusLog(any(), any(), isNull(), any());
     }
 
     @Test
@@ -356,7 +356,8 @@ public class EHRTimeoutHandlerTest {
 
         ehrTimeoutHandler.checkForTimeouts();
 
-        verify(migrationStatusLogService, times(1)).addMigrationStatusLog(EHR_GENERAL_PROCESSING_ERROR, conversationId, null);
+        verify(migrationStatusLogService, times(1))
+                                    .addMigrationStatusLog(EHR_GENERAL_PROCESSING_ERROR, conversationId, null, "99");
     }
 
     @Test
@@ -372,7 +373,8 @@ public class EHRTimeoutHandlerTest {
 
         ehrTimeoutHandler.checkForTimeouts();
 
-        verify(migrationStatusLogService, times(1)).addMigrationStatusLog(EHR_GENERAL_PROCESSING_ERROR, conversationId, null);
+        verify(migrationStatusLogService, times(1))
+                                    .addMigrationStatusLog(EHR_GENERAL_PROCESSING_ERROR, conversationId, null, "99");
     }
 
     @Test
@@ -388,7 +390,8 @@ public class EHRTimeoutHandlerTest {
 
         ehrTimeoutHandler.checkForTimeouts();
 
-        verify(migrationStatusLogService, times(1)).addMigrationStatusLog(EHR_GENERAL_PROCESSING_ERROR, conversationId, null);
+        verify(migrationStatusLogService, times(1))
+                                                 .addMigrationStatusLog(EHR_GENERAL_PROCESSING_ERROR, conversationId, null, "99");
     }
 
     private void callCheckForTimeoutsWithOneRequest(MigrationStatus migrationStatus, ZonedDateTime requestTimestamp,

--- a/gp2gp-translator/src/test/java/uk/nhs/adaptors/pss/translator/task/scheduled/EHRTimeoutHandlerTest.java
+++ b/gp2gp-translator/src/test/java/uk/nhs/adaptors/pss/translator/task/scheduled/EHRTimeoutHandlerTest.java
@@ -4,6 +4,7 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.argThat;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.ArgumentMatchers.isNull;
@@ -341,7 +342,7 @@ public class EHRTimeoutHandlerTest {
 
         ehrTimeoutHandler.checkForTimeouts();
 
-        verify(migrationStatusLogService, times(0)).addMigrationStatusLog(any(), any(), isNull(), any());
+        verify(migrationStatusLogService, times(0)).addMigrationStatusLog(any(), any(), isNull(), anyString());
     }
 
     @Test

--- a/gpc-api-facade/src/integrationTest/java/uk/nhs/adaptors/pss/gpc/controller/AcknowledgeRecordControllerIT.java
+++ b/gpc-api-facade/src/integrationTest/java/uk/nhs/adaptors/pss/gpc/controller/AcknowledgeRecordControllerIT.java
@@ -141,6 +141,6 @@ public class AcknowledgeRecordControllerIT {
     private void addMigrationRequestAndLogWithStatus(String conversationId, MigrationStatus status) {
         patientMigrationRequestDao.addNewRequest(PATIENT_NUMBER, conversationId, LOSING_PRACTICE_ODS, WINNING_PRACTICE_ODS);
         patientMigrationRequestDao.saveBundleAndInboundMessageData(conversationId, BUNDLE_VALUE, INBOUND_MESSAGE_VALUE);
-        migrationStatusLogService.addMigrationStatusLog(status, conversationId, null);
+        migrationStatusLogService.addMigrationStatusLog(status, conversationId, null, null);
     }
 }

--- a/gpc-api-facade/src/integrationTest/java/uk/nhs/adaptors/pss/gpc/controller/PatientTransferControllerIT.java
+++ b/gpc-api-facade/src/integrationTest/java/uk/nhs/adaptors/pss/gpc/controller/PatientTransferControllerIT.java
@@ -338,6 +338,6 @@ public class PatientTransferControllerIT {
         patientMigrationRequestDao.addNewRequest(MOCK_PATIENT_NUMBER, conversationId, LOSING_PRACTICE_ODS, WINNING_PRACTICE_ODS);
         patientMigrationRequestDao.saveBundleAndInboundMessageData(conversationId, readResourceAsString(EXAMPLE_JSON_BUNDLE),
             StringUtils.EMPTY);
-        migrationStatusLogService.addMigrationStatusLog(MIGRATION_COMPLETED, conversationId, null,null);
+        migrationStatusLogService.addMigrationStatusLog(MIGRATION_COMPLETED, conversationId, null, null);
     }
 }

--- a/gpc-api-facade/src/integrationTest/java/uk/nhs/adaptors/pss/gpc/controller/PatientTransferControllerIT.java
+++ b/gpc-api-facade/src/integrationTest/java/uk/nhs/adaptors/pss/gpc/controller/PatientTransferControllerIT.java
@@ -338,6 +338,6 @@ public class PatientTransferControllerIT {
         patientMigrationRequestDao.addNewRequest(MOCK_PATIENT_NUMBER, conversationId, LOSING_PRACTICE_ODS, WINNING_PRACTICE_ODS);
         patientMigrationRequestDao.saveBundleAndInboundMessageData(conversationId, readResourceAsString(EXAMPLE_JSON_BUNDLE),
             StringUtils.EMPTY);
-        migrationStatusLogService.addMigrationStatusLog(MIGRATION_COMPLETED, conversationId, null);
+        migrationStatusLogService.addMigrationStatusLog(MIGRATION_COMPLETED, conversationId, null,null);
     }
 }

--- a/gpc-api-facade/src/main/java/uk/nhs/adaptors/pss/gpc/controller/PatientTransferController.java
+++ b/gpc-api-facade/src/main/java/uk/nhs/adaptors/pss/gpc/controller/PatientTransferController.java
@@ -54,6 +54,7 @@ import uk.nhs.adaptors.pss.gpc.service.PatientTransferService;
 @Validated
 public class PatientTransferController {
 
+    public static final String INTERNAL_SERVER_ERROR = "INTERNAL_SERVER_ERROR";
     private static final String ISSUE_SYSTEM = "https://fhir.nhs.uk/STU3/ValueSet/Spine-ErrorOrWarningCode-1";
     private final PatientTransferService patientTransferService;
     private final FhirParser fhirParser;
@@ -124,14 +125,14 @@ public class PatientTransferController {
     }
 
     private OperationOutcome createErrorBodyForInProgressRequest(String conversationId) {
-        var operationErrorCode = "INTERNAL_SERVER_ERROR";
+        var operationErrorCode = INTERNAL_SERVER_ERROR;
         var operationErrorMessage = "PS - The Given NHS number is already being processed against Conversation ID: "
             + conversationId + ", you cannot start a new request until the current request has completed or failed.";
 
-        CodeableConcept details = CodeableConceptUtils.
-                createCodeableConcept(operationErrorCode, ISSUE_SYSTEM, operationErrorMessage, null);
+        var details = CodeableConceptUtils.createCodeableConcept(operationErrorCode, ISSUE_SYSTEM, operationErrorMessage, null);
         return createOperationOutcome(EXCEPTION, ERROR, details, "");
     }
+
     private OperationOutcome createErrorBodyFromMigrationStatus(MigrationStatus migrationStatus) {
 
         String operationErrorCode;
@@ -152,15 +153,16 @@ public class PatientTransferController {
                     + "not the patient’s current primary healthcare provider";
                 break;
             case EHR_EXTRACT_REQUEST_NEGATIVE_ACK_GP2GP_EHR_GENERATION_ERROR:
-                operationErrorCode = "INTERNAL_SERVER_ERROR";
+                operationErrorCode = INTERNAL_SERVER_ERROR;
+
                 operationErrorMessage = "GP2GP - Failed to successfully generate the EHR";
                 break;
             case EHR_EXTRACT_REQUEST_NEGATIVE_ACK_GP2GP_MULTI_OR_NO_RESPONSES:
-                operationErrorCode = "INTERNAL_SERVER_ERROR";
+                operationErrorCode = INTERNAL_SERVER_ERROR;
                 operationErrorMessage = "GP2GP - SDS lookup provided zero or more than one result to the query for each interaction.";
                 break;
             case EHR_EXTRACT_REQUEST_NEGATIVE_ACK_UNKNOWN:
-                operationErrorCode = "INTERNAL_SERVER_ERROR";
+                operationErrorCode = INTERNAL_SERVER_ERROR;
                 operationErrorMessage = "GP2GP - This is a code that should only be used in circumstances where no other codes can"
                     + " be used to accurately describe the condition.";
                 break;
@@ -169,47 +171,47 @@ public class PatientTransferController {
                 operationErrorMessage = "GP2GP - End Point setup but GP2GP configuration switched OFF";
                 break;
             case ERROR_LRG_MSG_REASSEMBLY_FAILURE:
-                operationErrorCode = "INTERNAL_SERVER_ERROR";
+                operationErrorCode = INTERNAL_SERVER_ERROR;
                 operationErrorMessage = "PS - The Adaptor was unable to recombine the parts of a received attachment";
                 break;
             case ERROR_LRG_MSG_ATTACHMENTS_NOT_RECEIVED:
-                operationErrorCode = "INTERNAL_SERVER_ERROR";
+                operationErrorCode = INTERNAL_SERVER_ERROR;
                 operationErrorMessage = "PS - At least one attachment has not been received or could not be processed";
                 break;
             case ERROR_LRG_MSG_GENERAL_FAILURE:
-                operationErrorCode = "INTERNAL_SERVER_ERROR";
+                operationErrorCode = INTERNAL_SERVER_ERROR;
                 operationErrorMessage = "PS - A general processing error has occurred";
                 break;
             case ERROR_LRG_MSG_TIMEOUT:
-                operationErrorCode = "INTERNAL_SERVER_ERROR";
+                operationErrorCode = INTERNAL_SERVER_ERROR;
                 operationErrorMessage = "PS - An attachment was not received before a timeout condition occurred";
                 break;
             case ERROR_REQUEST_TIMEOUT:
-                operationErrorCode = "INTERNAL_SERVER_ERROR";
+                operationErrorCode = INTERNAL_SERVER_ERROR;
                 operationErrorMessage = "PS - The EHR record was not received within the given timeout timeframe";
                 break;
             case EHR_EXTRACT_NEGATIVE_ACK_ABA_INCORRECT_PATIENT:
-                operationErrorCode = "INTERNAL_SERVER_ERROR";
+                operationErrorCode = INTERNAL_SERVER_ERROR;
                 operationErrorMessage = "PS - A-B-A EHR Extract Received and rejected due to wrong record or wrong patient";
                 break;
             case EHR_EXTRACT_NEGATIVE_ACK_NON_ABA_INCORRECT_PATIENT:
-                operationErrorCode = "INTERNAL_SERVER_ERROR";
+                operationErrorCode = INTERNAL_SERVER_ERROR;
                 operationErrorMessage = "PS - Non A-B-A EHR Extract Received and rejected due to wrong record or wrong patient";
                 break;
             case EHR_EXTRACT_NEGATIVE_ACK_FAILED_TO_INTEGRATE:
-                operationErrorCode = "INTERNAL_SERVER_ERROR";
+                operationErrorCode = INTERNAL_SERVER_ERROR;
                 operationErrorMessage = "PS - Failed to successfully integrate EHR Extract";
                 break;
             case EHR_EXTRACT_NEGATIVE_ACK_SUPPRESSED:
-                operationErrorCode = "INTERNAL_SERVER_ERROR";
+                operationErrorCode = INTERNAL_SERVER_ERROR;
                 operationErrorMessage = "PS - A-B-A EHR Extract Received and Stored As Suppressed Record";
                 break;
             case ERROR_EXTRACT_CANNOT_BE_PROCESSED:
-                operationErrorCode = "INTERNAL_SERVER_ERROR";
+                operationErrorCode = INTERNAL_SERVER_ERROR;
                 operationErrorMessage = "PS - EHR Extract message not well-formed or not able to be processed";
                 break;
             default:
-                operationErrorCode = "INTERNAL_SERVER_ERROR";
+                operationErrorCode = INTERNAL_SERVER_ERROR;
                 operationErrorMessage = "PS - A general error has occurred";
                 break;
         }

--- a/gpc-api-facade/src/main/java/uk/nhs/adaptors/pss/gpc/service/PatientTransferService.java
+++ b/gpc-api-facade/src/main/java/uk/nhs/adaptors/pss/gpc/service/PatientTransferService.java
@@ -46,7 +46,7 @@ public class PatientTransferService {
             patientMigrationRequestDao.addNewRequest(patientNhsNumber, conversationId, headers.get(TO_ODS), headers.get(FROM_ODS));
 
             int addedId = patientMigrationRequestDao.getMigrationRequestId(conversationId);
-            migrationStatusLogDao.addMigrationStatusLog(REQUEST_RECEIVED, dateUtils.getCurrentOffsetDateTime(), addedId, null);
+            migrationStatusLogDao.addMigrationStatusLog(REQUEST_RECEIVED, dateUtils.getCurrentOffsetDateTime(), addedId, null, null);
 
             var pssMessage = createTransferRequestMessage(patientNhsNumber, headers, conversationId);
             pssQueuePublisher.sendToPssQueue(pssMessage);

--- a/gpc-api-facade/src/test/java/uk/nhs/adaptors/pss/gpc/controller/PatientTransferControllerTest.java
+++ b/gpc-api-facade/src/test/java/uk/nhs/adaptors/pss/gpc/controller/PatientTransferControllerTest.java
@@ -1,6 +1,7 @@
 package uk.nhs.adaptors.pss.gpc.controller;
 
 import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.when;
@@ -39,6 +40,7 @@ import uk.nhs.adaptors.pss.gpc.service.PatientTransferService;
 
 @ExtendWith(MockitoExtension.class)
 public class PatientTransferControllerTest {
+
     private static final String RESPONSE_BODY = "{responseBody}";
     private static final Parameters PARAMETERS = new Parameters();
     private static final String TO_ASID_VALUE = "123";
@@ -68,7 +70,8 @@ public class PatientTransferControllerTest {
 
         ResponseEntity<String> response = controller.migratePatientStructuredRecord(
             PARAMETERS, TO_ASID_VALUE, FROM_ASID_VALUE, TO_ODS_VALUE, FROM_ODS_VALUE);
-        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.ACCEPTED);
+
+        assertEquals(HttpStatus.ACCEPTED, response.getStatusCode());
         assertThat(response.getBody()).isNull();
     }
 
@@ -79,7 +82,8 @@ public class PatientTransferControllerTest {
 
         ResponseEntity<String> response = controller.migratePatientStructuredRecord(
             PARAMETERS, TO_ASID_VALUE, FROM_ASID_VALUE, TO_ODS_VALUE, FROM_ODS_VALUE);
-        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.NO_CONTENT);
+
+        assertEquals(HttpStatus.NO_CONTENT, response.getStatusCode());
         assertThat(response.getBody()).isNull();
     }
 
@@ -90,7 +94,8 @@ public class PatientTransferControllerTest {
 
         ResponseEntity<String> response = controller.migratePatientStructuredRecord(
             PARAMETERS, TO_ASID_VALUE, FROM_ASID_VALUE, TO_ODS_VALUE, FROM_ODS_VALUE);
-        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.NO_CONTENT);
+
+        assertEquals(HttpStatus.NO_CONTENT, response.getStatusCode());
         assertThat(response.getBody()).isNull();
     }
 
@@ -102,7 +107,8 @@ public class PatientTransferControllerTest {
 
         ResponseEntity<String> response = controller.migratePatientStructuredRecord(
             PARAMETERS, TO_ASID_VALUE, FROM_ASID_VALUE, TO_ODS_VALUE, FROM_ODS_VALUE);
-        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+
+        assertEquals(HttpStatus.OK, response.getStatusCode());
         assertThat(response.getBody()).isEqualTo(RESPONSE_BODY);
     }
 
@@ -113,7 +119,8 @@ public class PatientTransferControllerTest {
 
         Exception exception = assertThrows(IllegalStateException.class, () -> controller.migratePatientStructuredRecord(
             PARAMETERS, TO_ASID_VALUE, FROM_ASID_VALUE, TO_ODS_VALUE, FROM_ODS_VALUE));
-        assertThat(exception.getMessage()).isEqualTo("Unsupported transfer status: EHR_EXTRACT_REQUEST_ERROR");
+
+        assertEquals("Unsupported transfer status: EHR_EXTRACT_REQUEST_ERROR", exception.getMessage());
     }
 
     @Test
@@ -126,7 +133,8 @@ public class PatientTransferControllerTest {
 
         ResponseEntity<String> response = controller.migratePatientStructuredRecord(
             PARAMETERS, TO_ASID_VALUE, FROM_ASID_VALUE, TO_ODS_VALUE, FROM_ODS_VALUE);
-        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.INTERNAL_SERVER_ERROR);
+
+        assertEquals(HttpStatus.INTERNAL_SERVER_ERROR, response.getStatusCode());
     }
 
     @Test
@@ -139,7 +147,8 @@ public class PatientTransferControllerTest {
 
         ResponseEntity<String> response = controller.migratePatientStructuredRecord(
             PARAMETERS, TO_ASID_VALUE, FROM_ASID_VALUE, TO_ODS_VALUE, FROM_ODS_VALUE);
-        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.NOT_IMPLEMENTED);
+
+        assertEquals(HttpStatus.NOT_IMPLEMENTED, response.getStatusCode());
     }
 
     @Test
@@ -152,7 +161,8 @@ public class PatientTransferControllerTest {
 
         ResponseEntity<String> response = controller.migratePatientStructuredRecord(
             PARAMETERS, TO_ASID_VALUE, FROM_ASID_VALUE, TO_ODS_VALUE, FROM_ODS_VALUE);
-        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.BAD_REQUEST);
+
+        assertEquals(HttpStatus.BAD_REQUEST, response.getStatusCode());
     }
 
     @Test
@@ -165,7 +175,8 @@ public class PatientTransferControllerTest {
 
         ResponseEntity<String> response = controller.migratePatientStructuredRecord(
             PARAMETERS, TO_ASID_VALUE, FROM_ASID_VALUE, TO_ODS_VALUE, FROM_ODS_VALUE);
-        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.NOT_FOUND);
+
+        assertEquals(HttpStatus.NOT_FOUND, response.getStatusCode());
     }
 
     @Test
@@ -178,7 +189,8 @@ public class PatientTransferControllerTest {
 
         ResponseEntity<String> response = controller.migratePatientStructuredRecord(
             PARAMETERS, TO_ASID_VALUE, FROM_ASID_VALUE, TO_ODS_VALUE, FROM_ODS_VALUE);
-        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.INTERNAL_SERVER_ERROR);
+
+        assertEquals(HttpStatus.INTERNAL_SERVER_ERROR, response.getStatusCode());
     }
 
     @Test
@@ -189,7 +201,7 @@ public class PatientTransferControllerTest {
         var response = controller.migratePatientStructuredRecord(
                 PARAMETERS, TO_ASID_VALUE, FROM_ASID_VALUE, TO_ODS_VALUE, FROM_ODS_VALUE);
 
-        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.INTERNAL_SERVER_ERROR);
+        assertEquals(HttpStatus.INTERNAL_SERVER_ERROR, response.getStatusCode());
 
     }
 

--- a/gpc-api-facade/src/test/java/uk/nhs/adaptors/pss/gpc/service/PatientTransferServiceTest.java
+++ b/gpc-api-facade/src/test/java/uk/nhs/adaptors/pss/gpc/service/PatientTransferServiceTest.java
@@ -1,6 +1,7 @@
 package uk.nhs.adaptors.pss.gpc.service;
 
 import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
@@ -99,7 +100,7 @@ public class PatientTransferServiceTest {
 
         MigrationStatusLog patientMigrationRequest = service.handlePatientMigrationRequest(parameters, HEADERS);
 
-        assertThat(patientMigrationRequest).isEqualTo(null);
+        assertThat(patientMigrationRequest).isNull();
         verify(pssQueuePublisher).sendToPssQueue(expectedPssQueueMessage);
         verify(patientMigrationRequestDao).addNewRequest(PATIENT_NHS_NUMBER, CONVERSATION_ID, LOSING_ODS_CODE, WINNING_ODS_CODE);
         verify(migrationStatusLogDao).addMigrationStatusLog(MigrationStatus.REQUEST_RECEIVED, now, migrationRequestId, null);
@@ -125,7 +126,7 @@ public class PatientTransferServiceTest {
 
         MigrationStatusLog patientMigrationRequest = service.handlePatientMigrationRequest(parameters, HEADERS);
 
-        assertThat(patientMigrationRequest).isEqualTo(null);
+        assertThat(patientMigrationRequest).isNull();
         verify(pssQueuePublisher).sendToPssQueue(expectedPssQueueMessage);
         verify(patientMigrationRequestDao).addNewRequest(PATIENT_NHS_NUMBER, CONVERSATION_ID, LOSING_ODS_CODE, WINNING_ODS_CODE);
         verify(migrationStatusLogDao).addMigrationStatusLog(MigrationStatus.REQUEST_RECEIVED, now, migrationRequestId, null);
@@ -143,7 +144,7 @@ public class PatientTransferServiceTest {
 
         MigrationStatusLog patientMigrationRequest = service.handlePatientMigrationRequest(parameters, HEADERS);
 
-        assertThat(patientMigrationRequest).isEqualTo(expectedMigrationStatusLog);
+        assertEquals(expectedMigrationStatusLog, patientMigrationRequest);
         verifyNoInteractions(pssQueuePublisher);
         verify(patientMigrationRequestDao).getMigrationRequest(CONVERSATION_ID);
         verifyNoMoreInteractions(patientMigrationRequestDao);
@@ -162,7 +163,7 @@ public class PatientTransferServiceTest {
 
         MigrationStatusLog patientMigrationRequest = service.handlePatientMigrationRequest(parameters, HEADERS);
 
-        assertThat(patientMigrationRequest).isEqualTo(expectedMigrationStatusLog);
+        assertEquals(expectedMigrationStatusLog, patientMigrationRequest);
         verifyNoInteractions(pssQueuePublisher);
         verify(patientMigrationRequestDao).getMigrationRequest(CONVERSATION_ID);
         verifyNoMoreInteractions(patientMigrationRequestDao);
@@ -212,7 +213,7 @@ public class PatientTransferServiceTest {
         var existingConversationId = service.checkExistingPatientMigrationRequestInProgress(parameters);
 
         assertThat(existingConversationId).isNotNull();
-        assertThat(existingConversationId).isEqualTo(CONVERSATION_ID);
+        assertEquals(CONVERSATION_ID, existingConversationId);
     }
 
     @ParameterizedTest

--- a/gpc-api-facade/src/test/java/uk/nhs/adaptors/pss/gpc/service/PatientTransferServiceTest.java
+++ b/gpc-api-facade/src/test/java/uk/nhs/adaptors/pss/gpc/service/PatientTransferServiceTest.java
@@ -103,7 +103,7 @@ public class PatientTransferServiceTest {
         assertThat(patientMigrationRequest).isNull();
         verify(pssQueuePublisher).sendToPssQueue(expectedPssQueueMessage);
         verify(patientMigrationRequestDao).addNewRequest(PATIENT_NHS_NUMBER, CONVERSATION_ID, LOSING_ODS_CODE, WINNING_ODS_CODE);
-        verify(migrationStatusLogDao).addMigrationStatusLog(MigrationStatus.REQUEST_RECEIVED, now, migrationRequestId, null);
+        verify(migrationStatusLogDao).addMigrationStatusLog(MigrationStatus.REQUEST_RECEIVED, now, migrationRequestId, null, null);
     }
 
     @Test
@@ -129,7 +129,7 @@ public class PatientTransferServiceTest {
         assertThat(patientMigrationRequest).isNull();
         verify(pssQueuePublisher).sendToPssQueue(expectedPssQueueMessage);
         verify(patientMigrationRequestDao).addNewRequest(PATIENT_NHS_NUMBER, CONVERSATION_ID, LOSING_ODS_CODE, WINNING_ODS_CODE);
-        verify(migrationStatusLogDao).addMigrationStatusLog(MigrationStatus.REQUEST_RECEIVED, now, migrationRequestId, null);
+        verify(migrationStatusLogDao).addMigrationStatusLog(MigrationStatus.REQUEST_RECEIVED, now, migrationRequestId, null, null);
     }
 
     @Test

--- a/gpc-api-facade/src/test/java/uk/nhs/adaptors/pss/gpc/util/fhir/OperationOutcomeUtilsTest.java
+++ b/gpc-api-facade/src/test/java/uk/nhs/adaptors/pss/gpc/util/fhir/OperationOutcomeUtilsTest.java
@@ -4,9 +4,7 @@ import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
 import static org.hl7.fhir.dstu3.model.OperationOutcome.IssueSeverity.ERROR;
 import static org.hl7.fhir.dstu3.model.OperationOutcome.IssueType.NOTSUPPORTED;
 import static org.junit.jupiter.api.Assertions.assertEquals;
-
 import org.hl7.fhir.dstu3.model.CodeableConcept;
-import org.hl7.fhir.dstu3.model.OperationOutcome;
 import org.junit.jupiter.api.Test;
 
 import uk.nhs.adaptors.common.util.CodeableConceptUtils;

--- a/gpc-api-facade/src/test/java/uk/nhs/adaptors/pss/gpc/util/fhir/OperationOutcomeUtilsTest.java
+++ b/gpc-api-facade/src/test/java/uk/nhs/adaptors/pss/gpc/util/fhir/OperationOutcomeUtilsTest.java
@@ -3,6 +3,7 @@ package uk.nhs.adaptors.pss.gpc.util.fhir;
 import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
 import static org.hl7.fhir.dstu3.model.OperationOutcome.IssueSeverity.ERROR;
 import static org.hl7.fhir.dstu3.model.OperationOutcome.IssueType.NOTSUPPORTED;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import org.hl7.fhir.dstu3.model.CodeableConcept;
 import org.hl7.fhir.dstu3.model.OperationOutcome;
@@ -15,16 +16,17 @@ public class OperationOutcomeUtilsTest {
 
     @Test
     public void testCreateOperationOutcome() {
+
         var details = createCodeableConcept();
         var diagnostics = "Dancing not supported";
 
-        OperationOutcome result = OperationOutcomeUtils.createOperationOutcome(NOTSUPPORTED, ERROR, details, diagnostics);
+        var result = OperationOutcomeUtils.createOperationOutcome(NOTSUPPORTED, ERROR, details, diagnostics);
 
         assertThat(result.getMeta().getProfile().get(0).equals(URI_TYPE)).isTrue();
-        assertThat(result.getIssueFirstRep().getCode()).isEqualTo(NOTSUPPORTED);
-        assertThat(result.getIssueFirstRep().getSeverity()).isEqualTo(ERROR);
-        assertThat(result.getIssueFirstRep().getDetails()).isEqualTo(details);
-        assertThat(result.getIssueFirstRep().getDiagnostics()).isEqualTo(diagnostics);
+        assertEquals(NOTSUPPORTED, result.getIssueFirstRep().getCode());
+        assertEquals(ERROR, result.getIssueFirstRep().getSeverity());
+        assertEquals(details, result.getIssueFirstRep().getDetails());
+        assertEquals(diagnostics, result.getIssueFirstRep().getDiagnostics());
     }
 
     private CodeableConcept createCodeableConcept() {


### PR DESCRIPTION
## What

Capturing negative ack error code in DB

## Why

PS Adaptor doesn't record/store original error code sent by an incumbent in case of a failure. There is a requirement by NHS England to send failure details hence there should be some mechanism to capture it in PS Adaptor in order to give an access to such information when required.

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Internal change (non-breaking change with no effect on the functionality affecting end users)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:

- [x] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] I have updated the [Changelog](/CHANGELOG.md) with details of my change in the UNRELEASED section if this change will affect end users
- [ ] A corresponding change has been made to the [Mapping Documentation repository][mapping-docs]

[mapping-docs]: https://github.com/NHSDigital/patient-switching-adaptors-mapping-documentation