### PR TITLE
Update base docker java image from 17.0.2 to 17.0.9_9

### DIFF
--- a/docker/gp2gp-translator/Dockerfile
+++ b/docker/gp2gp-translator/Dockerfile
@@ -9,7 +9,7 @@ COPY --chown=gradle:gradle ./config /home/gradle/service/config
 WORKDIR /home/gradle/service/gp2gp-translator
 RUN ./gradlew --build-cache bootJar
 
-FROM openjdk:17
+FROM eclipse-temurin:17
 
 EXPOSE 8085
 

--- a/docker/gpc-facade/Dockerfile
+++ b/docker/gpc-facade/Dockerfile
@@ -8,7 +8,7 @@ COPY --chown=gradle:gradle ./config /home/gradle/service/config
 WORKDIR /home/gradle/service/gpc-api-facade
 RUN ./gradlew --build-cache bootJar
 
-FROM openjdk:17
+FROM eclipse-temurin:17
 
 EXPOSE 8081
 


### PR DESCRIPTION
## What

Update base docker java image from 17.0.2 to 17.0.9_9

## Why

openjdk has been deprecated since July 2022 and so our base image hasn't been receiving fixes or security patches

By switching to eclipse-temurin we start getting updates again.

## Type of change

🔧 Update dependency!

## Checklist:

- [x] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I have updated the [Changelog](/CHANGELOG.md) with details of my change in the UNRELEASED section if this change will affect end users
- [ ] A corresponding change has been made to the [Mapping Documentation repository][mapping-docs]

[mapping-docs]: https://github.com/NHSDigital/patient-switching-adaptors-mapping-documentation