### PR TITLE
Update OperationOutcome example in README with new GP2GP code

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,36 +73,41 @@ The endpoint also requires a JSON body that includes the needed patient NHS numb
 Endpoint calling:
 
 1. Initial request: If you successfully configure the endpoint described above and call it, you should receive a 202-accepted response. This means the adaptor has received the request and is making the relevant requests.
-2. Polling the request: after receiving a 202 response, we recommend polling the endpoint at regular intervals using an increasing call gap strategy. Each poll can return the following responses:-
-    1. 204 No content: this response indicates that we are still processing the requests / waiting for the EHR message response.
-    2. 200 Success: this response indicates we have successfully received and converted the EHR to JSON; you will also receive the FHIR bundle in the response's body.
-    3. 400,404,500,501: The endpoint can return all these possible error codes. These will all provide a detailed error with an operationOutcome JSON model response in the body. This looks like...
+   2. Polling the request: after receiving a 202 response, we recommend polling the endpoint at regular intervals using an increasing call gap strategy. Each poll can return the following responses:-
+       1. 204 No content: this response indicates that we are still processing the requests / waiting for the EHR message response.
+       2. 200 Success: this response indicates we have successfully received and converted the EHR to JSON; you will also receive the FHIR bundle in the response's body.
+       3. 400,404,500,501: The endpoint can return all these possible error codes. These will all provide a detailed error with an operationOutcome JSON model response in the body. This looks like...
 
-   ``` 
-   {
-      "resourceType": "OperationOutcome",
-      "meta": {
-         "profile": [
-            "https://fhir.nhs.uk/STU3/StructureDefinition/GPConnect-OperationOutcome-1"
-         ]
-      },
-      "issue": [
-         {
-            "severity": "error",
-            "code": "exception",
-            "details": {
-               "coding": [
-                  {
-                     "system": "https://fhir.nhs.uk/STU3/ValueSet/Spine-ErrorOrWarningCode-1",
-                     "code": "PATIENT_NOT_FOUND",
-                     "display": "GP2GP - Patient is not registered at the practice"
-                  }
-               ]
+      ``` 
+      {
+         "resourceType": "OperationOutcome",
+         "meta": {
+            "profile": [
+               "https://fhir.nhs.uk/STU3/StructureDefinition/GPConnect-OperationOutcome-1"
+            ]
+         },
+         "issue": [
+            {
+               "severity": "error",
+               "code": "exception",
+               "details": {
+                  "coding": [
+                     {
+                        "system": "https://fhir.nhs.uk/STU3/ValueSet/Spine-ErrorOrWarningCode-1",
+                        "code": "PATIENT_NOT_FOUND",
+                        "display": "GP2GP - Patient is not registered at the practice"
+                     },
+                     {
+                       "system": "2.16.840.1.113883.2.1.3.2.4.17.101"
+                       "code": "06"
+                       "display": "Patient not at surgery"
+                     }
+                  ]
+               }
             }
-         }
-      ]
-   }
-   ```
+         ]
+      }
+      ```
 
 ### /$gpc.ack
 


### PR DESCRIPTION
## What

Readme update about OperationOutcome error output

## Why

The readme section didn't have the latest change to OperationOutcome section where specific GP2GP error code output was added hence this change fixes it.

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Internal change (non-breaking change with no effect on the functionality affecting end users)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:

- [x] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I have updated the [Changelog](/CHANGELOG.md) with details of my change in the UNRELEASED section if this change will affect end users
- [ ] A corresponding change has been made to the [Mapping Documentation repository][mapping-docs]

[mapping-docs]: https://github.com/NHSDigital/patient-switching-adaptors-mapping-documentation