### PR TITLE
NIAD-2772: adding identifier block to practitioner section

### DIFF
--- a/gp2gp-translator/src/integrationTest/resources/e2e-mapping/output-json/PWTP10-output.json
+++ b/gp2gp-translator/src/integrationTest/resources/e2e-mapping/output-json/PWTP10-output.json
@@ -46,7 +46,11 @@
               "Dr"
             ]
           }
-        ]
+        ],
+        "identifier": [ {
+          "system": "https://fhir.hl7.org.uk/Id/gmp-number",
+          "value": "7882315"
+        } ]
       }
     },
     {
@@ -69,7 +73,11 @@
               "Dr"
             ]
           }
-        ]
+        ],
+        "identifier": [ {
+          "system": "https://fhir.hl7.org.uk/Id/gmp-number",
+          "value": "7889233"
+        } ]
       }
     },
     {

--- a/gp2gp-translator/src/integrationTest/resources/e2e-mapping/output-json/PWTP11-output.json
+++ b/gp2gp-translator/src/integrationTest/resources/e2e-mapping/output-json/PWTP11-output.json
@@ -46,7 +46,11 @@
               "Dr"
             ]
           }
-        ]
+        ],
+        "identifier": [ {
+          "system": "https://fhir.hl7.org.uk/Id/gmp-number",
+          "value": "7889233"
+        } ]
       }
     },
     {

--- a/gp2gp-translator/src/integrationTest/resources/e2e-mapping/output-json/PWTP2-output.json
+++ b/gp2gp-translator/src/integrationTest/resources/e2e-mapping/output-json/PWTP2-output.json
@@ -46,7 +46,11 @@
               "Dr"
             ]
           }
-        ]
+        ],
+        "identifier": [ {
+          "system": "https://fhir.hl7.org.uk/Id/gmp-number",
+          "value": "7882315"
+        } ]
       }
     },
     {
@@ -92,7 +96,11 @@
               "Dr"
             ]
           }
-        ]
+        ],
+        "identifier": [ {
+          "system": "https://fhir.hl7.org.uk/Id/gmp-number",
+          "value": "7889233"
+        } ]
       }
     },
     {

--- a/gp2gp-translator/src/integrationTest/resources/e2e-mapping/output-json/PWTP3-output.json
+++ b/gp2gp-translator/src/integrationTest/resources/e2e-mapping/output-json/PWTP3-output.json
@@ -46,7 +46,11 @@
               "Dr"
             ]
           }
-        ]
+        ],
+        "identifier": [ {
+          "system": "https://fhir.hl7.org.uk/Id/gmp-number",
+          "value": "7882315"
+        } ]
       }
     },
     {
@@ -69,7 +73,11 @@
               "Dr"
             ]
           }
-        ]
+        ],
+        "identifier": [ {
+          "system": "https://fhir.hl7.org.uk/Id/gmp-number",
+          "value": "7889233"
+        } ]
       }
     },
     {

--- a/gp2gp-translator/src/integrationTest/resources/e2e-mapping/output-json/PWTP4-output.json
+++ b/gp2gp-translator/src/integrationTest/resources/e2e-mapping/output-json/PWTP4-output.json
@@ -63,7 +63,11 @@
               "Dr"
             ]
           }
-        ]
+        ],
+        "identifier": [ {
+          "system": "https://fhir.hl7.org.uk/Id/gmp-number",
+          "value": "7882315"
+        } ]
       }
     },
     {
@@ -132,7 +136,11 @@
               "Dr"
             ]
           }
-        ]
+        ],
+        "identifier": [ {
+          "system": "https://fhir.hl7.org.uk/Id/gmp-number",
+          "value": "7889233"
+        } ]
       }
     },
     {

--- a/gp2gp-translator/src/integrationTest/resources/e2e-mapping/output-json/PWTP5-output.json
+++ b/gp2gp-translator/src/integrationTest/resources/e2e-mapping/output-json/PWTP5-output.json
@@ -46,7 +46,11 @@
               "Dr"
             ]
           }
-        ]
+        ],
+        "identifier": [ {
+          "system": "https://fhir.hl7.org.uk/Id/gmp-number",
+          "value": "7889233"
+        } ]
       }
     },
     {

--- a/gp2gp-translator/src/integrationTest/resources/e2e-mapping/output-json/PWTP6-output.json
+++ b/gp2gp-translator/src/integrationTest/resources/e2e-mapping/output-json/PWTP6-output.json
@@ -46,7 +46,11 @@
               "Dr"
             ]
           }
-        ]
+        ],
+        "identifier": [ {
+          "system": "https://fhir.hl7.org.uk/Id/gmp-number",
+          "value": "7882315"
+        } ]
       }
     },
     {
@@ -69,7 +73,11 @@
               "Dr"
             ]
           }
-        ]
+        ],
+        "identifier": [ {
+          "system": "https://fhir.hl7.org.uk/Id/gmp-number",
+          "value": "7889233"
+        } ]
       }
     },
     {

--- a/gp2gp-translator/src/integrationTest/resources/e2e-mapping/output-json/PWTP7_vis-output.json
+++ b/gp2gp-translator/src/integrationTest/resources/e2e-mapping/output-json/PWTP7_vis-output.json
@@ -63,7 +63,11 @@
               "Dr"
             ]
           }
-        ]
+        ],
+        "identifier": [ {
+          "system": "https://fhir.hl7.org.uk/Id/gmp-number",
+          "value": "7882315"
+        } ]
       }
     },
     {
@@ -86,7 +90,11 @@
               "Dr"
             ]
           }
-        ]
+        ],
+        "identifier": [ {
+          "system": "https://fhir.hl7.org.uk/Id/gmp-number",
+          "value": "7889233"
+        } ]
       }
     },
     {

--- a/gp2gp-translator/src/integrationTest/resources/e2e-mapping/output-json/PWTP9-output.json
+++ b/gp2gp-translator/src/integrationTest/resources/e2e-mapping/output-json/PWTP9-output.json
@@ -46,7 +46,11 @@
               "Dr"
             ]
           }
-        ]
+        ],
+        "identifier": [ {
+          "system": "https://fhir.hl7.org.uk/Id/gmp-number",
+          "value": "7882315"
+        } ]
       }
     },
     {
@@ -92,7 +96,11 @@
               "Dr"
             ]
           }
-        ]
+        ],
+        "identifier": [ {
+          "system": "https://fhir.hl7.org.uk/Id/gmp-number",
+          "value": "7889233"
+        } ]
       }
     },
     {

--- a/gp2gp-translator/src/integrationTest/resources/json/LargeMessage/expectedBundleScenario1.json
+++ b/gp2gp-translator/src/integrationTest/resources/json/LargeMessage/expectedBundleScenario1.json
@@ -97,7 +97,11 @@
               "Dr"
             ]
           }
-        ]
+        ],
+        "identifier": [ {
+          "system": "https://fhir.hl7.org.uk/Id/gmp-number",
+          "value": "G2141239"
+        } ]
       }
     },
     {
@@ -210,7 +214,11 @@
               "Dr"
             ]
           }
-        ]
+        ],
+        "identifier": [ {
+          "system": "https://fhir.hl7.org.uk/Id/gmp-number",
+          "value": "G9489493"
+        } ]
       }
     },
     {

--- a/gp2gp-translator/src/integrationTest/resources/json/LargeMessage/expectedBundleScenario10.json
+++ b/gp2gp-translator/src/integrationTest/resources/json/LargeMessage/expectedBundleScenario10.json
@@ -92,7 +92,11 @@
               "Dr"
             ]
           }
-        ]
+        ],
+        "identifier": [ {
+          "system": "https://fhir.hl7.org.uk/Id/gmp-number",
+          "value": "12345"
+        } ]
       }
     },
     {

--- a/gp2gp-translator/src/integrationTest/resources/json/LargeMessage/expectedBundleScenario11.json
+++ b/gp2gp-translator/src/integrationTest/resources/json/LargeMessage/expectedBundleScenario11.json
@@ -92,7 +92,11 @@
               "Dr"
             ]
           }
-        ]
+        ],
+        "identifier": [ {
+          "system": "https://fhir.hl7.org.uk/Id/gmp-number",
+          "value": "12345"
+        } ]
       }
     },
     {

--- a/gp2gp-translator/src/integrationTest/resources/json/LargeMessage/expectedBundleScenario2.json
+++ b/gp2gp-translator/src/integrationTest/resources/json/LargeMessage/expectedBundleScenario2.json
@@ -97,7 +97,11 @@
               "Dr"
             ]
           }
-        ]
+        ],
+        "identifier": [ {
+          "system": "https://fhir.hl7.org.uk/Id/gmp-number",
+          "value": "G2141239"
+        } ]
       }
     },
     {
@@ -210,7 +214,11 @@
               "Dr"
             ]
           }
-        ]
+        ],
+        "identifier": [ {
+          "system": "https://fhir.hl7.org.uk/Id/gmp-number",
+          "value": "G9489493"
+        } ]
       }
     },
     {

--- a/gp2gp-translator/src/integrationTest/resources/json/LargeMessage/expectedBundleScenario3.json
+++ b/gp2gp-translator/src/integrationTest/resources/json/LargeMessage/expectedBundleScenario3.json
@@ -97,7 +97,11 @@
               "Dr"
             ]
           }
-        ]
+        ],
+        "identifier": [ {
+          "system": "https://fhir.hl7.org.uk/Id/gmp-number",
+          "value": "G2141239"
+        } ]
       }
     },
     {
@@ -210,7 +214,11 @@
               "Dr"
             ]
           }
-        ]
+        ],
+        "identifier": [ {
+          "system": "https://fhir.hl7.org.uk/Id/gmp-number",
+          "value": "G9489493"
+        } ]
       }
     },
     {

--- a/gp2gp-translator/src/integrationTest/resources/json/LargeMessage/expectedBundleScenario4.json
+++ b/gp2gp-translator/src/integrationTest/resources/json/LargeMessage/expectedBundleScenario4.json
@@ -97,7 +97,11 @@
               "Dr"
             ]
           }
-        ]
+        ],
+        "identifier": [ {
+          "system": "https://fhir.hl7.org.uk/Id/gmp-number",
+          "value": "G2141239"
+        } ]
       }
     },
     {
@@ -210,7 +214,11 @@
               "Dr"
             ]
           }
-        ]
+        ],
+        "identifier": [ {
+          "system": "https://fhir.hl7.org.uk/Id/gmp-number",
+          "value": "G9489493"
+        } ]
       }
     },
     {

--- a/gp2gp-translator/src/integrationTest/resources/json/LargeMessage/expectedBundleScenario5.json
+++ b/gp2gp-translator/src/integrationTest/resources/json/LargeMessage/expectedBundleScenario5.json
@@ -97,7 +97,11 @@
               "Dr"
             ]
           }
-        ]
+        ],
+        "identifier": [ {
+          "system": "https://fhir.hl7.org.uk/Id/gmp-number",
+          "value": "G2141239"
+        } ]
       }
     },
     {
@@ -210,7 +214,11 @@
               "Dr"
             ]
           }
-        ]
+        ],
+        "identifier": [ {
+          "system": "https://fhir.hl7.org.uk/Id/gmp-number",
+          "value": "G9489493"
+        } ]
       }
     },
     {

--- a/gp2gp-translator/src/integrationTest/resources/json/LargeMessage/expectedBundleScenario6.json
+++ b/gp2gp-translator/src/integrationTest/resources/json/LargeMessage/expectedBundleScenario6.json
@@ -96,7 +96,11 @@
               "Dr"
             ]
           }
-        ]
+        ],
+        "identifier": [ {
+          "system": "https://fhir.hl7.org.uk/Id/gmp-number",
+          "value": "G7777781"
+        } ]
       }
     },
     {

--- a/gp2gp-translator/src/integrationTest/resources/json/LargeMessage/expectedBundleScenario7.json
+++ b/gp2gp-translator/src/integrationTest/resources/json/LargeMessage/expectedBundleScenario7.json
@@ -97,7 +97,11 @@
               "Dr"
             ]
           }
-        ]
+        ],
+        "identifier": [ {
+          "system": "https://fhir.hl7.org.uk/Id/gmp-number",
+          "value": "G2141239"
+        } ]
       }
     },
     {
@@ -210,7 +214,11 @@
               "Dr"
             ]
           }
-        ]
+        ],
+        "identifier": [ {
+          "system": "https://fhir.hl7.org.uk/Id/gmp-number",
+          "value": "G9489493"
+        } ]
       }
     },
     {

--- a/gp2gp-translator/src/integrationTest/resources/json/LargeMessage/expectedBundleScenario8.json
+++ b/gp2gp-translator/src/integrationTest/resources/json/LargeMessage/expectedBundleScenario8.json
@@ -97,7 +97,11 @@
               "Dr"
             ]
           }
-        ]
+        ],
+        "identifier": [ {
+          "system": "https://fhir.hl7.org.uk/Id/gmp-number",
+          "value": "G2141239"
+        } ]
       }
     },
     {
@@ -210,7 +214,11 @@
               "Dr"
             ]
           }
-        ]
+        ],
+        "identifier": [ {
+          "system": "https://fhir.hl7.org.uk/Id/gmp-number",
+          "value": "G9489493"
+        } ]
       }
     },
     {

--- a/gp2gp-translator/src/integrationTest/resources/json/LargeMessage/expectedBundleScenario9.json
+++ b/gp2gp-translator/src/integrationTest/resources/json/LargeMessage/expectedBundleScenario9.json
@@ -97,7 +97,11 @@
               "Dr"
             ]
           }
-        ]
+        ],
+        "identifier": [ {
+          "system": "https://fhir.hl7.org.uk/Id/gmp-number",
+          "value": "G2141239"
+        } ]
       }
     },
     {
@@ -210,7 +214,11 @@
               "Dr"
             ]
           }
-        ]
+        ],
+        "identifier": [ {
+          "system": "https://fhir.hl7.org.uk/Id/gmp-number",
+          "value": "G9489493"
+        } ]
       }
     },
     {

--- a/gp2gp-translator/src/main/java/uk/nhs/adaptors/pss/translator/mapper/AgentDirectoryMapper.java
+++ b/gp2gp-translator/src/main/java/uk/nhs/adaptors/pss/translator/mapper/AgentDirectoryMapper.java
@@ -1,5 +1,6 @@
 package uk.nhs.adaptors.pss.translator.mapper;
 
+import static org.apache.logging.log4j.util.Strings.isNotEmpty;
 import static uk.nhs.adaptors.pss.translator.util.OrganizationUtil.findDuplicateOrganisation;
 import static uk.nhs.adaptors.pss.translator.util.ResourceUtil.generateMeta;
 
@@ -99,7 +100,7 @@ public class AgentDirectoryMapper {
         practitioner.setMeta(generateMeta(PRACT_META_PROFILE));
         practitioner.setName(getPractitionerName(agentPerson.getName()));
 
-        if (gpNumber != null && !"".equals(gpNumber)) {
+        if (isNotEmpty(gpNumber)) {
             Identifier identifier = new Identifier()
                 .setSystem("https://fhir.hl7.org.uk/Id/gmp-number")
                 .setValue(gpNumber);

--- a/gp2gp-translator/src/main/java/uk/nhs/adaptors/pss/translator/mapper/AgentDirectoryMapper.java
+++ b/gp2gp-translator/src/main/java/uk/nhs/adaptors/pss/translator/mapper/AgentDirectoryMapper.java
@@ -99,10 +99,12 @@ public class AgentDirectoryMapper {
         practitioner.setMeta(generateMeta(PRACT_META_PROFILE));
         practitioner.setName(getPractitionerName(agentPerson.getName()));
 
-        Identifier identifier = new Identifier()
-                                        .setSystem("https://fhir.hl7.org.uk/Id/gmp-number")
-                                        .setValue(gpNumber);
-        practitioner.setIdentifier(List.of(identifier));
+        if (gpNumber != null && !"".equals(gpNumber)) {
+            Identifier identifier = new Identifier()
+                .setSystem("https://fhir.hl7.org.uk/Id/gmp-number")
+                .setValue(gpNumber);
+            practitioner.setIdentifier(List.of(identifier));
+        }
 
         return practitioner;
     }

--- a/gp2gp-translator/src/main/java/uk/nhs/adaptors/pss/translator/mapper/AgentDirectoryMapper.java
+++ b/gp2gp-translator/src/main/java/uk/nhs/adaptors/pss/translator/mapper/AgentDirectoryMapper.java
@@ -71,9 +71,10 @@ public class AgentDirectoryMapper {
         var agentOrganization = agent.getAgentOrganization();
         var representedOrganization = agent.getRepresentedOrganization();
         var resourceId = agent.getId().get(0).getRoot();
+        var gpNumber = agent.getId().size() > 1 ? agent.getId().get(1).getExtension() : "";
 
         if (agentPerson != null && representedOrganization != null) {
-            agentResourceList.add(createPractitioner(agentPerson, resourceId));
+            agentResourceList.add(createPractitioner(agentPerson, resourceId, gpNumber));
 
             var representedOrganisation = createRepresentedOrganization(representedOrganization, resourceId);
             Optional<Organization> duplicateOrganisation = findDuplicateOrganisation(representedOrganisation, agentResourceList);
@@ -85,18 +86,23 @@ public class AgentDirectoryMapper {
                 agentResourceList.add(createPractitionerRole(resourceId, agent.getCode(), duplicateOrganisation.orElseThrow().getId()));
             }
         } else if (agentPerson != null && agentOrganization == null) {
-            agentResourceList.add(createPractitioner(agentPerson, resourceId));
+            agentResourceList.add(createPractitioner(agentPerson, resourceId, gpNumber));
         } else if (agentPerson == null && agentOrganization != null) {
             agentResourceList.add(createAgentOrganization(agentOrganization, resourceId, agent.getCode()));
         }
     }
 
-    private Practitioner createPractitioner(RCCTMT120101UK01Person agentPerson, String id) {
+    private Practitioner createPractitioner(RCCTMT120101UK01Person agentPerson, String id, String gpNumber) {
         var practitioner = new Practitioner();
 
         practitioner.setId(id);
         practitioner.setMeta(generateMeta(PRACT_META_PROFILE));
         practitioner.setName(getPractitionerName(agentPerson.getName()));
+
+        Identifier identifier = new Identifier()
+                                        .setSystem("https://fhir.hl7.org.uk/Id/gmp-number")
+                                        .setValue(gpNumber);
+        practitioner.setIdentifier(List.of(identifier));
 
         return practitioner;
     }

--- a/gp2gp-translator/src/test/java/uk/nhs/adaptors/pss/translator/mapper/AgentDirectoryMapperTest.java
+++ b/gp2gp-translator/src/test/java/uk/nhs/adaptors/pss/translator/mapper/AgentDirectoryMapperTest.java
@@ -149,7 +149,7 @@ public class AgentDirectoryMapperTest {
 
         List mappedAgents = agentDirectoryMapper.mapAgentDirectory(agentDirectory);
 
-        assertThat(mappedAgents.size()).isEqualTo(1);
+        assertThat(mappedAgents).hasSize(1);
 
         var practitioner = (Practitioner) mappedAgents.get(0);
         assertEquals("95D00D99-0601-4A8E-AD1D-1B564307B0A6", practitioner.getId());
@@ -166,7 +166,7 @@ public class AgentDirectoryMapperTest {
 
         List mappedAgents = agentDirectoryMapper.mapAgentDirectory(agentDirectory);
 
-        assertThat(mappedAgents.size()).isEqualTo(1);
+        assertThat(mappedAgents).hasSize(1);
 
         var practitioner = (Practitioner) mappedAgents.get(0);
         assertThat(practitioner.getId()).isEqualTo("95D00D99-0601-4A8E-AD1D-1B564307B0A6");
@@ -183,7 +183,7 @@ public class AgentDirectoryMapperTest {
 
         List mappedAgents = agentDirectoryMapper.mapAgentDirectory(agentDirectory);
 
-        assertThat(mappedAgents.size()).isEqualTo(1);
+        assertThat(mappedAgents).hasSize(1);
 
         var practitioner = (Practitioner) mappedAgents.get(0);
         assertThat(practitioner.getId()).isEqualTo("95D00D99-0601-4A8E-AD1D-1B564307B0A6");
@@ -200,7 +200,7 @@ public class AgentDirectoryMapperTest {
 
         List mappedAgents = agentDirectoryMapper.mapAgentDirectory(agentDirectory);
 
-        assertThat(mappedAgents.size()).isEqualTo(1);
+        assertThat(mappedAgents).hasSize(1);
 
         var organization = (Organization) mappedAgents.get(0);
         assertThat(organization.getId()).isEqualTo("1D9BDC28-50AB-440D-B421-0E5E049526FA");
@@ -217,7 +217,7 @@ public class AgentDirectoryMapperTest {
 
         List mappedAgents = agentDirectoryMapper.mapAgentDirectory(agentDirectory);
 
-        assertThat(mappedAgents.size()).isEqualTo(1);
+        assertThat(mappedAgents).hasSize(1);
 
         var organization = (Organization) mappedAgents.get(0);
         assertThat(organization.getId()).isEqualTo("1D9BDC28-50AB-440D-B421-0E5E049526FA");

--- a/gp2gp-translator/src/test/java/uk/nhs/adaptors/pss/translator/mapper/AgentDirectoryMapperTest.java
+++ b/gp2gp-translator/src/test/java/uk/nhs/adaptors/pss/translator/mapper/AgentDirectoryMapperTest.java
@@ -16,6 +16,7 @@ import org.hl7.v3.RCMRMT030101UK04AgentDirectory;
 import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.springframework.util.ResourceUtils.getFile;
 
 import static uk.nhs.adaptors.pss.translator.util.XmlUnmarshallUtil.unmarshallFile;
@@ -23,6 +24,7 @@ import static uk.nhs.adaptors.pss.translator.util.XmlUnmarshallUtil.unmarshallFi
 import java.util.List;
 
 public class AgentDirectoryMapperTest {
+
     private static final String XML_RESOURCES_BASE = "xml/AgentDirectory/";
     private static final String PRACT_META_PROFILE = "https://fhir.nhs.uk/STU3/StructureDefinition/CareConnect-GPC-Practitioner-1";
     private static final String ORG_META_PROFILE = "https://fhir.nhs.uk/STU3/StructureDefinition/CareConnect-GPC-Organization-1";
@@ -41,7 +43,7 @@ public class AgentDirectoryMapperTest {
         List mappedAgents = agentDirectoryMapper.mapAgentDirectory(agentDirectory);
 
         // asserts that for the 3 varying Agents in the input, that there are correctly 5 mapped resources output
-        assertThat(mappedAgents.size()).isEqualTo(FIVE_RESOURCES_MAPPED);
+        assertEquals(FIVE_RESOURCES_MAPPED, mappedAgents.size());
     }
 
     @Test
@@ -50,26 +52,39 @@ public class AgentDirectoryMapperTest {
 
         List mappedAgents = agentDirectoryMapper.mapAgentDirectory(agentDirectory);
 
-        assertThat(mappedAgents.size()).isEqualTo(THREE_RESOURCES_MAPPED);
+        assertEquals(THREE_RESOURCES_MAPPED, mappedAgents.size());
 
         var practitioner = (Practitioner) mappedAgents.get(0);
-        assertThat(practitioner.getId()).isEqualTo("94F00D99-0601-4A8E-AD1D-1B564307B0A6");
-        assertThat(practitioner.getMeta().getProfile().get(0).getValue()).isEqualTo(PRACT_META_PROFILE);
-        assertThat(practitioner.getNameFirstRep().getUse()).isEqualTo(NameUse.OFFICIAL);
-        assertThat(practitioner.getNameFirstRep().getFamily()).isEqualTo("Test");
+        assertEquals("94F00D99-0601-4A8E-AD1D-1B564307B0A6", practitioner.getId());
+        assertEquals(PRACT_META_PROFILE, practitioner.getMeta().getProfile().get(0).getValue());
+        assertEquals(NameUse.OFFICIAL, practitioner.getNameFirstRep().getUse());
+        assertEquals("Test", practitioner.getNameFirstRep().getFamily());
 
         var organization = (Organization) mappedAgents.get(1);
-        assertThat(organization.getId()).isEqualTo("94F00D99-0601-4A8E-AD1D-1B564307B0A6-ORG");
-        assertThat(organization.getMeta().getProfile().get(0).getValue()).isEqualTo(ORG_META_PROFILE);
-        assertThat(organization.getName()).isEqualTo("TEMPLE SOWERBY MEDICAL PRACTICE");
-        assertThat(organization.getType().size()).isEqualTo(0);
+        assertEquals("94F00D99-0601-4A8E-AD1D-1B564307B0A6-ORG", organization.getId());
+        assertEquals(ORG_META_PROFILE, organization.getMeta().getProfile().get(0).getValue());
+        assertEquals("TEMPLE SOWERBY MEDICAL PRACTICE", organization.getName());
+        assertThat(organization.getType()).isEmpty();
 
         var practitionerRole = (PractitionerRole) mappedAgents.get(2);
-        assertThat(practitionerRole.getId()).isEqualTo("94F00D99-0601-4A8E-AD1D-1B564307B0A6-PR");
-        assertThat(practitionerRole.getMeta().getProfile().get(0).getValue()).isEqualTo(PRACT_ROLE_META_PROFILE);
-        assertThat(practitionerRole.getPractitioner().getReference()).isEqualTo("Practitioner/94F00D99-0601-4A8E-AD1D-1B564307B0A6");
-        assertThat(practitionerRole.getOrganization().getReference()).isEqualTo("Organization/94F00D99-0601-4A8E-AD1D-1B564307B0A6-ORG");
-        assertThat(practitionerRole.getCode().size()).isEqualTo(0);
+        assertEquals("94F00D99-0601-4A8E-AD1D-1B564307B0A6-PR", practitionerRole.getId());
+        assertEquals(PRACT_ROLE_META_PROFILE, practitionerRole.getMeta().getProfile().get(0).getValue());
+        assertEquals("Practitioner/94F00D99-0601-4A8E-AD1D-1B564307B0A6", practitionerRole.getPractitioner().getReference());
+        assertEquals("Organization/94F00D99-0601-4A8E-AD1D-1B564307B0A6-ORG", practitionerRole.getOrganization().getReference());
+        assertThat(practitionerRole.getCode()).isEmpty();
+    }
+
+    @Test
+    public void mapAgentDirectoryWithAgentPersonAndGeneralPractitionerNumber() {
+        var agentDirectory = unmarshallAgentDirectoryElement("agent_org_with_general_practitioner_number.xml");
+
+        List mappedAgents = agentDirectoryMapper.mapAgentDirectory(agentDirectory);
+        var practitioner = (Practitioner) mappedAgents.get(0);
+
+        assertEquals("E7E7B550-09EF-BE85-C20F-34598014166C", practitioner.getId());
+        assertThat(practitioner.getIdentifier()).isNotEmpty();
+        assertEquals("https://fhir.hl7.org.uk/Id/gmp-number", practitioner.getIdentifier().get(0).getSystem());
+        assertEquals("12345", practitioner.getIdentifier().get(0).getValue());
     }
 
     @Test
@@ -78,26 +93,26 @@ public class AgentDirectoryMapperTest {
 
         List mappedAgents = agentDirectoryMapper.mapAgentDirectory(agentDirectory);
 
-        assertThat(mappedAgents.size()).isEqualTo(THREE_RESOURCES_MAPPED);
+        assertEquals(THREE_RESOURCES_MAPPED, mappedAgents.size());
 
         var practitioner = (Practitioner) mappedAgents.get(0);
-        assertThat(practitioner.getId()).isEqualTo("94F00D99-0601-4A8E-AD1D-1B564307B0A6");
-        assertThat(practitioner.getMeta().getProfile().get(0).getValue()).isEqualTo(PRACT_META_PROFILE);
-        assertThat(practitioner.getNameFirstRep().getUse()).isEqualTo(NameUse.OFFICIAL);
-        assertThat(practitioner.getNameFirstRep().getFamily()).isEqualTo("Test");
+        assertEquals("94F00D99-0601-4A8E-AD1D-1B564307B0A6", practitioner.getId());
+        assertEquals(PRACT_META_PROFILE, practitioner.getMeta().getProfile().get(0).getValue());
+        assertEquals(NameUse.OFFICIAL, practitioner.getNameFirstRep().getUse());
+        assertEquals("Test", practitioner.getNameFirstRep().getFamily());
 
         var organization = (Organization) mappedAgents.get(1);
-        assertThat(organization.getId()).isEqualTo("94F00D99-0601-4A8E-AD1D-1B564307B0A6-ORG");
-        assertThat(organization.getMeta().getProfile().get(0).getValue()).isEqualTo(ORG_META_PROFILE);
-        assertThat(organization.getName()).isEqualTo("TEMPLE SOWERBY MEDICAL PRACTICE");
-        assertThat(organization.getType().size()).isEqualTo(0);
+        assertEquals("94F00D99-0601-4A8E-AD1D-1B564307B0A6-ORG", organization.getId());
+        assertEquals(ORG_META_PROFILE, organization.getMeta().getProfile().get(0).getValue());
+        assertEquals("TEMPLE SOWERBY MEDICAL PRACTICE", organization.getName());
+        assertThat(organization.getType()).isEmpty();
 
         var practitionerRole = (PractitionerRole) mappedAgents.get(2);
-        assertThat(practitionerRole.getId()).isEqualTo("94F00D99-0601-4A8E-AD1D-1B564307B0A6-PR");
-        assertThat(practitionerRole.getMeta().getProfile().get(0).getValue()).isEqualTo(PRACT_ROLE_META_PROFILE);
-        assertThat(practitionerRole.getPractitioner().getReference()).isEqualTo("Practitioner/94F00D99-0601-4A8E-AD1D-1B564307B0A6");
-        assertThat(practitionerRole.getOrganization().getReference()).isEqualTo("Organization/94F00D99-0601-4A8E-AD1D-1B564307B0A6-ORG");
-        assertThat(practitionerRole.getCodeFirstRep().getText()).isEqualTo("Clerical Worker");
+        assertEquals("94F00D99-0601-4A8E-AD1D-1B564307B0A6-PR", practitionerRole.getId());
+        assertEquals(PRACT_ROLE_META_PROFILE, practitionerRole.getMeta().getProfile().get(0).getValue());
+        assertEquals("Practitioner/94F00D99-0601-4A8E-AD1D-1B564307B0A6", practitionerRole.getPractitioner().getReference());
+        assertEquals("Organization/94F00D99-0601-4A8E-AD1D-1B564307B0A6-ORG", practitionerRole.getOrganization().getReference());
+        assertEquals("Clerical Worker", practitionerRole.getCodeFirstRep().getText());
     }
 
     @Test
@@ -106,26 +121,26 @@ public class AgentDirectoryMapperTest {
 
         List mappedAgents = agentDirectoryMapper.mapAgentDirectory(agentDirectory);
 
-        assertThat(mappedAgents.size()).isEqualTo(THREE_RESOURCES_MAPPED);
+        assertEquals(THREE_RESOURCES_MAPPED, mappedAgents.size());
 
         var practitioner = (Practitioner) mappedAgents.get(0);
-        assertThat(practitioner.getId()).isEqualTo("94F00D99-0601-4A8E-AD1D-1B564307B0A6");
-        assertThat(practitioner.getMeta().getProfile().get(0).getValue()).isEqualTo(PRACT_META_PROFILE);
-        assertThat(practitioner.getNameFirstRep().getUse()).isEqualTo(NameUse.OFFICIAL);
-        assertThat(practitioner.getNameFirstRep().getFamily()).isEqualTo("Test");
+        assertEquals("94F00D99-0601-4A8E-AD1D-1B564307B0A6", practitioner.getId());
+        assertEquals(PRACT_META_PROFILE, practitioner.getMeta().getProfile().get(0).getValue());
+        assertEquals(NameUse.OFFICIAL, practitioner.getNameFirstRep().getUse());
+        assertEquals("Test", practitioner.getNameFirstRep().getFamily());
 
         var organization = (Organization) mappedAgents.get(1);
-        assertThat(organization.getId()).isEqualTo("94F00D99-0601-4A8E-AD1D-1B564307B0A6-ORG");
-        assertThat(organization.getMeta().getProfile().get(0).getValue()).isEqualTo(ORG_META_PROFILE);
-        assertThat(organization.getName()).isEqualTo("TEMPLE SOWERBY MEDICAL PRACTICE");
-        assertThat(organization.getType().size()).isEqualTo(0);
+        assertEquals("94F00D99-0601-4A8E-AD1D-1B564307B0A6-ORG", organization.getId());
+        assertEquals(ORG_META_PROFILE, organization.getMeta().getProfile().get(0).getValue());
+        assertEquals("TEMPLE SOWERBY MEDICAL PRACTICE", organization.getName());
+        assertThat(organization.getType()).isEmpty();
 
         var practitionerRole = (PractitionerRole) mappedAgents.get(2);
-        assertThat(practitionerRole.getId()).isEqualTo("94F00D99-0601-4A8E-AD1D-1B564307B0A6-PR");
-        assertThat(practitionerRole.getMeta().getProfile().get(0).getValue()).isEqualTo(PRACT_ROLE_META_PROFILE);
-        assertThat(practitionerRole.getPractitioner().getReference()).isEqualTo("Practitioner/94F00D99-0601-4A8E-AD1D-1B564307B0A6");
-        assertThat(practitionerRole.getOrganization().getReference()).isEqualTo("Organization/94F00D99-0601-4A8E-AD1D-1B564307B0A6-ORG");
-        assertThat(practitionerRole.getCodeFirstRep().getText()).isEqualTo("General practice");
+        assertEquals("94F00D99-0601-4A8E-AD1D-1B564307B0A6-PR", practitionerRole.getId());
+        assertEquals(PRACT_ROLE_META_PROFILE, practitionerRole.getMeta().getProfile().get(0).getValue());
+        assertEquals("Practitioner/94F00D99-0601-4A8E-AD1D-1B564307B0A6", practitionerRole.getPractitioner().getReference());
+        assertEquals("Organization/94F00D99-0601-4A8E-AD1D-1B564307B0A6-ORG", practitionerRole.getOrganization().getReference());
+        assertEquals("General practice", practitionerRole.getCodeFirstRep().getText());
     }
 
     @Test
@@ -137,12 +152,12 @@ public class AgentDirectoryMapperTest {
         assertThat(mappedAgents.size()).isEqualTo(1);
 
         var practitioner = (Practitioner) mappedAgents.get(0);
-        assertThat(practitioner.getId()).isEqualTo("95D00D99-0601-4A8E-AD1D-1B564307B0A6");
-        assertThat(practitioner.getMeta().getProfile().get(0).getValue()).isEqualTo(PRACT_META_PROFILE);
-        assertThat(practitioner.getNameFirstRep().getUse()).isEqualTo(NameUse.OFFICIAL);
-        assertThat(practitioner.getNameFirstRep().getFamily()).isEqualTo("Test");
-        assertThat(practitioner.getNameFirstRep().getGiven().size()).isEqualTo(0);
-        assertThat(practitioner.getNameFirstRep().getPrefix().size()).isEqualTo(0);
+        assertEquals("95D00D99-0601-4A8E-AD1D-1B564307B0A6", practitioner.getId());
+        assertEquals(PRACT_META_PROFILE, practitioner.getMeta().getProfile().get(0).getValue());
+        assertEquals(NameUse.OFFICIAL, practitioner.getNameFirstRep().getUse());
+        assertEquals("Test", practitioner.getNameFirstRep().getFamily());
+        assertThat(practitioner.getNameFirstRep().getGiven()).isEmpty();
+        assertThat(practitioner.getNameFirstRep().getPrefix()).isEmpty();
     }
 
     @Test
@@ -158,8 +173,8 @@ public class AgentDirectoryMapperTest {
         assertThat(practitioner.getMeta().getProfile().get(0).getValue()).isEqualTo(PRACT_META_PROFILE);
         assertThat(practitioner.getNameFirstRep().getUse()).isEqualTo(NameUse.OFFICIAL);
         assertThat(practitioner.getNameFirstRep().getFamily()).isEqualTo("Unknown");
-        assertThat(practitioner.getNameFirstRep().getGiven().size()).isEqualTo(0);
-        assertThat(practitioner.getNameFirstRep().getPrefix().size()).isEqualTo(0);
+        assertThat(practitioner.getNameFirstRep().getGiven()).isEmpty();
+        assertThat(practitioner.getNameFirstRep().getPrefix()).isEmpty();
     }
 
     @Test
@@ -191,9 +206,9 @@ public class AgentDirectoryMapperTest {
         assertThat(organization.getId()).isEqualTo("1D9BDC28-50AB-440D-B421-0E5E049526FA");
         assertThat(organization.getMeta().getProfile().get(0).getValue()).isEqualTo(ORG_META_PROFILE);
         assertThat(organization.getName()).isEqualTo("The Health Centre");
-        assertThat(organization.getIdentifier().size()).isEqualTo(0);
-        assertThat(organization.getTelecom().size()).isEqualTo(0);
-        assertThat(organization.getAddress().size()).isEqualTo(0);
+        assertThat(organization.getIdentifier()).isEmpty();
+        assertThat(organization.getTelecom()).isEmpty();
+        assertThat(organization.getAddress()).isEmpty();
     }
 
     @Test
@@ -208,9 +223,9 @@ public class AgentDirectoryMapperTest {
         assertThat(organization.getId()).isEqualTo("1D9BDC28-50AB-440D-B421-0E5E049526FA");
         assertThat(organization.getMeta().getProfile().get(0).getValue()).isEqualTo(ORG_META_PROFILE);
         assertThat(organization.getName()).isEqualTo("Unknown");
-        assertThat(organization.getIdentifier().size()).isEqualTo(0);
-        assertThat(organization.getTelecom().size()).isEqualTo(0);
-        assertThat(organization.getAddress().size()).isEqualTo(0);
+        assertThat(organization.getIdentifier()).isEmpty();
+        assertThat(organization.getTelecom()).isEmpty();
+        assertThat(organization.getAddress()).isEmpty();
     }
 
     @Test
@@ -219,16 +234,16 @@ public class AgentDirectoryMapperTest {
 
         List mappedAgents = agentDirectoryMapper.mapAgentDirectory(agentDirectory);
 
-        assertThat(mappedAgents.size()).isEqualTo(1);
+        assertEquals(1, mappedAgents.size());
 
         var organization = (Organization) mappedAgents.get(0);
-        assertThat(organization.getId()).isEqualTo("1D9BDC28-50AB-440D-B421-0E5E049526FA");
-        assertThat(organization.getMeta().getProfile().get(0).getValue()).isEqualTo(ORG_META_PROFILE);
-        assertThat(organization.getName()).isEqualTo("The Health Centre");
-        assertThat(organization.getIdentifierFirstRep().getSystem()).isEqualTo(ORG_IDENTIFIER_SYSTEM);
-        assertThat(organization.getIdentifierFirstRep().getValue()).isEqualTo("A81001");
-        assertThat(organization.getTelecom().size()).isEqualTo(0);
-        assertThat(organization.getAddress().size()).isEqualTo(0);
+        assertEquals("1D9BDC28-50AB-440D-B421-0E5E049526FA", organization.getId());
+        assertEquals(ORG_META_PROFILE, organization.getMeta().getProfile().get(0).getValue());
+        assertEquals("The Health Centre", organization.getName());
+        assertEquals(ORG_IDENTIFIER_SYSTEM, organization.getIdentifierFirstRep().getSystem());
+        assertEquals("A81001", organization.getIdentifierFirstRep().getValue());
+        assertThat(organization.getTelecom()).isEmpty();
+        assertThat(organization.getAddress()).isEmpty();
     }
 
     @Test
@@ -237,15 +252,15 @@ public class AgentDirectoryMapperTest {
 
         List mappedAgents = agentDirectoryMapper.mapAgentDirectory(agentDirectory);
 
-        assertThat(mappedAgents.size()).isEqualTo(1);
+        assertEquals(1, mappedAgents.size());
 
         var organization = (Organization) mappedAgents.get(0);
-        assertThat(organization.getId()).isEqualTo("1D9BDC28-50AB-440D-B421-0E5E049526FA");
-        assertThat(organization.getMeta().getProfile().get(0).getValue()).isEqualTo(ORG_META_PROFILE);
-        assertThat(organization.getName()).isEqualTo("The Health Centre");
-        assertThat(organization.getIdentifier().size()).isEqualTo(0);
-        assertThat(organization.getTelecom().size()).isEqualTo(0);
-        assertThat(organization.getAddress().size()).isEqualTo(0);
+        assertEquals("1D9BDC28-50AB-440D-B421-0E5E049526FA", organization.getId());
+        assertEquals(ORG_META_PROFILE, organization.getMeta().getProfile().get(0).getValue());
+        assertEquals("The Health Centre", organization.getName());
+        assertThat(organization.getIdentifier()).isEmpty();
+        assertThat(organization.getTelecom()).isEmpty();
+        assertThat(organization.getAddress()).isEmpty();
     }
 
     @Test
@@ -254,15 +269,15 @@ public class AgentDirectoryMapperTest {
 
         List mappedAgents = agentDirectoryMapper.mapAgentDirectory(agentDirectory);
 
-        assertThat(mappedAgents.size()).isEqualTo(1);
+        assertEquals(1, mappedAgents.size());
 
         var organization = (Organization) mappedAgents.get(0);
-        assertThat(organization.getId()).isEqualTo("1D9BDC28-50AB-440D-B421-0E5E049526FA");
-        assertThat(organization.getMeta().getProfile().get(0).getValue()).isEqualTo(ORG_META_PROFILE);
-        assertThat(organization.getName()).isEqualTo("The Health Centre");
-        assertThat(organization.getIdentifier().size()).isEqualTo(0);
+        assertEquals("1D9BDC28-50AB-440D-B421-0E5E049526FA", organization.getId());
+        assertEquals(ORG_META_PROFILE, organization.getMeta().getProfile().get(0).getValue());
+        assertEquals("The Health Centre", organization.getName());
+        assertThat(organization.getIdentifier()).isEmpty();
         assertTelecom(organization.getTelecomFirstRep(), "01234567890");
-        assertThat(organization.getAddress().size()).isEqualTo(0);
+        assertThat(organization.getAddress()).isEmpty();
     }
 
     @Test
@@ -271,15 +286,15 @@ public class AgentDirectoryMapperTest {
 
         List mappedAgents = agentDirectoryMapper.mapAgentDirectory(agentDirectory);
 
-        assertThat(mappedAgents.size()).isEqualTo(1);
+        assertEquals(1, mappedAgents.size());
 
         var organization = (Organization) mappedAgents.get(0);
-        assertThat(organization.getId()).isEqualTo("1D9BDC28-50AB-440D-B421-0E5E049526FA");
-        assertThat(organization.getMeta().getProfile().get(0).getValue()).isEqualTo(ORG_META_PROFILE);
-        assertThat(organization.getName()).isEqualTo("The Health Centre");
-        assertThat(organization.getIdentifier().size()).isEqualTo(0);
+        assertEquals("1D9BDC28-50AB-440D-B421-0E5E049526FA", organization.getId());
+        assertEquals(ORG_META_PROFILE, organization.getMeta().getProfile().get(0).getValue());
+        assertEquals("The Health Centre", organization.getName());
+        assertThat(organization.getIdentifier()).isEmpty();
         assertTelecom(organization.getTelecomFirstRep(), "01234567890");
-        assertThat(organization.getAddress().size()).isEqualTo(0);
+        assertThat(organization.getAddress()).isEmpty();
     }
 
     @Test
@@ -288,31 +303,31 @@ public class AgentDirectoryMapperTest {
 
         List mappedAgents = agentDirectoryMapper.mapAgentDirectory(agentDirectory);
 
-        assertThat(mappedAgents.size()).isEqualTo(1);
+        assertEquals(1, mappedAgents.size());
 
         var organization = (Organization) mappedAgents.get(0);
-        assertThat(organization.getId()).isEqualTo("1D9BDC28-50AB-440D-B421-0E5E049526FA");
-        assertThat(organization.getMeta().getProfile().get(0).getValue()).isEqualTo(ORG_META_PROFILE);
-        assertThat(organization.getName()).isEqualTo("The Health Centre");
-        assertThat(organization.getIdentifier().size()).isEqualTo(0);
-        assertThat(organization.getTelecom().size()).isEqualTo(0);
+        assertEquals("1D9BDC28-50AB-440D-B421-0E5E049526FA", organization.getId());
+        assertEquals(ORG_META_PROFILE, organization.getMeta().getProfile().get(0).getValue());
+        assertEquals("The Health Centre", organization.getName());
+        assertThat(organization.getIdentifier()).isEmpty();
+        assertThat(organization.getTelecom()).isEmpty();
         assertAddress(organization.getAddressFirstRep());
     }
 
     private void assertAddress(Address address) {
-        assertThat(address.getUse()).isEqualTo(AddressUse.WORK);
-        assertThat(address.getType()).isEqualTo(AddressType.PHYSICAL);
-        assertThat(address.getLine().get(0).getValue()).isEqualTo("234 ASHTREE ROAD");
-        assertThat(address.getLine().get(1).getValue()).isEqualTo("LEEDS");
-        assertThat(address.getLine().get(2).getValue()).isEqualTo("YORKSHIRE");
-        assertThat(address.getPostalCode()).isEqualTo("LS12 3RT");
+        assertEquals(AddressUse.WORK, address.getUse());
+        assertEquals(AddressType.PHYSICAL, address.getType());
+        assertEquals("234 ASHTREE ROAD", address.getLine().get(0).getValue());
+        assertEquals("LEEDS", address.getLine().get(1).getValue());
+        assertEquals("YORKSHIRE", address.getLine().get(2).getValue());
+        assertEquals("LS12 3RT", address.getPostalCode());
     }
 
     private void assertTelecom(ContactPoint telecom, String value) {
-        assertThat(telecom.getSystem()).isEqualTo(ContactPointSystem.PHONE);
-        assertThat(telecom.getUse()).isEqualTo(ContactPointUse.WORK);
-        assertThat(telecom.getRank()).isEqualTo(TELECOM_RANK);
-        assertThat(telecom.getValue()).isEqualTo(value);
+        assertEquals(ContactPointSystem.PHONE, telecom.getSystem());
+        assertEquals(ContactPointUse.WORK, telecom.getUse());
+        assertEquals(TELECOM_RANK, telecom.getRank());
+        assertEquals(value, telecom.getValue());
     }
 
     @SneakyThrows

--- a/gp2gp-translator/src/test/resources/xml/AgentDirectory/agent_org_with_general_practitioner_number.xml
+++ b/gp2gp-translator/src/test/resources/xml/AgentDirectory/agent_org_with_general_practitioner_number.xml
@@ -1,0 +1,19 @@
+<agentDirectory
+  xmlns="urn:hl7-org:v3" classCode="AGNT">
+	<part typeCode="PART">
+		<Agent classCode="AGNT">
+			<id root="E7E7B550-09EF-BE85-C20F-34598014166C" />
+			<id root="2.16.840.1.113883.2.1.4.2" extension="12345" />
+			<code code="309394004" codeSystem="2.16.840.1.113883.2.1.3.2.4.15" displayName="General Practitioner Principal">
+				<originalText>General Medical Practitioner</originalText>
+			</code>
+			<agentPerson classCode="PSN" determinerCode="INSTANCE">
+				<name>
+					<prefix>Dr</prefix>
+					<given>helen</given>
+					<family>tallantyre</family>
+				</name>
+			</agentPerson>
+		</Agent>
+	</part>
+</agentDirectory>


### PR DESCRIPTION
## What

Practitioner GP Number Field Missing from FHIR Output

## Why

GP Number Field that is included in agentDirectory section doesn't appear in FHIR Output Practitioner section. This PR adds this information into Practitioner section.

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Internal change (non-breaking change with no effect on the functionality affecting end users)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:

- [x] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have updated the [Changelog](/CHANGELOG.md) with details of my change in the UNRELEASED section if this change will affect end users
- [x] A corresponding change has been made to the [Mapping Documentation repository][mapping-docs]

[mapping-docs]: https://github.com/NHSDigital/patient-switching-adaptors-mapping-documentation