### PR TITLE
NIAD-2921: fixing asserter and recorder fields

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 ### Changed
 
 * Changed `ReferralRequest` mapping to use `ASAP` instead of the `Stat` value.
+* Changed 'author' to be used as Recorder and 'practitioner' to be used as Asserter in AllergyIntolerance
 
 ## [1.1.0] - 2023-11-09
 

--- a/gp2gp-translator/src/integrationTest/resources/e2e-mapping/output-json/PWTP10-output.json
+++ b/gp2gp-translator/src/integrationTest/resources/e2e-mapping/output-json/PWTP10-output.json
@@ -4729,10 +4729,10 @@
         "onsetDateTime": "2010-02-06T12:41:00+00:00",
         "assertedDate": "2010-02-06T12:41:00+00:00",
         "recorder": {
-          "reference": "Practitioner/C5DEFBF3-0174-BC6F-182C-B777B9C6FF43"
+          "reference": "Practitioner/1E473786-E7FA-785E-C911-A8D38FB56F20"
         },
         "asserter": {
-          "reference": "Practitioner/1E473786-E7FA-785E-C911-A8D38FB56F20"
+          "reference": "Practitioner/C5DEFBF3-0174-BC6F-182C-B777B9C6FF43"
         }
       }
     },
@@ -4800,10 +4800,10 @@
         "onsetDateTime": "2010-02-06T12:41:00+00:00",
         "assertedDate": "2010-02-06T12:41:00+00:00",
         "recorder": {
-          "reference": "Practitioner/C5DEFBF3-0174-BC6F-182C-B777B9C6FF43"
+          "reference": "Practitioner/1E473786-E7FA-785E-C911-A8D38FB56F20"
         },
         "asserter": {
-          "reference": "Practitioner/1E473786-E7FA-785E-C911-A8D38FB56F20"
+          "reference": "Practitioner/C5DEFBF3-0174-BC6F-182C-B777B9C6FF43"
         }
       }
     },

--- a/gp2gp-translator/src/main/java/uk/nhs/adaptors/pss/translator/mapper/AllergyIntoleranceMapper.java
+++ b/gp2gp-translator/src/main/java/uk/nhs/adaptors/pss/translator/mapper/AllergyIntoleranceMapper.java
@@ -55,7 +55,7 @@ public class AllergyIntoleranceMapper extends AbstractMapper<AllergyIntolerance>
     private static final String ALLERGY_TERM_TEXT = "H/O: drug allergy";
     private static final String ALLERGY_NOTE = "Allergy Code: %s";
     public static final String EPISODICITY_NOTE = "Episodicity : %s";
-    public static final String AUTHOR = "author";
+    public static final String ASSERTER = "asserter";
     public static final String RECORDER = "recorder";
 
     private final CodeableConceptMapper codeableConceptMapper;
@@ -131,10 +131,10 @@ public class AllergyIntoleranceMapper extends AbstractMapper<AllergyIntolerance>
 
         var recorderAndAsserter = fetchRecorderAndAsserter(ehrComposition);
 
-        if (recorderAndAsserter.get(RECORDER).isPresent() && recorderAndAsserter.get(AUTHOR).isPresent()) {
+        if (recorderAndAsserter.get(RECORDER).isPresent() && recorderAndAsserter.get(ASSERTER).isPresent()) {
             allergyIntolerance
                     .setRecorder(recorderAndAsserter.get(RECORDER).get())
-                    .setAsserter(recorderAndAsserter.get(AUTHOR).get());
+                    .setAsserter(recorderAndAsserter.get(ASSERTER).get());
         } else {
             var practitioner = Optional.ofNullable(getParticipantReference(
                     compoundStatement.getParticipant(),
@@ -151,7 +151,7 @@ public class AllergyIntoleranceMapper extends AbstractMapper<AllergyIntolerance>
         var practitioner = Optional.ofNullable(getParticipant2Reference(ehrComposition, "RESP"));
         var author = getAuthorReference(ehrComposition);
 
-        return Map.of(RECORDER, practitioner, AUTHOR, author);
+        return Map.of(RECORDER, author, ASSERTER, practitioner);
     }
 
     private void buildExtension(RCMRMT030101UK04EhrComposition ehrComposition, List<Encounter> encounters,

--- a/gp2gp-translator/src/test/java/uk/nhs/adaptors/pss/translator/mapper/AllergyIntoleranceMapperTest.java
+++ b/gp2gp-translator/src/test/java/uk/nhs/adaptors/pss/translator/mapper/AllergyIntoleranceMapperTest.java
@@ -5,6 +5,7 @@ import static org.hl7.fhir.dstu3.model.AllergyIntolerance.AllergyIntoleranceCate
 import static org.hl7.fhir.dstu3.model.AllergyIntolerance.AllergyIntoleranceCategory.MEDICATION;
 import static org.hl7.fhir.dstu3.model.AllergyIntolerance.AllergyIntoleranceClinicalStatus.ACTIVE;
 import static org.hl7.fhir.dstu3.model.AllergyIntolerance.AllergyIntoleranceVerificationStatus.UNCONFIRMED;
+import static org.junit.jupiter.api.Assertions.assertAll;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.times;
@@ -124,9 +125,11 @@ public class AllergyIntoleranceMapperTest {
         assertEquals(1, allergyIntolerances.size());
         var allergyIntolerance = allergyIntolerances.get(0);
 
-        assertExtension(allergyIntolerance);
-        assertEquals("Practitioner/9F2ABD26-1682-FDFE-1E88-19673307C67A", allergyIntolerance.getRecorder().getReference());
-        assertEquals("Practitioner/E7E7B550-09EF-BE85-C20F-34598014166C", allergyIntolerance.getAsserter().getReference());
+        assertAll(
+            () -> assertExtension(allergyIntolerance),
+            () -> assertEquals("Practitioner/9F2ABD26-1682-FDFE-1E88-19673307C67A", allergyIntolerance.getAsserter().getReference()),
+            () -> assertEquals("Practitioner/E7E7B550-09EF-BE85-C20F-34598014166C", allergyIntolerance.getRecorder().getReference())
+        );
     }
 
     @Test
@@ -143,9 +146,11 @@ public class AllergyIntoleranceMapperTest {
         assertEquals(1, allergyIntolerances.size());
         var allergyIntolerance = allergyIntolerances.get(0);
 
-        assertExtension(allergyIntolerance);
-        assertEquals("Practitioner/9F2ABD26-1682-FDFE-1E88-19673307C67A", allergyIntolerance.getRecorder().getReference());
-        assertEquals("Practitioner/9F2ABD26-1682-FDFE-1E88-19673307C67A", allergyIntolerance.getAsserter().getReference());
+        assertAll(
+            () -> assertExtension(allergyIntolerance),
+            () -> assertEquals("Practitioner/9F2ABD26-1682-FDFE-1E88-19673307C67A", allergyIntolerance.getRecorder().getReference()),
+            () -> assertEquals("Practitioner/9F2ABD26-1682-FDFE-1E88-19673307C67A", allergyIntolerance.getAsserter().getReference())
+        );
     }
 
     @Test
@@ -162,9 +167,11 @@ public class AllergyIntoleranceMapperTest {
         assertEquals(1, allergyIntolerances.size());
         var allergyIntolerance = allergyIntolerances.get(0);
 
-        assertExtension(allergyIntolerance);
-        assertEquals("Practitioner/9F2ABD26-1682-FDFE-1E88-19673307C67A", allergyIntolerance.getRecorder().getReference());
-        assertEquals("Practitioner/E7E7B550-09EF-BE85-C20F-34598014166C", allergyIntolerance.getAsserter().getReference());
+        assertAll(
+            () -> assertExtension(allergyIntolerance),
+            () -> assertEquals("Practitioner/9F2ABD26-1682-FDFE-1E88-19673307C67A", allergyIntolerance.getAsserter().getReference()),
+            () -> assertEquals("Practitioner/E7E7B550-09EF-BE85-C20F-34598014166C", allergyIntolerance.getRecorder().getReference())
+        );
     }
 
     @Test


### PR DESCRIPTION
## What

The order of fields in which we pull recorder and asserter (author and practitioner) have been requested to be changed.

## Why

Before the change we pulled author XML field and assigned it to asserter and practitioner XML field and assigned it to recorder. It was not the order of pulling fields and it was requested to be changed which was addressed in this PR.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Internal change (non-breaking change with no effect on the functionality affecting end users)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:

- [x] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have updated the [Changelog](/CHANGELOG.md) with details of my change in the UNRELEASED section if this change will affect end users
- [ ] A corresponding change has been made to the [Mapping Documentation repository][mapping-docs]

[mapping-docs]: https://github.com/NHSDigital/patient-switching-adaptors-mapping-documentation