### PR TITLE
NIAD-2989: When mapping PractitionerRole and OrganizationRoles populate the systemcode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,10 +9,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 * REST buffer size has been set to 150Mb
 
 ### Fixed
-* Fixed issue where mapping failed due to a Referral Request Priority not being found. 
-* Additional information (code, display and system) will be provided in PractionionerRole and Organization resources via Codeable Concept
+* Fixed issue where mapping failed due to a Referral Request Priority not being found.
+* Codings are now provided (code, display and system) in `PractionionerRole.code` and `Organization.type` fields,
+  where only the `text` attribute was provided previously.
 * Fixed a bug which could lead to medication resource not being mapped if a failure had occurred when processing the previous EhrExtract during the medication mapping stage
-
 
 ## [1.3.0] - 2023-12-11
 

--- a/gp2gp-translator/src/integrationTest/resources/json/LargeMessage/expectedBundleScenario1.json
+++ b/gp2gp-translator/src/integrationTest/resources/json/LargeMessage/expectedBundleScenario1.json
@@ -63,7 +63,7 @@
         ],
         "type": [ {
           "coding": [ {
-            "system": "2.16.840.1.113883.2.1.3.2.4.15",
+            "system": "http://snomed.info/sct",
             "code": "394745000",
             "display": "General practice (organisation)"
           } ]

--- a/gp2gp-translator/src/integrationTest/resources/json/LargeMessage/expectedBundleScenario2.json
+++ b/gp2gp-translator/src/integrationTest/resources/json/LargeMessage/expectedBundleScenario2.json
@@ -63,7 +63,7 @@
         ],
         "type": [ {
           "coding": [ {
-            "system": "2.16.840.1.113883.2.1.3.2.4.15",
+            "system": "http://snomed.info/sct",
             "code": "394745000",
             "display": "General practice (organisation)"
           } ]

--- a/gp2gp-translator/src/integrationTest/resources/json/LargeMessage/expectedBundleScenario3.json
+++ b/gp2gp-translator/src/integrationTest/resources/json/LargeMessage/expectedBundleScenario3.json
@@ -63,7 +63,7 @@
         ],
         "type": [ {
           "coding": [ {
-            "system": "2.16.840.1.113883.2.1.3.2.4.15",
+            "system": "http://snomed.info/sct",
             "code": "394745000",
             "display": "General practice (organisation)"
           } ]

--- a/gp2gp-translator/src/integrationTest/resources/json/LargeMessage/expectedBundleScenario4.json
+++ b/gp2gp-translator/src/integrationTest/resources/json/LargeMessage/expectedBundleScenario4.json
@@ -63,7 +63,7 @@
         ],
         "type": [ {
           "coding": [ {
-            "system": "2.16.840.1.113883.2.1.3.2.4.15",
+            "system": "http://snomed.info/sct",
             "code": "394745000",
             "display": "General practice (organisation)"
           } ]

--- a/gp2gp-translator/src/integrationTest/resources/json/LargeMessage/expectedBundleScenario5.json
+++ b/gp2gp-translator/src/integrationTest/resources/json/LargeMessage/expectedBundleScenario5.json
@@ -63,7 +63,7 @@
         ],
         "type": [ {
           "coding": [ {
-            "system": "2.16.840.1.113883.2.1.3.2.4.15",
+            "system": "http://snomed.info/sct",
             "code": "394745000",
             "display": "General practice (organisation)"
           } ]

--- a/gp2gp-translator/src/integrationTest/resources/json/LargeMessage/expectedBundleScenario6.json
+++ b/gp2gp-translator/src/integrationTest/resources/json/LargeMessage/expectedBundleScenario6.json
@@ -63,7 +63,7 @@
         ],
         "type": [ {
           "coding": [ {
-            "system": "2.16.840.1.113883.2.1.3.2.4.15",
+            "system": "http://snomed.info/sct",
             "code": "394745000",
             "display": "General practice (organisation)"
           } ]

--- a/gp2gp-translator/src/integrationTest/resources/json/LargeMessage/expectedBundleScenario7.json
+++ b/gp2gp-translator/src/integrationTest/resources/json/LargeMessage/expectedBundleScenario7.json
@@ -63,7 +63,7 @@
         ],
         "type": [ {
           "coding": [ {
-            "system": "2.16.840.1.113883.2.1.3.2.4.15",
+            "system": "http://snomed.info/sct",
             "code": "394745000",
             "display": "General practice (organisation)"
           } ]

--- a/gp2gp-translator/src/integrationTest/resources/json/LargeMessage/expectedBundleScenario8.json
+++ b/gp2gp-translator/src/integrationTest/resources/json/LargeMessage/expectedBundleScenario8.json
@@ -63,7 +63,7 @@
         ],
         "type": [ {
           "coding": [ {
-            "system": "2.16.840.1.113883.2.1.3.2.4.15",
+            "system": "http://snomed.info/sct",
             "code": "394745000",
             "display": "General practice (organisation)"
           } ]

--- a/gp2gp-translator/src/integrationTest/resources/json/LargeMessage/expectedBundleScenario9.json
+++ b/gp2gp-translator/src/integrationTest/resources/json/LargeMessage/expectedBundleScenario9.json
@@ -63,7 +63,7 @@
         ],
         "type": [ {
           "coding": [ {
-            "system": "2.16.840.1.113883.2.1.3.2.4.15",
+            "system": "http://snomed.info/sct",
             "code": "394745000",
             "display": "General practice (organisation)"
           } ]

--- a/gp2gp-translator/src/main/java/uk/nhs/adaptors/pss/translator/mapper/AgentDirectoryMapper.java
+++ b/gp2gp-translator/src/main/java/uk/nhs/adaptors/pss/translator/mapper/AgentDirectoryMapper.java
@@ -53,7 +53,6 @@ public class AgentDirectoryMapper {
     private static final String PRACTITIONER_ROLE_SUFFIX = "-PR";
     private static final String ORG_ROOT = "2.16.840.1.113883.2.1.4.3";
     private static final String UNKNOWN = "Unknown";
-    private static final String SNOMED_SYSTEM_CODE = "2.16.840.1.113883.2.1.3.2.4.15";
     private static final String GMP_NUMBER_SYSTEM_CODE = "https://fhir.hl7.org.uk/Id/gmp-number";
 
     public List<? extends DomainResource> mapAgentDirectory(RCMRMT030101UK04AgentDirectory agentDirectory) {
@@ -223,22 +222,29 @@ public class AgentDirectoryMapper {
      * @param code <a href="https://data.developer.nhs.uk/dms/mim/4.2.00/Domains/CMETs/Tabular%20View/RCCT_HD120100UK01-NoEdit.htm#Agent">See the code field of Agent in MiM</a>
      */
     private CodeableConcept getText(CV code) {
+
+        // It is unclear if it is valid to have a code without a code system, an assumption has been made for NIAD-2989
+        // that in the case of missing code system we will leave the codeSystem blank.  This may need to be revisited
+        // if this is not the case
+
         if (code != null) {
-            String codeSystem = StringUtils.isEmpty(code.getCodeSystem())
-                    ? SNOMED_SYSTEM_CODE
-                    : code.getCodeSystem();
+
+
+            var codeSystem = code.hasCodeSystem()
+                    ? CodeSystemsUtil.getFhirCodeSystem(code.getCodeSystem())
+                    : null;
 
             if (StringUtils.isNotEmpty(code.getOriginalText())) {
                 return createCodeableConcept(
                         code.getCode(),
-                        CodeSystemsUtil.getFhirCodeSystem(codeSystem),
+                        codeSystem,
                         code.getDisplayName(),
                         code.getOriginalText());
 
             } else if (StringUtils.isNotEmpty(code.getDisplayName())) {
                 return createCodeableConcept(
                         code.getCode(),
-                        CodeSystemsUtil.getFhirCodeSystem(codeSystem),
+                        codeSystem,
                         code.getDisplayName());
             }
         }

--- a/gp2gp-translator/src/main/java/uk/nhs/adaptors/pss/translator/mapper/AgentDirectoryMapper.java
+++ b/gp2gp-translator/src/main/java/uk/nhs/adaptors/pss/translator/mapper/AgentDirectoryMapper.java
@@ -222,14 +222,15 @@ public class AgentDirectoryMapper {
      * @param code <a href="https://data.developer.nhs.uk/dms/mim/4.2.00/Domains/CMETs/Tabular%20View/RCCT_HD120100UK01-NoEdit.htm#Agent">See the code field of Agent in MiM</a>
      */
     private CodeableConcept getText(CV code) {
+        /* It is unclear if it is valid to have a code without a code system, an assumption has been made for NIAD-2989
+           that in the case of missing code system we will leave the codeSystem blank.
+           This may need to be revisited if this is not the case.
 
-        // It is unclear if it is valid to have a code without a code system, an assumption has been made for NIAD-2989
-        // that in the case of missing code system we will leave the codeSystem blank.  This may need to be revisited
-        // if this is not the case
+           See example in gp2gp-translator/src/integrationTest/resources/json/LargeMessage/Scenario_5/uk06.json
+             <code code="309394004" displayName="General Practitioner Principal">
+        */
 
         if (code != null) {
-
-
             var codeSystem = code.hasCodeSystem()
                     ? CodeSystemsUtil.getFhirCodeSystem(code.getCodeSystem())
                     : null;

--- a/gp2gp-translator/src/main/java/uk/nhs/adaptors/pss/translator/mapper/AgentDirectoryMapper.java
+++ b/gp2gp-translator/src/main/java/uk/nhs/adaptors/pss/translator/mapper/AgentDirectoryMapper.java
@@ -43,16 +43,18 @@ import static uk.nhs.adaptors.common.util.CodeableConceptUtils.createCodeableCon
 @Service
 public class AgentDirectoryMapper {
 
-    private static final String PRACT_META_PROFILE = "Practitioner-1";
+    private static final String PRACTITIONER_META_PROFILE = "Practitioner-1";
     private static final String ORG_META_PROFILE = "Organization-1";
-    private static final String PRACT_ROLE_META_PROFILE = "PractitionerRole-1";
+    private static final String PRACTITIONER_ROLE_META_PROFILE = "PractitionerRole-1";
     private static final String ORG_IDENTIFIER_SYSTEM = "https://fhir.nhs.uk/Id/ods-organization-code";
     private static final String ORG_PREFIX = "Organization/";
-    private static final String PRACT_PREFIX = "Practitioner/";
+    private static final String PRACTITIONER_PREFIX = "Practitioner/";
     private static final String ORG_ID_SUFFIX = "-ORG";
-    private static final String PRACT_ROLE_SUFFIX = "-PR";
+    private static final String PRACTITIONER_ROLE_SUFFIX = "-PR";
     private static final String ORG_ROOT = "2.16.840.1.113883.2.1.4.3";
     private static final String UNKNOWN = "Unknown";
+    private static final String SNOMED_SYSTEM_CODE = "2.16.840.1.113883.2.1.3.2.4.15";
+    private static final String GMP_NUMBER_SYSTEM_CODE = "https://fhir.hl7.org.uk/Id/gmp-number";
 
     public List<? extends DomainResource> mapAgentDirectory(RCMRMT030101UK04AgentDirectory agentDirectory) {
         var partList = agentDirectory.getPart();
@@ -100,12 +102,12 @@ public class AgentDirectoryMapper {
         var practitioner = new Practitioner();
 
         practitioner.setId(id);
-        practitioner.setMeta(generateMeta(PRACT_META_PROFILE));
+        practitioner.setMeta(generateMeta(PRACTITIONER_META_PROFILE));
         practitioner.setName(getPractitionerName(agentPerson.getName()));
 
         if (isNotEmpty(gpNumber)) {
             Identifier identifier = new Identifier()
-                .setSystem("https://fhir.hl7.org.uk/Id/gmp-number")
+                .setSystem(GMP_NUMBER_SYSTEM_CODE)
                 .setValue(gpNumber);
             practitioner.setIdentifier(List.of(identifier));
         }
@@ -160,17 +162,7 @@ public class AgentDirectoryMapper {
             organization.getIdentifier().add(identifier.orElseThrow());
         }
 
-        var address = getOrganizationAddress(representedOrg.getAddr());
-        if (address != null) {
-            organization.getAddress().add(address);
-        }
-
-        var telecom = getOrganizationTelecom(representedOrg.getTelecom());
-        if (telecom != null) {
-            organization.getTelecom().add(telecom);
-        }
-
-        return organization;
+        return addOrganisationAddressAndTelecomIfPresent(representedOrg, organization);
     }
 
     private Organization createAgentOrganization(RCCTMT120101UK01Organization agentOrg, String id, CV code) {
@@ -187,9 +179,13 @@ public class AgentDirectoryMapper {
 
         var text = getText(code);
         if (text != null) {
-            organization.getType().add(getText(code));
+            organization.getType().add(text);
         }
 
+        return addOrganisationAddressAndTelecomIfPresent(agentOrg, organization);
+    }
+
+    private Organization addOrganisationAddressAndTelecomIfPresent(RCCTMT120101UK01Organization agentOrg, Organization organization) {
         var address = getOrganizationAddress(agentOrg.getAddr());
         if (address != null) {
             organization.getAddress().add(address);
@@ -228,12 +224,22 @@ public class AgentDirectoryMapper {
      */
     private CodeableConcept getText(CV code) {
         if (code != null) {
-            String codeSystem = code.getCodeSystem() != null ? code.getCodeSystem() : "2.16.840.1.113883.2.1.3.2.4.15";
+            String codeSystem = StringUtils.isEmpty(code.getCodeSystem())
+                    ? SNOMED_SYSTEM_CODE
+                    : code.getCodeSystem();
+
             if (StringUtils.isNotEmpty(code.getOriginalText())) {
-                return createCodeableConcept(code.getCode(), CodeSystemsUtil.getFhirCodeSystem(codeSystem),
-                                             code.getDisplayName(), code.getOriginalText());
+                return createCodeableConcept(
+                        code.getCode(),
+                        CodeSystemsUtil.getFhirCodeSystem(codeSystem),
+                        code.getDisplayName(),
+                        code.getOriginalText());
+
             } else if (StringUtils.isNotEmpty(code.getDisplayName())) {
-                return createCodeableConcept(code.getCode(), CodeSystemsUtil.getFhirCodeSystem(codeSystem), code.getDisplayName());
+                return createCodeableConcept(
+                        code.getCode(),
+                        CodeSystemsUtil.getFhirCodeSystem(codeSystem),
+                        code.getDisplayName());
             }
         }
 
@@ -259,9 +265,9 @@ public class AgentDirectoryMapper {
     private PractitionerRole createPractitionerRole(String id, CV code, String organisationId) {
         var practitionerRole = new PractitionerRole();
 
-        practitionerRole.setId(id + PRACT_ROLE_SUFFIX);
-        practitionerRole.setMeta(generateMeta(PRACT_ROLE_META_PROFILE));
-        practitionerRole.setPractitioner(new Reference(PRACT_PREFIX + id));
+        practitionerRole.setId(id + PRACTITIONER_ROLE_SUFFIX);
+        practitionerRole.setMeta(generateMeta(PRACTITIONER_ROLE_META_PROFILE));
+        practitionerRole.setPractitioner(new Reference(PRACTITIONER_PREFIX + id));
         practitionerRole.setOrganization(new Reference(ORG_PREFIX + organisationId));
 
         var text = getText(code);

--- a/gp2gp-translator/src/main/java/uk/nhs/adaptors/pss/translator/mapper/AgentDirectoryMapper.java
+++ b/gp2gp-translator/src/main/java/uk/nhs/adaptors/pss/translator/mapper/AgentDirectoryMapper.java
@@ -36,6 +36,7 @@ import org.springframework.util.CollectionUtils;
 
 import io.micrometer.core.instrument.util.StringUtils;
 import uk.nhs.adaptors.pss.translator.util.AddressUtil;
+import uk.nhs.adaptors.pss.translator.util.CodeSystemsUtil;
 import uk.nhs.adaptors.pss.translator.util.TelecomUtil;
 import static uk.nhs.adaptors.common.util.CodeableConceptUtils.createCodeableConcept;
 
@@ -222,14 +223,17 @@ public class AgentDirectoryMapper {
         return name != null ? name : UNKNOWN;
     }
 
+    /**
+     * @param code <a href="https://data.developer.nhs.uk/dms/mim/4.2.00/Domains/CMETs/Tabular%20View/RCCT_HD120100UK01-NoEdit.htm#Agent">See the code field of Agent in MiM</a>
+     */
     private CodeableConcept getText(CV code) {
-
         if (code != null) {
+            String codeSystem = code.getCodeSystem() != null ? code.getCodeSystem() : "2.16.840.1.113883.2.1.3.2.4.15";
             if (StringUtils.isNotEmpty(code.getOriginalText())) {
-                return createCodeableConcept(code.getCode(), code.getCodeSystem(),
+                return createCodeableConcept(code.getCode(), CodeSystemsUtil.getFhirCodeSystem(codeSystem),
                                              code.getDisplayName(), code.getOriginalText());
             } else if (StringUtils.isNotEmpty(code.getDisplayName())) {
-                return createCodeableConcept(code.getCode(), code.getCodeSystem(), code.getDisplayName());
+                return createCodeableConcept(code.getCode(), CodeSystemsUtil.getFhirCodeSystem(codeSystem), code.getDisplayName());
             }
         }
 

--- a/gp2gp-translator/src/test/java/uk/nhs/adaptors/pss/translator/mapper/AgentDirectoryMapperTest.java
+++ b/gp2gp-translator/src/test/java/uk/nhs/adaptors/pss/translator/mapper/AgentDirectoryMapperTest.java
@@ -2,13 +2,9 @@ package uk.nhs.adaptors.pss.translator.mapper;
 
 import lombok.SneakyThrows;
 
-import org.hl7.fhir.dstu3.model.Address;
+import org.hl7.fhir.dstu3.model.*;
 import org.hl7.fhir.dstu3.model.Address.AddressUse;
 import org.hl7.fhir.dstu3.model.Address.AddressType;
-import org.hl7.fhir.dstu3.model.ContactPoint;
-import org.hl7.fhir.dstu3.model.Organization;
-import org.hl7.fhir.dstu3.model.Practitioner;
-import org.hl7.fhir.dstu3.model.PractitionerRole;
 import org.hl7.fhir.dstu3.model.ContactPoint.ContactPointSystem;
 import org.hl7.fhir.dstu3.model.ContactPoint.ContactPointUse;
 import org.hl7.fhir.dstu3.model.HumanName.NameUse;
@@ -18,6 +14,7 @@ import org.junit.jupiter.api.Test;
 import javax.xml.bind.JAXBException;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertAll;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.springframework.util.ResourceUtils.getFile;
 
@@ -32,7 +29,7 @@ public class AgentDirectoryMapperTest {
     private static final String PRACT_META_PROFILE = "https://fhir.nhs.uk/STU3/StructureDefinition/CareConnect-GPC-Practitioner-1";
     private static final String ORG_META_PROFILE = "https://fhir.nhs.uk/STU3/StructureDefinition/CareConnect-GPC-Organization-1";
     private static final String PRACT_ROLE_META_PROFILE = "https://fhir.nhs.uk/STU3/StructureDefinition/CareConnect-GPC"
-        + "-PractitionerRole-1";
+            + "-PractitionerRole-1";
     private final AgentDirectoryMapper agentDirectoryMapper = new AgentDirectoryMapper();
     private static final String ORG_IDENTIFIER_SYSTEM = "https://fhir.nhs.uk/Id/ods-organization-code";
     private static final int TELECOM_RANK = 1;
@@ -84,61 +81,33 @@ public class AgentDirectoryMapperTest {
         // This is not always the case, and so we manually populate the codeSystem where it has been omitted.
 
         var agentDirectory = unmarshallString("""
-             <agentDirectory xmlns="urn:hl7-org:v3" classCode="AGNT">
-                 <part typeCode="PART">
-                     <Agent classCode="AGNT">
-                         <id root="94F00D99-0601-4A8E-AD1D-1B564307B0A6"/>
-                         <code code="394745000" displayName="General practice" />
-                         <!-- ⚠️ ⬆️️Missing codeSystem attribute -->
-                         <agentPerson classCode="PSN" determinerCode="INSTANCE">
-                             <name>
-                                 <family>Test</family>
-                             </name>
-                         </agentPerson>
-                         <representedOrganization classCode="ORG" determinerCode="INSTANCE">
-                             <name>TEMPLE SOWERBY MEDICAL PRACTICE</name>
-                         </representedOrganization>
-                     </Agent>
-                 </part>
-             </agentDirectory>""", RCMRMT030101UK04AgentDirectory.class);
+                <agentDirectory xmlns="urn:hl7-org:v3" classCode="AGNT">
+                    <part typeCode="PART">
+                        <Agent classCode="AGNT">
+                            <id root="94F00D99-0601-4A8E-AD1D-1B564307B0A6"/>
+                            <code code="394745000" displayName="General practice" />
+                            <!-- ⚠️ ⬆️️Missing codeSystem attribute -->
+                            <agentPerson classCode="PSN" determinerCode="INSTANCE">
+                                <name>
+                                    <family>Test</family>
+                                </name>
+                            </agentPerson>
+                            <representedOrganization classCode="ORG" determinerCode="INSTANCE">
+                                <name>TEMPLE SOWERBY MEDICAL PRACTICE</name>
+                            </representedOrganization>
+                        </Agent>
+                    </part>
+                </agentDirectory>""", RCMRMT030101UK04AgentDirectory.class);
 
         var agents = agentDirectoryMapper.mapAgentDirectory(agentDirectory);
         assertThat(((PractitionerRole) agents.get(2)).getCodeFirstRep().getCodingFirstRep().getSystem()).isEqualTo("http://snomed.info/sct");
     }
 
     @Test
-    public void mapPractitionerRoleWithNonSnomedCode() throws JAXBException {
-        // The MiM states that:
-        //  > The codeSystem attribute will contain an OID with the value "2.16.840.1.113883.6.96";
-        // We haven't seen any Read codes, but it seems prudent to map the codeSystem if we ever did see it.
-
-        var agentDirectory = unmarshallString("""
-             <agentDirectory xmlns="urn:hl7-org:v3" classCode="AGNT">
-                 <part typeCode="PART">
-                     <Agent classCode="AGNT">
-                         <id root="94F00D99-0601-4A8E-AD1D-1B564307B0A6"/>
-                         <code codeSystem="2.16.840.1.113883.2.1.6.2" code="1234" displayName="General practice" />
-                         <agentPerson classCode="PSN" determinerCode="INSTANCE">
-                             <name>
-                                 <family>Test</family>
-                             </name>
-                         </agentPerson>
-                         <representedOrganization classCode="ORG" determinerCode="INSTANCE">
-                             <name>TEMPLE SOWERBY MEDICAL PRACTICE</name>
-                         </representedOrganization>
-                     </Agent>
-                 </part>
-             </agentDirectory>""", RCMRMT030101UK04AgentDirectory.class);
-
-        var agents = agentDirectoryMapper.mapAgentDirectory(agentDirectory);
-        assertThat(((PractitionerRole) agents.get(2)).getCodeFirstRep().getCodingFirstRep().getSystem()).isEqualTo("http://read.info/readv2");
-    }
-
-    @Test
     public void mapAgentDirectoryWithAgentPersonAndGeneralPractitionerNumber() {
         var agentDirectory = unmarshallAgentDirectoryElement("agent_org_with_general_practitioner_number.xml");
 
-        List mappedAgents = agentDirectoryMapper.mapAgentDirectory(agentDirectory);
+        var mappedAgents = agentDirectoryMapper.mapAgentDirectory(agentDirectory);
         var practitioner = (Practitioner) mappedAgents.get(0);
 
         assertEquals("E7E7B550-09EF-BE85-C20F-34598014166C", practitioner.getId());
@@ -229,6 +198,7 @@ public class AgentDirectoryMapperTest {
         assertThat(mappedAgents).hasSize(1);
 
         var practitioner = (Practitioner) mappedAgents.get(0);
+
         assertThat(practitioner.getId()).isEqualTo("95D00D99-0601-4A8E-AD1D-1B564307B0A6");
         assertThat(practitioner.getMeta().getProfile().get(0).getValue()).isEqualTo(PRACT_META_PROFILE);
         assertThat(practitioner.getNameFirstRep().getUse()).isEqualTo(NameUse.OFFICIAL);
@@ -374,6 +344,117 @@ public class AgentDirectoryMapperTest {
         assertAddress(organization.getAddressFirstRep());
     }
 
+    @Test
+    public void When_AgentContainsCodeWithSnomedSystemCodeProvided_Expect_SnomedSystemCodeIsMappedToCodeSystem() {
+        var inputXml = """
+                    <agentDirectory xmlns="urn:hl7-org:v3" classCode="AGNT">
+                        <part typeCode="PART">
+                            <Agent classCode="AGNT">
+                                <id root="94F00D99-0601-4A8E-AD1D-1B564307B0A6"/>
+                                <code codeSystem="2.16.840.1.113883.2.1.3.2.4.15"
+                                code="1234"
+                                displayName="General practice" />
+                                <agentPerson classCode="PSN" determinerCode="INSTANCE">
+                                    <name>
+                                        <family>Test</family>
+                                    </name>
+                                </agentPerson>
+                                <representedOrganization classCode="ORG" determinerCode="INSTANCE">
+                                    <name>TEMPLE SOWERBY MEDICAL PRACTICE</name>
+                                </representedOrganization>
+                            </Agent>
+                        </part>
+                    </agentDirectory>
+                    """;
+        var agentDirectory = unmarshallAgentDirectoryFromXmlString(inputXml);
+
+        var mappedAgents = agentDirectoryMapper.mapAgentDirectory(agentDirectory);
+
+        var practitionerRole = (PractitionerRole) mappedAgents.get(2);
+        var coding = practitionerRole.getCode().get(0).getCoding().get(0);
+
+        assertAll(
+                () -> assertEquals("1234", coding.getCode()),
+                () -> assertEquals("http://snomed.info/sct", coding.getSystem()),
+                () -> assertEquals("General practice", coding.getDisplay())
+        );
+    }
+
+    @Test
+    public void mapPractitionerRoleWithKnownNonSnomedCode() throws JAXBException {
+        // The MiM states that:
+        //  > The codeSystem attribute will contain an OID with the value "2.16.840.1.113883.6.96";
+        // We haven't seen any Read codes, but it seems prudent to map the codeSystem if we ever did see it.
+
+        var inputXml = """
+                    <agentDirectory xmlns="urn:hl7-org:v3" classCode="AGNT">
+                        <part typeCode="PART">
+                            <Agent classCode="AGNT">
+                                <id root="94F00D99-0601-4A8E-AD1D-1B564307B0A6"/>
+                                <code codeSystem="2.16.840.1.113883.2.1.6.2"
+                                code="1234"
+                                displayName="General practice" />
+                                <agentPerson classCode="PSN" determinerCode="INSTANCE">
+                                    <name>
+                                        <family>Test</family>
+                                    </name>
+                                </agentPerson>
+                                <representedOrganization classCode="ORG" determinerCode="INSTANCE">
+                                    <name>TEMPLE SOWERBY MEDICAL PRACTICE</name>
+                                </representedOrganization>
+                            </Agent>
+                        </part>
+                    </agentDirectory>
+                    """;
+        var agentDirectory = unmarshallAgentDirectoryFromXmlString(inputXml);
+
+        var agents = agentDirectoryMapper.mapAgentDirectory(agentDirectory);
+        var practitionerRole = (PractitionerRole) agents.get(2);
+        var coding = practitionerRole.getCode().get(0).getCoding().get(0);
+
+        assertAll(
+                () -> assertEquals("1234", coding.getCode()),
+                () -> assertEquals("http://read.info/readv2", coding.getSystem()),
+                () -> assertEquals("General practice", coding.getDisplay())
+        );
+    }
+
+    @Test
+    public void When_AgentContainsCodeWithNonSnomedSystemCodeProvided_Expect_OriginalCodeSystemIsMappedToCodeSystem() {
+        var inputXml = """
+                    <agentDirectory xmlns="urn:hl7-org:v3" classCode="AGNT">
+                        <part typeCode="PART">
+                        	<Agent classCode="AGNT">
+                        		<id root="E9F2B192-6DC7-11EE-9D98-00155D78C707" />
+                        		<code code="1234"
+                        		codeSystem="1.2.3.4.5.6"
+                        		displayName="Other person" />
+                        		<agentPerson classCode="PSN" determinerCode="INSTANCE">
+                                    <name>
+                                        <family>Test</family>
+                                    </name>
+                        		</agentPerson>
+                        		<representedOrganization classCode="ORG" determinerCode="INSTANCE">
+                                    <name>TEMPLE SOWERBY MEDICAL PRACTICE</name>
+                                </representedOrganization>
+                        	</Agent>
+                        </part>
+                    </agentDirectory>
+                    """;
+        var agentDirectory = unmarshallAgentDirectoryFromXmlString(inputXml);
+
+        var mappedAgents = agentDirectoryMapper.mapAgentDirectory(agentDirectory);
+
+        var practitionerRole = (PractitionerRole) mappedAgents.get(2);
+        var coding = practitionerRole.getCode().get(0).getCoding().get(0);
+
+        assertAll(
+                () -> assertEquals("1234", coding.getCode()),
+                () -> assertEquals("1.2.3.4.5.6", coding.getSystem()),
+                () -> assertEquals("Other person", coding.getDisplay())
+        );
+    }
+
     private void assertAddress(Address address) {
         assertEquals(AddressUse.WORK, address.getUse());
         assertEquals(AddressType.PHYSICAL, address.getType());
@@ -393,5 +474,10 @@ public class AgentDirectoryMapperTest {
     @SneakyThrows
     private RCMRMT030101UK04AgentDirectory unmarshallAgentDirectoryElement(String fileName) {
         return unmarshallFile(getFile("classpath:" + XML_RESOURCES_BASE + fileName), RCMRMT030101UK04AgentDirectory.class);
+    }
+
+    @SneakyThrows
+    private RCMRMT030101UK04AgentDirectory unmarshallAgentDirectoryFromXmlString(String inputXml) {
+        return unmarshallString(inputXml, RCMRMT030101UK04AgentDirectory.class);
     }
 }


### PR DESCRIPTION
## What

Also output the URI as opposed to the OID

## Why

~~We've seen some records within the E2E tests folder which don't have an explicit code system specified.
The MiM states that the codeSystem will be SNOMED.
If the adaptor gets an Agent which is missing a codeSystem, default it to SNOMED.~~

When mapping the code system, we are populating the system code and not the code system (ie. http://...).  This should be populating the code system.

It has been unclear on what to do when the code system is missing, i.e. just a code is provided, so at present we are mapping this, and not providing a code system.  This may need to be reviewed further @adrianclay 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [x] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have updated the [Changelog](/CHANGELOG.md) with details of my change in the UNRELEASED section if this change will affect end users
- [x] A corresponding change has been made to the [Mapping Documentation repository][mapping-docs]
     https://github.com/NHSDigital/patient-switching-adaptors-mapping-documentation/pull/36

[mapping-docs]: https://github.com/NHSDigital/patient-switching-adaptors-mapping-documentation