### PR TITLE
NIAD-2962: PS Adaptor incorrectly includes "Filing Comments" in the "related" property of Observation FHIR resources

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 * Codings are now provided (code, display and system) in `PractionionerRole.code` and `Organization.type` fields,
   where only the `text` attribute was provided previously.
 * Fixed a bug which could lead to medication resource not being mapped if a failure had occurred when processing the previous EhrExtract during the medication mapping stage
+* Fixed an issue where `Observation Test Group` or `Observation Test Results` were incorrectly creating a relationship to `Filing Comments` using the `has-member` relationship
 
 ## [1.3.0] - 2023-12-11
 

--- a/gp2gp-translator/src/integrationTest/resources/e2e-mapping/output-json/PWTP9-output.json
+++ b/gp2gp-translator/src/integrationTest/resources/e2e-mapping/output-json/PWTP9-output.json
@@ -47,10 +47,12 @@
             ]
           }
         ],
-        "identifier": [ {
-          "system": "https://fhir.hl7.org.uk/Id/gmp-number",
-          "value": "7882315"
-        } ]
+        "identifier": [
+          {
+            "system": "https://fhir.hl7.org.uk/Id/gmp-number",
+            "value": "7882315"
+          }
+        ]
       }
     },
     {
@@ -97,10 +99,12 @@
             ]
           }
         ],
-        "identifier": [ {
-          "system": "https://fhir.hl7.org.uk/Id/gmp-number",
-          "value": "7889233"
-        } ]
+        "identifier": [
+          {
+            "system": "https://fhir.hl7.org.uk/Id/gmp-number",
+            "value": "7889233"
+          }
+        ]
       }
     },
     {
@@ -9285,14 +9289,6 @@
               "value": 4
             }
           }
-        ],
-        "related": [
-          {
-            "type": "has-member",
-            "target": {
-              "reference": "Observation/DB841CCA-E32E-4E80-89A4-9A138A45633B"
-            }
-          }
         ]
       }
     },
@@ -9393,14 +9389,6 @@
               "value": 29
             }
           }
-        ],
-        "related": [
-          {
-            "type": "has-member",
-            "target": {
-              "reference": "Observation/89F6985C-DAF1-46A6-B48F-D69B2CDEA717"
-            }
-          }
         ]
       }
     },
@@ -9499,14 +9487,6 @@
             },
             "high": {
               "value": 70
-            }
-          }
-        ],
-        "related": [
-          {
-            "type": "has-member",
-            "target": {
-              "reference": "Observation/D843FEFE-A2B9-4A81-849A-26274A768246"
             }
           }
         ]
@@ -10102,14 +10082,6 @@
               "value": 46
             }
           }
-        ],
-        "related": [
-          {
-            "type": "has-member",
-            "target": {
-              "reference": "Observation/0818199A-C60F-4317-8E4C-7D2C767342C8"
-            }
-          }
         ]
       }
     },
@@ -10196,14 +10168,6 @@
               "value": 6
             }
           }
-        ],
-        "related": [
-          {
-            "type": "has-member",
-            "target": {
-              "reference": "Observation/91709DC8-E41A-4077-AB4F-DFC4F9280E30"
-            }
-          }
         ]
       }
     },
@@ -10260,15 +10224,7 @@
         "comment": "                                                                                    Non fasting specimen.",
         "specimen": {
           "reference": "Specimen/9608BE52-16AF-4065-AECC-513856303FE0"
-        },
-        "related": [
-          {
-            "type": "has-member",
-            "target": {
-              "reference": "Observation/C4B28488-A574-4EA4-9E24-3649D76691AA"
-            }
-          }
-        ]
+        }
       }
     },
     {
@@ -11907,15 +11863,7 @@
         "comment": "                                                                                    Negative                                                                                    I.M.Screen",
         "specimen": {
           "reference": "Specimen/7D57ADE4-B274-44FE-91A2-7E794CB5DA42"
-        },
-        "related": [
-          {
-            "type": "has-member",
-            "target": {
-              "reference": "Observation/5B5F5691-1E84-40D9-ADB8-D56DC681C7B2"
-            }
-          }
-        ]
+        }
       }
     },
     {
@@ -11987,15 +11935,7 @@
         "comment": "                                                                                    WBC MORPHOLOGY NORMAL                                                                                    RBC MORPHOLOGY NORMAL",
         "specimen": {
           "reference": "Specimen/7D57ADE4-B274-44FE-91A2-7E794CB5DA42"
-        },
-        "related": [
-          {
-            "type": "has-member",
-            "target": {
-              "reference": "Observation/BCDD3845-B4E9-4C87-8F65-F91706634AF2"
-            }
-          }
-        ]
+        }
       }
     },
     {

--- a/gp2gp-translator/src/integrationTest/resources/json/expectedBundle.json
+++ b/gp2gp-translator/src/integrationTest/resources/json/expectedBundle.json
@@ -28926,21 +28926,7 @@
         ],
         "specimen": {
           "reference": "Specimen/A245DC81-485C-49DF-B8E5-9230C9855A78"
-        },
-        "related": [
-          {
-            "type": "has-member",
-            "target": {
-              "reference": "Observation/041CC213-A756-467C-8254-3221B58A7F6A"
-            }
-          },
-          {
-            "type": "has-member",
-            "target": {
-              "reference": "Observation/8FB20BD2-718D-4FFF-9E9A-E52AFD7BFCFB"
-            }
-          }
-        ]
+        }
       }
     },
     {
@@ -29164,15 +29150,7 @@
         "comment": "CommentType:LABORATORY RESULT                                                                    COMMENT(E141)                                                                    CommentDate:20100223000000                                                                    NEGATIVE                                                                    In normal pregnancies the test will usually be positive from the                                                                    second day after the expected menstruation.                                                                ",
         "specimen": {
           "reference": "Specimen/SPECIMEN_COMPOUND_STATEMENT_ID_1"
-        },
-        "related": [
-          {
-            "type": "has-member",
-            "target": {
-              "reference": "Observation/6035E061-EEEE-444B-8171-DBEE153FDE2E"
-            }
-          }
-        ]
+        }
       }
     },
     {
@@ -29254,14 +29232,6 @@
               "value": 90
             }
           }
-        ],
-        "related": [
-          {
-            "type": "has-member",
-            "target": {
-              "reference": "Observation/6035E061-FD34-444B-8171-DBDD243FDE1D"
-            }
-          }
         ]
       }
     },
@@ -29335,15 +29305,7 @@
         "comment": "CommentType:LABORATORY RESULT                                                                    COMMENT(E141)                                                                    CommentDate:20100223000000                                                                    Test not available                                                                ",
         "specimen": {
           "reference": "Specimen/SPECIMEN_COMPOUND_STATEMENT_ID_3"
-        },
-        "related": [
-          {
-            "type": "has-member",
-            "target": {
-              "reference": "Observation/6035E061-FD34-444B-8171-CCEE354GEF2C"
-            }
-          }
-        ]
+        }
       }
     },
     {
@@ -29477,21 +29439,7 @@
         ],
         "specimen": {
           "reference": "Specimen/1277BE3-481B-4254-AA8E-17B2529244B6"
-        },
-        "related": [
-          {
-            "type": "has-member",
-            "target": {
-              "reference": "Observation/8877BE3-481B-4254-AA8E-17B2529244B6"
-            }
-          },
-          {
-            "type": "has-member",
-            "target": {
-              "reference": "Observation/1177BE3-481B-4254-AA8E-17B2529244B6"
-            }
-          }
-        ]
+        }
       }
     },
     {
@@ -29661,12 +29609,6 @@
           "reference": "Specimen/1277BE3-481B-4254-AA8E-17B2529244B6"
         },
         "related": [
-          {
-            "type": "has-member",
-            "target": {
-              "reference": "Observation/USER_COMMENT_NARRATIVE_STATEMENT_ID"
-            }
-          },
           {
             "type": "derived-from",
             "target": {

--- a/gp2gp-translator/src/main/java/uk/nhs/adaptors/pss/translator/mapper/diagnosticreport/SpecimenCompoundsMapper.java
+++ b/gp2gp-translator/src/main/java/uk/nhs/adaptors/pss/translator/mapper/diagnosticreport/SpecimenCompoundsMapper.java
@@ -145,11 +145,6 @@ public class SpecimenCompoundsMapper {
                     .setType(ObservationRelationshipType.DERIVEDFROM)
                 );
             }
-
-            if (!containsRelatedComponent(observation, observationComment.getId())) {
-                observation.addRelated(new ObservationRelatedComponent(new Reference(observationComment))
-                    .setType(ObservationRelationshipType.HASMEMBER));
-            }
         }
     }
 

--- a/gp2gp-translator/src/test/java/uk/nhs/adaptors/pss/translator/mapper/diagnosticreport/SpecimenCompoundsMapperTest.java
+++ b/gp2gp-translator/src/test/java/uk/nhs/adaptors/pss/translator/mapper/diagnosticreport/SpecimenCompoundsMapperTest.java
@@ -23,8 +23,6 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 import lombok.SneakyThrows;
-import uk.nhs.adaptors.pss.translator.mapper.CodeableConceptMapper;
-import uk.nhs.adaptors.pss.translator.mapper.DateTimeMapper;
 
 @ExtendWith(MockitoExtension.class)
 public class SpecimenCompoundsMapperTest {
@@ -46,12 +44,6 @@ public class SpecimenCompoundsMapperTest {
     private List<Observation> observations;
     private List<Observation> observationComments;
     private List<DiagnosticReport> diagnosticReports;
-
-    @Mock
-    private DateTimeMapper dateTimeMapper;
-
-    @Mock
-    private CodeableConceptMapper codeableConceptMapper;
 
     @Mock
     private SpecimenBatteryMapper specimenBatteryMapper;
@@ -94,18 +86,13 @@ public class SpecimenCompoundsMapperTest {
 
         assertParentSpecimenIsReferenced(observation);
 
+        assertThat(observation.getRelated()).isEmpty();
         assertThat(observationComments.size()).isEqualTo(2);
         assertThat(observationComment.getComment()).isEqualTo(TEST_COMMENT_LINE_1);
         assertThat(observationComment.getRelated()).isNotEmpty();
-        assertThat(observationComment.getRelatedFirstRep().getTarget().getResource()).isNotNull();
-        assertThat(observationComment.getRelatedFirstRep().getTarget().getResource().getIdElement().getValue())
-            .isEqualTo(OBSERVATION_STATEMENT_ID);
-
-        assertThat(observation.getRelated()).isNotEmpty();
-        assertThat(observation.getRelatedFirstRep().getTarget().getResource()).isNotNull();
-        assertThat(observation.getRelatedFirstRep().getTarget().getResource().getIdElement().getValue())
-            .isEqualTo(NARRATIVE_STATEMENT_ID);
-
+        assertThat(observationComment.getRelated().get(0).getTarget().getResource()).isNotNull();
+        assertThat(observationComment.getRelated().get(0).getTarget().getResource().getIdElement().getValue())
+                .isEqualTo(observation.getId());
         assertThat(diagnosticReports.get(0).getResult().size()).isOne();
     }
 
@@ -133,8 +120,12 @@ public class SpecimenCompoundsMapperTest {
         );
 
         assertParentSpecimenIsReferenced(observations.get(0));
-        assertThat(observations.get(0).getRelated()).isNotEmpty();
         assertThat(observationComments.size()).isEqualTo(2);
+        assertThat(observationComments.get(0).getRelated()).isNotEmpty();
+        assertThat(observationComments.get(0).getRelated()).isNotEmpty();
+        assertThat(observationComments.get(0).getRelated().get(0).getTarget().getResource()).isNotNull();
+        assertThat(observationComments.get(0).getRelated().get(0).getTarget().getResource().getIdElement().getValue())
+                .isEqualTo(observations.get(0).getId());
         assertThat(observations.get(0).getComment()).isEqualTo(TEST_COMMENT_LINE);
     }
 


### PR DESCRIPTION
## What

Remove the functionality for this mapping and updated unit / integration tests accordingly

## Why

When `Filing Comments` are present when mapping a `Test Group Header` or `Test Result` they were referenced using the relationship field to provide a `has-member` relationship.  This was not the correct behaviour as listed in the [GP Connect documentation](https://developer.nhs.uk/apis/gpconnect-1-6-0/accessrecord_structured_development_observation_testResult.html#related)

## Type of change

Please delete options that are not relevant.

- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:

- [x] I have performed a self-review of my code
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have updated the [Changelog](/CHANGELOG.md) with details of my change in the UNRELEASED section if this change will affect end users
- [x] A corresponding change has been made to the [Mapping Documentation repository][mapping-docs]

[mapping-docs]: https://github.com/NHSDigital/patient-switching-adaptors-mapping-documentation