### PR TITLE
REST client buffer limit update

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## [Unreleased]
 
+### Changed
+* REST buffer size has been set to 150Mb
+
 ### Fixed
 * Fixed issue where mapping failed due to a Referral Request Priority not being found. 
 * Additional information (code, display and system) will be provided in PractionionerRole and Organization resources via Codeable Concept

--- a/gp2gp-translator/src/main/java/uk/nhs/adaptors/pss/translator/service/RequestBuilderService.java
+++ b/gp2gp-translator/src/main/java/uk/nhs/adaptors/pss/translator/service/RequestBuilderService.java
@@ -10,7 +10,7 @@ import lombok.SneakyThrows;
 @Service
 public class RequestBuilderService {
 
-    private static final int BYTE_COUNT = 16 * 1024 * 1024;
+    private static final int BYTE_COUNT = 150 * 1024 * 1024;
 
     @SneakyThrows
     public SslContext buildSSLContext() {


### PR DESCRIPTION
## What

REST buffer limit update

## Why

REST buffer size should be sufficient to accommodate the heavy messages that PS Adaptor might be given to translate

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Internal change (non-breaking change with no effect on the functionality affecting end users)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:

- [x] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I have updated the [Changelog](/CHANGELOG.md) with details of my change in the UNRELEASED section if this change will affect end users
- [ ] A corresponding change has been made to the [Mapping Documentation repository][mapping-docs]

[mapping-docs]: https://github.com/NHSDigital/patient-switching-adaptors-mapping-documentation