### PR TITLE
NIAD-2954: Use ehrComposition / author for authoredOn field instead of ehrExtract / availabilityTime

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 * REST buffer size has been set to 150Mb
 
 ### Fixed
+* `ProcedureRequestMapper.authoredOn` is no longer populated with `EhrExtract / availabilityTime` as a fallback,
+  but does use `EhrComposition / author / time` as a fallback instead now.
 * Fixed issue where mapping failed due to a Referral Request Priority not being found.
 * Codings are now provided (code, display and system) in `PractionionerRole.code` and `Organization.type` fields,
   where only the `text` attribute was provided previously.

--- a/gp2gp-translator/src/main/java/uk/nhs/adaptors/pss/translator/mapper/ProcedureRequestMapper.java
+++ b/gp2gp-translator/src/main/java/uk/nhs/adaptors/pss/translator/mapper/ProcedureRequestMapper.java
@@ -60,7 +60,7 @@ public class ProcedureRequestMapper extends AbstractMapper<ProcedureRequest> {
         procedureRequest
             .setStatus(ProcedureRequestStatus.ACTIVE)
             .setIntent(ProcedureRequestIntent.PLAN)
-            .setAuthoredOnElement(getAuthoredOn(planStatement.getAvailabilityTime(), ehrExtract, ehrComposition))
+            .setAuthoredOnElement(getAuthoredOn(planStatement.getAvailabilityTime(), ehrComposition))
             .setOccurrence(getOccurrenceDate(planStatement.getEffectiveTime()))
             .setSubject(new Reference(patient))
             .setMeta(generateMeta(META_PROFILE))
@@ -104,16 +104,13 @@ public class ProcedureRequestMapper extends AbstractMapper<ProcedureRequest> {
         return null;
     }
 
-    private DateTimeType getAuthoredOn(TS availabilityTime, RCMRMT030101UK04EhrExtract ehrExtract,
-        RCMRMT030101UK04EhrComposition ehrComposition) {
+    private DateTimeType getAuthoredOn(TS availabilityTime, RCMRMT030101UK04EhrComposition ehrComposition) {
         if (availabilityTime != null && availabilityTime.hasValue()) {
             return DateFormatUtil.parseToDateTimeType(availabilityTime.getValue());
-        } else {
-            if (ehrComposition.getAvailabilityTime() != null && ehrComposition.getAvailabilityTime().hasValue()) {
-                return DateFormatUtil.parseToDateTimeType(ehrComposition.getAvailabilityTime().getValue());
-            } else if (ehrExtract.getAvailabilityTime() != null && ehrExtract.getAvailabilityTime().hasValue()) {
-                return DateFormatUtil.parseToDateTimeType(ehrExtract.getAvailabilityTime().getValue());
-            }
+        } else if (ehrComposition.getAvailabilityTime() != null && ehrComposition.getAvailabilityTime().hasValue()) {
+            return DateFormatUtil.parseToDateTimeType(ehrComposition.getAvailabilityTime().getValue());
+        } else if (ehrComposition.hasAuthor() && ehrComposition.getAuthor().hasTime() && ehrComposition.getAuthor().getTime().hasValue()) {
+            return DateFormatUtil.parseToDateTimeType(ehrComposition.getAuthor().getTime().getValue());
         }
 
         return null;

--- a/gp2gp-translator/src/main/java/uk/nhs/adaptors/pss/translator/mapper/ProcedureRequestMapper.java
+++ b/gp2gp-translator/src/main/java/uk/nhs/adaptors/pss/translator/mapper/ProcedureRequestMapper.java
@@ -41,13 +41,12 @@ public class ProcedureRequestMapper extends AbstractMapper<ProcedureRequest> {
         return mapEhrExtractToFhirResource(ehrExtract, (extract, composition, component) ->
             extractAllPlanStatements(component)
                 .filter(Objects::nonNull)
-                .map(planStatement -> mapToProcedureRequest(ehrExtract, composition, planStatement, patient, encounters, practiseCode)))
+                .map(planStatement -> mapToProcedureRequest(composition, planStatement, patient, encounters, practiseCode)))
             .map(ProcedureRequest.class::cast)
             .toList();
     }
 
     public ProcedureRequest mapToProcedureRequest(
-            RCMRMT030101UK04EhrExtract ehrExtract,
             RCMRMT030101UK04EhrComposition ehrComposition,
             RCMRMT030101UK04PlanStatement planStatement,
             Patient patient,

--- a/gp2gp-translator/src/test/java/uk/nhs/adaptors/pss/translator/mapper/ProcedureRequestMapperTest.java
+++ b/gp2gp-translator/src/test/java/uk/nhs/adaptors/pss/translator/mapper/ProcedureRequestMapperTest.java
@@ -69,7 +69,7 @@ public class ProcedureRequestMapperTest {
         var planStatement = getPlanStatement(ehrExtract);
         setUpCodeableConceptMock();
 
-        ProcedureRequest procedureRequest = procedureRequestMapper.mapToProcedureRequest(ehrExtract, getEhrComposition(ehrExtract),
+        ProcedureRequest procedureRequest = procedureRequestMapper.mapToProcedureRequest(getEhrComposition(ehrExtract),
             planStatement, SUBJECT, ENCOUNTERS, PRACTISE_CODE);
 
         assertFixedValues(planStatement, procedureRequest);
@@ -91,7 +91,7 @@ public class ProcedureRequestMapperTest {
         var planStatement = getPlanStatement(ehrExtract);
         when(codeableConceptMapper.mapToCodeableConcept(any())).thenReturn(new CodeableConcept());
 
-        ProcedureRequest procedureRequest = procedureRequestMapper.mapToProcedureRequest(ehrExtract, getEhrComposition(ehrExtract),
+        ProcedureRequest procedureRequest = procedureRequestMapper.mapToProcedureRequest(getEhrComposition(ehrExtract),
                 planStatement, SUBJECT, ENCOUNTERS, PRACTISE_CODE);
 
         assertThat(procedureRequest.getCode().getCodingFirstRep()).isNotNull();
@@ -104,7 +104,7 @@ public class ProcedureRequestMapperTest {
         var ehrExtract = unmarshallCodeElement("no_optional_data_example.xml");
         var planStatement = getPlanStatement(ehrExtract);
 
-        ProcedureRequest procedureRequest = procedureRequestMapper.mapToProcedureRequest(ehrExtract, getEhrComposition(ehrExtract),
+        ProcedureRequest procedureRequest = procedureRequestMapper.mapToProcedureRequest(getEhrComposition(ehrExtract),
             planStatement, SUBJECT, ENCOUNTERS, PRACTISE_CODE);
 
         assertFixedValues(planStatement, procedureRequest);
@@ -118,7 +118,7 @@ public class ProcedureRequestMapperTest {
         var ehrExtract = unmarshallCodeElement("no_referenced_encounter_example.xml");
         var planStatement = getPlanStatement(ehrExtract);
 
-        ProcedureRequest procedureRequest = procedureRequestMapper.mapToProcedureRequest(ehrExtract, getEhrComposition(ehrExtract),
+        ProcedureRequest procedureRequest = procedureRequestMapper.mapToProcedureRequest(getEhrComposition(ehrExtract),
             planStatement, SUBJECT, ENCOUNTERS, PRACTISE_CODE);
 
         assertThat(procedureRequest.getContext().getResource()).isNull();
@@ -130,7 +130,7 @@ public class ProcedureRequestMapperTest {
         var planStatement = getPlanStatement(ehrExtract);
         setUpCodeableConceptMock();
 
-        ProcedureRequest procedureRequest = procedureRequestMapper.mapToProcedureRequest(ehrExtract, getEhrComposition(ehrExtract),
+        ProcedureRequest procedureRequest = procedureRequestMapper.mapToProcedureRequest(getEhrComposition(ehrExtract),
             planStatement, SUBJECT, ENCOUNTERS, PRACTISE_CODE);
 
         assertFixedValues(planStatement, procedureRequest);
@@ -147,7 +147,7 @@ public class ProcedureRequestMapperTest {
         var planStatement = getPlanStatement(ehrExtract);
         setUpCodeableConceptMock();
 
-        ProcedureRequest procedureRequest = procedureRequestMapper.mapToProcedureRequest(ehrExtract, getEhrComposition(ehrExtract),
+        ProcedureRequest procedureRequest = procedureRequestMapper.mapToProcedureRequest(getEhrComposition(ehrExtract),
             planStatement, SUBJECT, ENCOUNTERS, PRACTISE_CODE);
 
         assertFixedValues(planStatement, procedureRequest);
@@ -165,7 +165,7 @@ public class ProcedureRequestMapperTest {
         var planStatement = getPlanStatement(ehrExtract);
         setUpCodeableConceptMock();
 
-        ProcedureRequest procedureRequest = procedureRequestMapper.mapToProcedureRequest(ehrExtract, getEhrComposition(ehrExtract),
+        ProcedureRequest procedureRequest = procedureRequestMapper.mapToProcedureRequest(getEhrComposition(ehrExtract),
             planStatement, SUBJECT, ENCOUNTERS, PRACTISE_CODE);
 
         assertFixedValues(planStatement, procedureRequest);
@@ -182,7 +182,7 @@ public class ProcedureRequestMapperTest {
         var planStatement = getPlanStatement(ehrExtract);
         setUpCodeableConceptMock();
 
-        ProcedureRequest procedureRequest = procedureRequestMapper.mapToProcedureRequest(ehrExtract, getEhrComposition(ehrExtract),
+        ProcedureRequest procedureRequest = procedureRequestMapper.mapToProcedureRequest(getEhrComposition(ehrExtract),
             planStatement, SUBJECT, ENCOUNTERS, PRACTISE_CODE);
 
         assertFixedValues(planStatement, procedureRequest);

--- a/gp2gp-translator/src/test/java/uk/nhs/adaptors/pss/translator/mapper/ProcedureRequestMapperTest.java
+++ b/gp2gp-translator/src/test/java/uk/nhs/adaptors/pss/translator/mapper/ProcedureRequestMapperTest.java
@@ -177,8 +177,8 @@ public class ProcedureRequestMapperTest {
     }
 
     @Test
-    public void mapProcedureRequestWithEhrExtractAvailabilityTime() {
-        var ehrExtract = unmarshallCodeElement("ehr_extract_availability_time_example.xml");
+    public void mapProcedureRequestWithAuthorTime() {
+        var ehrExtract = unmarshallCodeElement("ehr_extract_author_time_example.xml");
         var planStatement = getPlanStatement(ehrExtract);
         setUpCodeableConceptMock();
 
@@ -187,7 +187,7 @@ public class ProcedureRequestMapperTest {
 
         assertFixedValues(planStatement, procedureRequest);
         assertThat(procedureRequest.getAuthoredOn()).isEqualTo(
-            DateFormatUtil.parseToDateTimeType(ehrExtract.getAvailabilityTime().getValue()).getValue());
+            DateFormatUtil.parseToDateTimeType(getEhrComposition(ehrExtract).getAuthor().getTime().getValue()).getValue());
         assertThat(procedureRequest.getCode().getCodingFirstRep().getDisplay()).isEqualTo(
             planStatement.getCode().getDisplayName());
         assertThat(procedureRequest.getContext().getResource().getIdElement().getValue()).isEqualTo(ENCOUNTER_ID);

--- a/gp2gp-translator/src/test/resources/xml/ProcedureRequest/ehr_extract_author_time_example.xml
+++ b/gp2gp-translator/src/test/resources/xml/ProcedureRequest/ehr_extract_author_time_example.xml
@@ -5,6 +5,9 @@
             <component typeCode="COMP">
                 <ehrComposition classCode="COMPOSITION" moodCode="EVN">
                     <id root="62A39454-299F-432E-993E-5A6232B4E099" />
+                    <author typeCode="AUT" contextControlCode="OP">
+                        <time value="20170101010101"/>
+                    </author>
                     <component typeCode="COMP" >
                         <PlanStatement classCode="OBS" moodCode="INT">
                             <id root="6DFFAEC4-7527-4D80-A2BD-81BDEBA04400" />


### PR DESCRIPTION
## Why

Please include details of the reasoning for these changes

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [x] I have performed a self-review of my code
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have updated the [Changelog](/CHANGELOG.md) with details of my change in the UNRELEASED section if this change will affect end users
- [x] A corresponding change has been made to the [Mapping Documentation repository][mapping-docs]

https://github.com/NHSDigital/patient-switching-adaptors-mapping-documentation/pull/37

[mapping-docs]: https://github.com/NHSDigital/patient-switching-adaptors-mapping-documentation