### PR TITLE
NIAD-2972: bugfix - Referral request priority code null pointer 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## [Unreleased]
 
+### Fixed
+* Fixed issue where mapping failed due to a Referral Request Priority not being found. 
+
 ### Added
 * Added code section with specific GP2GP error into Codeable Concept response section
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,11 +7,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ### Fixed
 * Fixed issue where mapping failed due to a Referral Request Priority not being found. 
+* Additional information (code, display and system) will be provided in PractionionerRole and Organization resources via Codeable Concept
 
 ## [1.3.0] - 2023-12-11
 
-### Added
-* Additional information (code, display and system) will be provided in PractionionerRole and Organization resources via Codeable Concept  
+### Added 
 * In the event of a GP2GP failure, the raw error code is now available in the `/Patient/$gpc.migratestructuredrecord` response section with code system `2.16.840.1.113883.2.1.3.2.4.17.101`.
 
 ### Changed

--- a/gp2gp-translator/src/main/java/uk/nhs/adaptors/pss/translator/mapper/ReferralRequestMapper.java
+++ b/gp2gp-translator/src/main/java/uk/nhs/adaptors/pss/translator/mapper/ReferralRequestMapper.java
@@ -2,12 +2,12 @@ package uk.nhs.adaptors.pss.translator.mapper;
 
 import static org.hl7.fhir.dstu3.model.ReferralRequest.ReferralPriority;
 import static org.hl7.fhir.dstu3.model.ReferralRequest.ReferralPriorityEnumFactory;
+
 import static uk.nhs.adaptors.pss.translator.util.CompoundStatementResourceExtractors.extractAllRequestStatements;
 import static uk.nhs.adaptors.pss.translator.util.ResourceUtil.buildIdentifier;
 import static uk.nhs.adaptors.pss.translator.util.ResourceUtil.generateMeta;
 
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
@@ -25,8 +25,6 @@ import org.hl7.v3.CD;
 import org.hl7.v3.CR;
 import org.hl7.v3.CV;
 import org.hl7.v3.IVLTS;
-import org.hl7.v3.RCMRMT030101UK04Component02;
-import org.hl7.v3.RCMRMT030101UK04Component4;
 import org.hl7.v3.RCMRMT030101UK04EhrComposition;
 import org.hl7.v3.RCMRMT030101UK04EhrExtract;
 import org.hl7.v3.RCMRMT030101UK04RequestStatement;
@@ -53,6 +51,7 @@ public class ReferralRequestMapper extends AbstractMapper<ReferralRequest> {
             "394849002", "urgent",
             "88694003", "asap"
     );
+    private static final String SNOMED_CODE_SYSTEM = "2.16.840.1.113883.2.1.3.2.4.15";
 
     private CodeableConceptMapper codeableConceptMapper;
 
@@ -76,7 +75,7 @@ public class ReferralRequestMapper extends AbstractMapper<ReferralRequest> {
         var identifier = buildIdentifier(id, practiseCode);
         var agent = ParticipantReferenceUtil.getParticipantReference(requestStatement.getParticipant(), ehrComposition);
         var authoredOn = getAuthoredOn(requestStatement.getAvailabilityTime());
-        var referralPriority = getReferralPriorityFromEhrComposition(ehrComposition);
+        var referralPriority = getReferralPriority(requestStatement);
 
         referralRequest.setId(id);
         referralRequest.setMeta(generateMeta(META_PROFILE));
@@ -177,85 +176,24 @@ public class ReferralRequestMapper extends AbstractMapper<ReferralRequest> {
         return ACTION_DATE_PREFIX + effectiveTimeValue.asStringValue();
     }
 
-    private ReferralPriority getReferralPriorityFromEhrComposition(RCMRMT030101UK04EhrComposition ehrComposition) {
+    private ReferralPriority getReferralPriority(RCMRMT030101UK04RequestStatement requestStatement) {
 
-        if (ehrComposition == null || ehrComposition.getComponent().isEmpty()) {
+        var priorityCode = requestStatement.getPriorityCode();
+        if (snomedCodeNotPresent(priorityCode)) {
             return null;
         }
 
-        var topLevelComponents = ehrComposition.getComponent();
-
-        var priorityCode = getPriorityCodesFromTopLevelComponents(topLevelComponents);
-
-        if (priorityCode == null) {
-            priorityCode = getReferralPriorityCodeFromChildComponents(topLevelComponents.get(0));
+        var hl7Code = priorityCode.getCode();
+        if (PRIORITY_CODES.containsKey(hl7Code)) {
+            return new ReferralPriorityEnumFactory().fromCode(PRIORITY_CODES.get(hl7Code));
         }
 
-        return new ReferralPriorityEnumFactory()
-                .fromCode(priorityCode);
+        return null;
     }
 
-    private String getPriorityCodesFromTopLevelComponents(List<RCMRMT030101UK04Component4> components) {
-        return components
-                .stream()
-                .filter(ReferralRequestMapper::hasPriorityCode)
-                .map(component4 -> component4.getRequestStatement().getPriorityCode().getCode())
-                .findFirst()
-                .map(this::getReferralPriorityCode)
-                .orElse(null);
-    }
-
-    private String getReferralPriorityCode(String priorityCode) {
-        if (PRIORITY_CODES.containsKey(priorityCode)) {
-            return PRIORITY_CODES.get(priorityCode);
-        }
-        throw new IllegalArgumentException("Unknown ReferralPriority code '" + priorityCode + "'");
-    }
-
-    private String getReferralPriorityCodeFromChildComponents(RCMRMT030101UK04Component4 topComponent) {
-        if (!topComponent.hasCompoundStatement()) {
-            return null;
-        }
-
-        var childComponents = topComponent.getCompoundStatement().getComponent();
-
-        if (childComponents == null) {
-            return null;
-        }
-
-        // We pass the child component to a recursive function, so it finds the priority code for each nested child
-        var priorityCode = getPriorityCode(childComponents);
-        return getReferralPriorityCode(priorityCode);
-    }
-
-    private String getPriorityCode(List<RCMRMT030101UK04Component02> components) {
-
-        var priorityCode = components
-                .stream()
-                .map(RCMRMT030101UK04Component02::getRequestStatement)
-                .filter(Objects::nonNull)
-                .map(RCMRMT030101UK04RequestStatement::getPriorityCode)
-                .filter(Objects::nonNull)
-                .map(CD::getCode)
-                .filter(StringUtils::isNotEmpty)
-                .findFirst()
-                .orElse(null);
-
-        if (priorityCode != null) {
-            return priorityCode;
-        }
-
-        var childComponents = components
-                .stream()
-                .filter(ReferralRequestMapper::hasComponentInCompoundStatement)
-                .map(c -> c.getCompoundStatement().getComponent())
-                .filter(c -> !c.isEmpty())
-                .findFirst()
-                .orElse(Collections.emptyList());
-
-        return childComponents.isEmpty()
-                ? null
-                : getPriorityCode(childComponents);
+    private boolean snomedCodeNotPresent(CV codeElement) {
+        return codeElement == null || !codeElement.hasCode() || !codeElement.hasCodeSystem()
+            || !SNOMED_CODE_SYSTEM.equals(codeElement.getCodeSystem());
     }
 
     private boolean hasIdValue(RCMRMT030101UK04ResponsibleParty3 responsibleParty) {
@@ -269,18 +207,6 @@ public class ReferralRequestMapper extends AbstractMapper<ReferralRequest> {
         return effectiveTime != null
                 && effectiveTime.getCenter() != null
                 && effectiveTime.getCenter().getValue() != null;
-    }
-
-    private static boolean hasPriorityCode(RCMRMT030101UK04Component4 component) {
-        return component.getRequestStatement() != null
-                && component.getRequestStatement().getPriorityCode() != null
-                && component.getRequestStatement().getPriorityCode().getCode() != null;
-    }
-
-    private static boolean hasComponentInCompoundStatement(RCMRMT030101UK04Component02 component) {
-        return component.hasCompoundStatement()
-                && component.getCompoundStatement().getComponent() != null
-                && !component.getCompoundStatement().getComponent().isEmpty();
     }
 
     private boolean isNotSelfReferral(RCMRMT030101UK04RequestStatement requestStatement) {

--- a/gp2gp-translator/src/test/resources/xml/RequestStatement/nested_request_statement.xml
+++ b/gp2gp-translator/src/test/resources/xml/RequestStatement/nested_request_statement.xml
@@ -1,0 +1,133 @@
+<ehrComposition xmlns="urn:hl7-org:v3" classCode="COMPOSITION" moodCode="EVN">
+    <id root="2227B72A-B855-4E2F-BD8C-5B678184CAF5"/>
+    <code code="25671000000102" codeSystem="2.16.840.1.113883.2.1.3.2.4.15" displayName="Surgery Consultation Note">
+        <originalText>GP Surgery</originalText>
+    </code>
+    <statusCode code="COMPLETE"/>
+    <effectiveTime>
+        <center nullFlavor="NI"/>
+    </effectiveTime>
+    <availabilityTime value="202312061049"/>
+    <author contextControlCode="OP" typeCode="AUT">
+        <time value="20231206105525"/>
+        <agentRef classCode="AGNT">
+            <id root="80A11057-899F-4B8E-90C1-6BF982144ADB"/>
+        </agentRef>
+    </author>
+    <location typeCode="LOC">
+        <locatedEntity classCode="LOCE">
+            <code code="1101121000000108" codeSystem="2.16.840.1.113883.2.1.3.2.4.15"
+                  displayName="Healthcare related organisation"/>
+            <locatedPlace classCode="PLC" determinerCode="INSTANCE">
+                <name>Charnock</name>
+            </locatedPlace>
+        </locatedEntity>
+    </location>
+    <Participant2 contextControlCode="OP" typeCode="RESP">
+        <agentRef classCode="AGNT">
+            <id root="80A11057-899F-4B8E-90C1-6BF982144ADB"/>
+        </agentRef>
+    </Participant2>
+    <component typeCode="COMP">
+        <CompoundStatement classCode="TOPIC" moodCode="EVN">
+            <id root="0AB92E72-02E6-4AF7-8B93-172B6507CD55"/>
+            <code code="252311015" codeSystem="2.16.840.1.113883.2.1.3.2.4.15" displayName="Backache"/>
+            <statusCode code="COMPLETE"/>
+            <effectiveTime>
+                <center nullFlavor="NI"/>
+            </effectiveTime>
+            <availabilityTime value="202312061049"/>
+            <component contextConductionInd="true" typeCode="COMP">
+                <CompoundStatement classCode="CATEGORY" moodCode="EVN">
+                    <id root="2A762CEB-1868-4FA1-9823-B72DC608682D"/>
+                    <code code="1672341000006108" codeSystem="2.16.840.1.113883.2.1.3.2.4.15" displayName="Medication"/>
+                    <statusCode code="COMPLETE"/>
+                    <effectiveTime>
+                        <center nullFlavor="NI"/>
+                    </effectiveTime>
+                    <availabilityTime value="202312061049"/>
+                    <component contextConductionInd="true" typeCode="COMP">
+                        <MedicationStatement classCode="SBADM" moodCode="ORD">
+                            <id root="B42B824C-1979-49F3-A919-C80BBE56CB26"/>
+                            <statusCode code="COMPLETE"/>
+                            <effectiveTime>
+                                <center nullFlavor="NI"/>
+                            </effectiveTime>
+                            <availabilityTime value="20231206"/>
+                            <consumable typeCode="CSM">
+                                <manufacturedProduct classCode="MANU">
+                                    <manufacturedMaterial classCode="MMAT" determinerCode="KIND">
+                                        <code code="MITA31478EMIS" codeSystem="2.16.840.1.113883.2.1.6.9" displayName="Mirtazapine 30mg tablets">
+                                            <translation code="321998002" codeSystem="2.16.840.1.113883.2.1.3.2.4.15"/>
+                                        </code>
+                                        <quantity unit="1" value="28">
+                                            <translation value="28">
+                                                <originalText>tablet</originalText>
+                                            </translation>
+                                        </quantity>
+                                    </manufacturedMaterial>
+                                </manufacturedProduct>
+                            </consumable>
+                            <component typeCode="COMP">
+                                <ehrSupplyPrescribe classCode="SPLY" moodCode="ORD">
+                                    <id root="1E782F3E-4B6F-49C5-BFA3-73854B47AACB"/>
+                                    <code code="9bG0.00" codeSystem="2.16.840.1.113883.2.1.6.2" displayName="NHS prescription"/>
+                                    <statusCode code="COMPLETE"/>
+                                    <availabilityTime value="20231206"/>
+                                    <quantity unit="1" value="28">
+                                        <translation value="28">
+                                            <originalText>tablet</originalText>
+                                        </translation>
+                                    </quantity>
+                                    <inFulfillmentOf typeCode="FLFS">
+                                        <priorMedicationRef classCode="SBADM" moodCode="ORD">
+                                            <id root="A4C9F3E5-0A68-447C-9306-62D81761DA16"/>
+                                        </priorMedicationRef>
+                                    </inFulfillmentOf>
+                                </ehrSupplyPrescribe>
+                            </component>
+                            <pertinentInformation typeCode="PERT">
+                                <pertinentMedicationDosage classCode="SBADM" moodCode="RMD">
+                                    <text>One To Be Taken At Night</text>
+                                </pertinentMedicationDosage>
+                            </pertinentInformation>
+                        </MedicationStatement>
+                    </component>
+                </CompoundStatement>
+            </component>
+            <component contextConductionInd="true" typeCode="COMP">
+                <CompoundStatement classCode="CATEGORY" moodCode="EVN">
+                    <id root="DF14ADB4-7250-4CEE-8276-5961D47C34F1"/>
+                    <code code="3457005" codeSystem="2.16.840.1.113883.2.1.3.2.4.15" displayName="Referral"/>
+                    <statusCode code="COMPLETE"/>
+                    <effectiveTime>
+                        <center nullFlavor="NI"/>
+                    </effectiveTime>
+                    <availabilityTime value="202312061049"/>
+                    <component contextConductionInd="true" typeCode="COMP">
+                        <RequestStatement classCode="OBS" moodCode="RQO">
+                            <id root="9E63CAA9-6863-4ABE-BD7A-DC7B303059FC"/>
+                            <code code="EMISNQRE553" codeSystem="2.16.840.1.113883.2.1.6.3"
+                                  displayName="Referral for back rehabilitation">
+                                <qualifier codeSystem="2.16.840.1.113883.2.1.6.3" inverted="false">
+                                    <name code="RequestType" displayName="RequestType"/>
+                                    <value code="Unknown" displayName="Unknown"/>
+                                </qualifier>
+                            </code>
+                            <text>NHS e-Referral Service, Purpose: Unknown</text>
+                            <statusCode code="COMPLETE"/>
+                            <effectiveTime>
+                                <center nullFlavor="NI"/>
+                            </effectiveTime>
+                            <availabilityTime value="20231206"/>
+                            <priorityCode code="394848005" codeSystem="2.16.840.1.113883.2.1.3.2.4.15"
+                                          displayName="Normal">
+                                <originalText>Routine</originalText>
+                            </priorityCode>
+                        </RequestStatement>
+                    </component>
+                </CompoundStatement>
+            </component>
+        </CompoundStatement>
+    </component>
+</ehrComposition>

--- a/gp2gp-translator/src/test/resources/xml/RequestStatement/request_statement_missing_priority_code.xml
+++ b/gp2gp-translator/src/test/resources/xml/RequestStatement/request_statement_missing_priority_code.xml
@@ -1,0 +1,35 @@
+<ehrComposition xmlns="urn:hl7-org:v3" classCode="COMPOSITION" moodCode="EVN">
+    <id root="72A39454-299F-432E-993E-5A6232B4E099" />
+    <availabilityTime value="20190708143500"/>
+    <Participant2 typeCode="PRF" contextControlCode="OP">
+        <agentRef classCode="AGNT">
+            <id root="B1AF3701-4D1C-11E3-9E6B-010000001205"/>
+        </agentRef>
+    </Participant2>
+    <component typeCode="COMP" >
+        <RequestStatement classCode="OBS" moodCode="RQO">
+            <id root="B4303C92-4D1C-11E3-A2DD-010000000161"/>
+            <code code="8HV6." codeSystem="2.16.840.1.113883.2.1.3.2.4.14" displayName="Reason Code">
+                <translation code="183885007" codeSystem="2.16.840.1.113883.2.1.3.2.4.15" displayName="Reason Code 1"/>
+                <translation code="8HV6.00" codeSystem="2.16.840.1.113883.2.1.6.2" displayName="Reason Code 2"/>
+            </code>
+            <text>Test request statement text
+                New line</text>
+            <statusCode code="COMPLETE"/>
+            <effectiveTime>
+                <center value="20050406" nullFlavor="NI"/>
+            </effectiveTime>
+            <availabilityTime value="20100101123000"/>
+            <responsibleParty typeCode="RESP">
+                <agentRef classCode="AGNT">
+                    <id root="B8CA3710-4D1C-11E3-9E6B-010000001205"/>
+                </agentRef>
+            </responsibleParty>
+            <Participant typeCode="PPRF" contextControlCode="OP">
+                <agentRef classCode="AGNT">
+                    <id root="58341512-03F3-4C8E-B41C-A8FCA3886BBB"/>
+                </agentRef>
+            </Participant>
+        </RequestStatement>
+    </component>
+</ehrComposition>

--- a/gp2gp-translator/src/test/resources/xml/RequestStatement/request_statement_unexpected_priority_code.xml
+++ b/gp2gp-translator/src/test/resources/xml/RequestStatement/request_statement_unexpected_priority_code.xml
@@ -1,0 +1,39 @@
+<ehrComposition xmlns="urn:hl7-org:v3" classCode="COMPOSITION" moodCode="EVN">
+    <id root="72A39454-299F-432E-993E-5A6232B4E099"/>
+    <availabilityTime value="20190708143500"/>
+    <Participant2 typeCode="PRF" contextControlCode="OP">
+        <agentRef classCode="AGNT">
+            <id root="B1AF3701-4D1C-11E3-9E6B-010000001205"/>
+        </agentRef>
+    </Participant2>
+    <component typeCode="COMP">
+        <RequestStatement classCode="OBS" moodCode="RQO">
+            <id root="B4303C92-4D1C-11E3-A2DD-010000000161"/>
+            <code code="8HV6." codeSystem="2.16.840.1.113883.2.1.3.2.4.14" displayName="Reason Code">
+                <translation code="183885007" codeSystem="2.16.840.1.113883.2.1.3.2.4.15" displayName="Reason Code 1"/>
+                <translation code="8HV6.00" codeSystem="2.16.840.1.113883.2.1.6.2" displayName="Reason Code 2"/>
+            </code>
+            <text>Test request statement text
+                New line
+            </text>
+            <statusCode code="COMPLETE"/>
+            <effectiveTime>
+                <center value="20050406" nullFlavor="NI"/>
+            </effectiveTime>
+            <availabilityTime value="20100101123000"/>
+            <priorityCode code="441808003" displayName="Delayed priority" codeSystem="2.16.840.1.113883.2.1.3.2.4.15">
+                <originalText>Delayed priority</originalText>
+            </priorityCode>
+            <responsibleParty typeCode="RESP">
+                <agentRef classCode="AGNT">
+                    <id root="B8CA3710-4D1C-11E3-9E6B-010000001205"/>
+                </agentRef>
+            </responsibleParty>
+            <Participant typeCode="PPRF" contextControlCode="OP">
+                <agentRef classCode="AGNT">
+                    <id root="58341512-03F3-4C8E-B41C-A8FCA3886BBB"/>
+                </agentRef>
+            </Participant>
+        </RequestStatement>
+    </component>
+</ehrComposition>

--- a/gp2gp-translator/src/test/resources/xml/RequestStatement/two_nested_request_statements.xml
+++ b/gp2gp-translator/src/test/resources/xml/RequestStatement/two_nested_request_statements.xml
@@ -1,0 +1,108 @@
+<ehrComposition xmlns="urn:hl7-org:v3" classCode="COMPOSITION" moodCode="EVN">
+    <id root="2227B72A-B855-4E2F-BD8C-5B678184CAF5"/>
+    <code code="25671000000102" codeSystem="2.16.840.1.113883.2.1.3.2.4.15" displayName="Surgery Consultation Note">
+        <originalText>GP Surgery</originalText>
+    </code>
+    <statusCode code="COMPLETE"/>
+    <effectiveTime>
+        <center nullFlavor="NI"/>
+    </effectiveTime>
+    <availabilityTime value="202312061049"/>
+    <author contextControlCode="OP" typeCode="AUT">
+        <time value="20231206105525"/>
+        <agentRef classCode="AGNT">
+            <id root="80A11057-899F-4B8E-90C1-6BF982144ADB"/>
+        </agentRef>
+    </author>
+    <location typeCode="LOC">
+        <locatedEntity classCode="LOCE">
+            <code code="1101121000000108" codeSystem="2.16.840.1.113883.2.1.3.2.4.15"
+                  displayName="Healthcare related organisation"/>
+            <locatedPlace classCode="PLC" determinerCode="INSTANCE">
+                <name>Charnock</name>
+            </locatedPlace>
+        </locatedEntity>
+    </location>
+    <Participant2 contextControlCode="OP" typeCode="RESP">
+        <agentRef classCode="AGNT">
+            <id root="80A11057-899F-4B8E-90C1-6BF982144ADB"/>
+        </agentRef>
+    </Participant2>
+    <component typeCode="COMP">
+        <CompoundStatement classCode="TOPIC" moodCode="EVN">
+            <id root="499384BB-88CA-405B-86D2-F1EB99286761"/>
+            <code code="252311015" codeSystem="2.16.840.1.113883.2.1.3.2.4.15" displayName="Backache"/>
+            <statusCode code="COMPLETE"/>
+            <effectiveTime>
+                <center nullFlavor="NI"/>
+            </effectiveTime>
+            <availabilityTime value="202312061049"/>
+            <component contextConductionInd="true" typeCode="COMP">
+                <CompoundStatement classCode="CATEGORY" moodCode="EVN">
+                    <id root="F170C52C-B4B4-4806-AC49-9B0C3ED1F8DB"/>
+                    <code code="3457005" codeSystem="2.16.840.1.113883.2.1.3.2.4.15" displayName="Referral"/>
+                    <statusCode code="COMPLETE"/>
+                    <effectiveTime>
+                        <center nullFlavor="NI"/>
+                    </effectiveTime>
+                    <availabilityTime value="202312061049"/>
+                    <component contextConductionInd="true" typeCode="COMP">
+                        <RequestStatement classCode="OBS" moodCode="RQO">
+                            <id root="C9922E37-EFC2-4FAA-B882-2F82BB88EBAE"/>
+                            <code code="EMISNQRE553" codeSystem="2.16.840.1.113883.2.1.6.3"
+                                  displayName="Referral for back rehabilitation">
+                                <qualifier codeSystem="2.16.840.1.113883.2.1.6.3" inverted="false">
+                                    <name code="RequestType" displayName="RequestType"/>
+                                    <value code="Unknown" displayName="Unknown"/>
+                                </qualifier>
+                            </code>
+                            <text>NHS e-Referral Service, Purpose: Unknown</text>
+                            <statusCode code="COMPLETE"/>
+                            <effectiveTime>
+                                <center nullFlavor="NI"/>
+                            </effectiveTime>
+                            <availabilityTime value="20231206"/>
+                            <priorityCode code="394848005" codeSystem="2.16.840.1.113883.2.1.3.2.4.15"
+                                          displayName="Normal">
+                                <originalText>Routine</originalText>
+                            </priorityCode>
+                        </RequestStatement>
+                    </component>
+                </CompoundStatement>
+            </component>
+            <component contextConductionInd="true" typeCode="COMP">
+                <CompoundStatement classCode="CATEGORY" moodCode="EVN">
+                    <id root="DF14ADB4-7250-4CEE-8276-5961D47C34F1"/>
+                    <code code="3457005" codeSystem="2.16.840.1.113883.2.1.3.2.4.15" displayName="Referral"/>
+                    <statusCode code="COMPLETE"/>
+                    <effectiveTime>
+                        <center nullFlavor="NI"/>
+                    </effectiveTime>
+                    <availabilityTime value="202312061049"/>
+                    <component contextConductionInd="true" typeCode="COMP">
+                        <RequestStatement classCode="OBS" moodCode="RQO">
+                            <id root="9E63CAA9-6863-4ABE-BD7A-DC7B303059FC"/>
+                            <code code="EMISNQRE553" codeSystem="2.16.840.1.113883.2.1.6.3"
+                                  displayName="Referral for back rehabilitation">
+                                <qualifier codeSystem="2.16.840.1.113883.2.1.6.3" inverted="false">
+                                    <name code="RequestType" displayName="RequestType"/>
+                                    <value code="Unknown" displayName="Unknown"/>
+                                </qualifier>
+                            </code>
+                            <text>NHS e-Referral Service, Purpose: Unknown</text>
+                            <statusCode code="COMPLETE"/>
+                            <effectiveTime>
+                                <center nullFlavor="NI"/>
+                            </effectiveTime>
+                            <availabilityTime value="20231206"/>
+                            <priorityCode code="88694003" codeSystem="2.16.840.1.113883.2.1.3.2.4.15"
+                                          displayName="Immediate">
+                                <originalText>Routine</originalText>
+                            </priorityCode>
+                        </RequestStatement>
+                    </component>
+                </CompoundStatement>
+            </component>
+        </CompoundStatement>
+    </component>
+</ehrComposition>


### PR DESCRIPTION
## What

Map a referral request's priority from the request statement's priority code element. Remove unnecessary recursive method.

- If the priority code is not provided or not recognised as an `EhrReferralPriority` code. Do not populate the referral request's priority

 ## Why

Conversation ID = `018C3F38-A5D9-727E-AE60-E5B94933480C` (2023-12-06 13:02:10.282) from EMIS to Medius 

The mapping of the EHR Extract failed due to a null pointer in the Referral Request mapper. Specifically when mapping the priority code. 

The method causing the null pointer was recursively searching for a request statement with a priority code. However, the mapped request statement is already available in the call stack. There is no documented reason why the recursive search is required.   

**Note:** the priority codes original text / display string was already mapped to the referral request's note array, regardless whether the code is a `EhrReferralPriority` or not. This functionality has not been changed 

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [x] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have updated the [Changelog](/CHANGELOG.md) with details of my change in the UNRELEASED section if this change will affect end users
- [x] A corresponding change has been made to the [Mapping Documentation repository][mapping-docs]

[mapping-docs]: https://github.com/NHSDigital/patient-switching-adaptors-mapping-documentation