### PR TITLE
Revert back to Ubuntu focal

### DIFF
--- a/docker/gp2gp-translator/Dockerfile
+++ b/docker/gp2gp-translator/Dockerfile
@@ -9,7 +9,7 @@ COPY --chown=gradle:gradle ./config /home/gradle/service/config
 WORKDIR /home/gradle/service/gp2gp-translator
 RUN ./gradlew --build-cache bootJar
 
-FROM eclipse-temurin:17
+FROM eclipse-temurin:17-jre-focal
 
 EXPOSE 8085
 

--- a/docker/gpc-facade/Dockerfile
+++ b/docker/gpc-facade/Dockerfile
@@ -8,7 +8,7 @@ COPY --chown=gradle:gradle ./config /home/gradle/service/config
 WORKDIR /home/gradle/service/gpc-api-facade
 RUN ./gradlew --build-cache bootJar
 
-FROM eclipse-temurin:17
+FROM eclipse-temurin:17-jre-focal
 
 EXPOSE 8081
 


### PR DESCRIPTION
## What

Please include a summary of the changes and the related issue

## Why

We appear to be hitting https://github.com/netty/netty/issues/12343

Note that this defect only appears to happen when running inside of the AWS path to live environment. When run locally, the adaptor doesn't run into this codepath.

Will investigate an upgrade to Netty in a future PR

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [x] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] I have updated the [Changelog](/CHANGELOG.md) with details of my change in the UNRELEASED section if this change will affect end users
- [ ] A corresponding change has been made to the [Mapping Documentation repository][mapping-docs]

[mapping-docs]: https://github.com/NHSDigital/patient-switching-adaptors-mapping-documentation