### PR TITLE
Eliminating possible NPE + adding safer try--with-resources version + small code cleanup

### DIFF
--- a/gp2gp-translator/src/main/java/uk/nhs/adaptors/pss/translator/mapper/AgentDirectoryMapper.java
+++ b/gp2gp-translator/src/main/java/uk/nhs/adaptors/pss/translator/mapper/AgentDirectoryMapper.java
@@ -63,7 +63,7 @@ public class AgentDirectoryMapper {
             return agentResources;
         }
 
-        return null;
+        return List.of();
     }
 
     private void mapAgent(RCCTMT120101UK01Agent agent, List<DomainResource> agentResourceList) {

--- a/gp2gp-translator/src/main/java/uk/nhs/adaptors/pss/translator/mapper/DocumentReferenceMapper.java
+++ b/gp2gp-translator/src/main/java/uk/nhs/adaptors/pss/translator/mapper/DocumentReferenceMapper.java
@@ -238,6 +238,6 @@ public class DocumentReferenceMapper extends AbstractMapper<DocumentReference> {
     // stubbed method for abstract class
     public List<DocumentReference> mapResources(RCMRMT030101UK04EhrExtract ehrExtract, Patient patient,
         List<Encounter> encounterList, String practiseCode) {
-        return null;
+        return List.of();
     }
 }

--- a/gp2gp-translator/src/main/java/uk/nhs/adaptors/pss/translator/storage/AzureStorageService.java
+++ b/gp2gp-translator/src/main/java/uk/nhs/adaptors/pss/translator/storage/AzureStorageService.java
@@ -82,23 +82,21 @@ public class AzureStorageService implements StorageService {
     }
 
     private void addFileStringToMainContainer(String filename, byte[] fileAsString) throws StorageException, IOException {
-        try {
+        try (InputStream dataStream = new ByteArrayInputStream(fileAsString)) {
             BlockBlobClient blobClient = createBlobBlockClient(filename);
-            InputStream dataStream = new ByteArrayInputStream(fileAsString);
             blobClient.upload(dataStream, fileAsString.length);
-            dataStream.close();
         } catch (IOException e) {
             throw new StorageException("Failed to upload blob to Azure Blob storage", e);
         }
     }
 
     private ByteArrayOutputStream downloadFileToStream(String filename) throws StorageException {
-        try {
-            BlockBlobClient blobClient = createBlobBlockClient(filename);
-            int dataSize = (int) blobClient.getProperties().getBlobSize();
-            ByteArrayOutputStream outputStream = new ByteArrayOutputStream(dataSize);
+
+        BlockBlobClient blobClient = createBlobBlockClient(filename);
+        int dataSize = (int) blobClient.getProperties().getBlobSize();
+
+        try (ByteArrayOutputStream outputStream = new ByteArrayOutputStream(dataSize)) {
             blobClient.downloadStream(outputStream);
-            outputStream.close();
             return outputStream;
         } catch (IOException e) {
             throw new StorageException("Failed to download blob from Azure Blob storage", e);

--- a/gp2gp-translator/src/main/java/uk/nhs/adaptors/pss/translator/util/ObservationUtil.java
+++ b/gp2gp-translator/src/main/java/uk/nhs/adaptors/pss/translator/util/ObservationUtil.java
@@ -138,10 +138,8 @@ public class ObservationUtil {
                 effectivePeriod.setEndElement(DateFormatUtil.parseToDateTimeType(effectiveTime.getHigh().getValue()));
             }
 
-            if (availabilityTimeHasValue(availabilityTime) && effectivePeriod.getStart() == null) {
-                if (effectivePeriod.getEnd() != null) {
-                    effectivePeriod.setStartElement(DateFormatUtil.parseToDateTimeType(availabilityTime.getValue()));
-                }
+            if (availabilityTimeHasValue(availabilityTime) && effectivePeriod.getStart() == null && effectivePeriod.getEnd() != null) {
+                effectivePeriod.setStartElement(DateFormatUtil.parseToDateTimeType(availabilityTime.getValue()));
             }
 
             if (effectivePeriod.hasStart() || effectivePeriod.hasEnd()) {

--- a/gp2gp-translator/src/main/java/uk/nhs/adaptors/pss/translator/util/ResourceReferenceUtil.java
+++ b/gp2gp-translator/src/main/java/uk/nhs/adaptors/pss/translator/util/ResourceReferenceUtil.java
@@ -4,8 +4,6 @@ import static uk.nhs.adaptors.pss.translator.util.ResourceFilterUtil.isAllergyIn
 import static uk.nhs.adaptors.pss.translator.util.ResourceFilterUtil.isBloodPressure;
 import static uk.nhs.adaptors.pss.translator.util.ResourceFilterUtil.isDiagnosticReport;
 import static uk.nhs.adaptors.pss.translator.util.ResourceFilterUtil.isDocumentReference;
-import static uk.nhs.adaptors.pss.translator.util.ResourceFilterUtil.isTemplate;
-
 import java.util.List;
 
 import org.hl7.fhir.dstu3.model.IdType;
@@ -57,14 +55,6 @@ public class ResourceReferenceUtil {
                 addDiagnosticReportEntry(compoundStatement, entryReferences);
             } else {
 
-                // NIAD_2190 the section below appears to be for Questionnaire Response links and the observation
-                // created that goes with it. Since Questionnaires have been removed, the contents of the addTemplateEntry function has
-                // been commented out while it is tested more in depth. It can be removed following the effect investigation
-                // - Scott Alexander 21072022
-                if (isTemplate(compoundStatement)) {
-                    addTemplateEntry(compoundStatement, entryReferences);
-                }
-
                 compoundStatement.getComponent().forEach(component -> {
                     addObservationStatementEntry(
                         component.getObservationStatement(), entryReferences, compoundStatement);
@@ -106,14 +96,6 @@ public class ResourceReferenceUtil {
             || references.contains(QUESTIONNAIRE_ID.formatted(QUESTIONNAIRE_REFERENCE.formatted(
             compoundStatement.getId().get(0).getRoot())))
             || !references.contains(OBSERVATION_REFERENCE.formatted(compoundStatement.getId().get(0).getRoot()));
-    }
-
-    private static void addTemplateEntry(RCMRMT030101UK04CompoundStatement compoundStatement,
-                                         List<Reference> entryReferences) {
-//        entryReferences.add(createResourceReference(ResourceType.QuestionnaireResponse.name(),
-//            QUESTIONNAIRE_ID.formatted(compoundStatement.getId().get(0).getRoot())));
-//        entryReferences.add(createResourceReference(ResourceType.Observation.name(),
-//            compoundStatement.getId().get(0).getRoot()));
     }
 
     private void addObservationStatementEntry(RCMRMT030101UK04ObservationStatement observationStatement,


### PR DESCRIPTION
## What

Methods in mappers return null which potentially can cause NPE, also there is a safer version of try-catch introduced: try-with-resources

## Why

When method returns null instead of an empty collection it will propagate nulls into other places in code and can potentially trigger NPE. It is better and safer to return an empty collection. Also, try-with-resources will make sure that the steam will be always closed not matter what.

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Internal change (non-breaking change with no effect on the functionality affecting end users)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:

- [x] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I have updated the [Changelog](/CHANGELOG.md) with details of my change in the UNRELEASED section if this change will affect end users
- [ ] A corresponding change has been made to the [Mapping Documentation repository][mapping-docs]

[mapping-docs]: https://github.com/NHSDigital/patient-switching-adaptors-mapping-documentation