### PR TITLE
Added parameterised unit test to test asserted date is mapped from th…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 * REST buffer size has been set to 150Mb
 
 ### Fixed
+* `AllergyIntoleranceMapper.assertedDate`  is no longer populated with `EhrExtract / availabilityTime` as a fallback,
+  but does use `EhrComposition / author / time` as a fallback instead now.
 * `ProcedureRequestMapper.authoredOn` is no longer populated with `EhrExtract / availabilityTime` as a fallback,
   but does use `EhrComposition / author / time` as a fallback instead now.
 * Fixed issue where mapping failed due to a Referral Request Priority not being found.

--- a/gp2gp-translator/src/test/java/uk/nhs/adaptors/pss/translator/mapper/AllergyIntoleranceMapperTest.java
+++ b/gp2gp-translator/src/test/java/uk/nhs/adaptors/pss/translator/mapper/AllergyIntoleranceMapperTest.java
@@ -395,7 +395,32 @@ public class AllergyIntoleranceMapperTest {
                 .isEqualTo(EPISODICITY_WITHOUT_ORIGINAL_TEXT_NOTE_TEXT);
     }
 
+    @ParameterizedTest
+    @MethodSource("allergyStructuresWithDifferentAssertedDateLocations")
+    public void When_AllergyIntoleranceIsMappingAssertedDate_Expect_TheCorrectValueMapped(
+            String filename,
+            String expectedAssertedDateAsString) {
 
+        when(codeableConceptMapper.mapToCodeableConcept(any(CD.class)))
+                .thenReturn(defaultCodeableConcept());
+
+        var ehrExtract = unmarshallEhrExtract(filename);
+
+        List<AllergyIntolerance> allergyIntolerances = allergyIntoleranceMapper.mapResources(ehrExtract, getPatient(),
+                getEncounterList(), PRACTISE_CODE);
+
+        var allergyIntolerance = allergyIntolerances.get(0);
+
+        assertThat(allergyIntolerance.getAssertedDateElement().asStringValue()).isEqualTo(expectedAssertedDateAsString);
+    }
+
+    public static Stream<Arguments> allergyStructuresWithDifferentAssertedDateLocations() {
+        return Stream.of(
+                Arguments.of("allergy-with-compound-statement-availability-time.xml", "1978-12-31"),
+                Arguments.of("allergy-without-compound-statement-availability-time.xml", "2019-07-08"),
+                Arguments.of("allergy-with-only-ehr-composition-author-time.xml", "2019-12-25")
+        );
+    }
 
     @ParameterizedTest
     @MethodSource("allergyStructuresWithTranslations")

--- a/gp2gp-translator/src/test/resources/xml/AllergyIntolerance/allergy-with-compound-statement-availability-time.xml
+++ b/gp2gp-translator/src/test/resources/xml/AllergyIntolerance/allergy-with-compound-statement-availability-time.xml
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<EhrExtract xmlns="urn:hl7-org:v3" classCode="EXTRACT" moodCode="EVN">
+    <availabilityTime value="20200101000000" />
+    <component typeCode="COMP">
+        <ehrFolder classCode="FOLDER" moodCode="EVN">
+            <component typeCode="COMP">
+                <ehrComposition classCode="COMPOSITION" moodCode="EVN">
+                    <id root="62A39454-299F-432E-993E-5A6232B4E099"/>
+                    <availabilityTime value="20190708143500"/>
+                    <Participant2 typeCode="PRF" contextControlCode="OP" nullFlavor="UNK" />
+                    <component typeCode="COMP">
+                        <CompoundStatement classCode="CATEGORY" moodCode="EVN">
+                            <id root="394559384658936"/>
+                            <code code="14L..00" codeSystem="2.16.840.1.113883.2.1.6.2" displayName="H/O: drug allergy"/>
+                            <effectiveTime nullFlavor="UNK" />
+                            <availabilityTime value="19781231" />
+                            <component typeCode="COMP" contextConductionInd="true">
+                                <ObservationStatement classCode="OBS" moodCode="ENV">
+                                    <id root="394559384658936"/>
+                                    <code nullFlavor="UNK"><originalText>Mocked code</originalText></code>
+                                </ObservationStatement>
+                            </component>
+                        </CompoundStatement>
+                    </component>
+                </ehrComposition>
+            </component>
+        </ehrFolder>
+    </component>
+</EhrExtract>

--- a/gp2gp-translator/src/test/resources/xml/AllergyIntolerance/allergy-with-only-ehr-composition-author-time.xml
+++ b/gp2gp-translator/src/test/resources/xml/AllergyIntolerance/allergy-with-only-ehr-composition-author-time.xml
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<EhrExtract xmlns="urn:hl7-org:v3" classCode="EXTRACT" moodCode="EVN">
+    <availabilityTime value="20200101000000" />
+    <component typeCode="COMP">
+        <ehrFolder classCode="FOLDER" moodCode="EVN">
+            <component typeCode="COMP">
+                <ehrComposition classCode="COMPOSITION" moodCode="EVN">
+                    <id root="62A39454-299F-432E-993E-5A6232B4E099"/>
+                    <author typeCode="AUT" contextControlCode="OP">
+                        <time value="20191225" />
+                        <agentRef classCode="AGNT">
+                            <id root="E7E7B550-09EF-BE85-C20F-34598014166C" />
+                        </agentRef>
+                    </author>
+                    <availabilityTime nullFlavor="UNK"/>
+                    <Participant2 typeCode="PRF" contextControlCode="OP" nullFlavor="UNK" />
+                    <component typeCode="COMP">
+                        <CompoundStatement classCode="CATEGORY" moodCode="EVN">
+                            <id root="394559384658936"/>
+                            <code code="14L..00" codeSystem="2.16.840.1.113883.2.1.6.2" displayName="H/O: drug allergy"/>
+                            <effectiveTime nullFlavor="UNK" />
+                            <availabilityTime nullFlavor="UNK" />
+                            <component typeCode="COMP" contextConductionInd="true">
+                                <ObservationStatement classCode="OBS" moodCode="ENV">
+                                    <id root="394559384658936"/>
+                                    <code nullFlavor="UNK"><originalText>Mocked code</originalText></code>
+                                </ObservationStatement>
+                            </component>
+                        </CompoundStatement>
+                    </component>
+                </ehrComposition>
+            </component>
+        </ehrFolder>
+    </component>
+</EhrExtract>

--- a/gp2gp-translator/src/test/resources/xml/AllergyIntolerance/allergy-without-compound-statement-availability-time.xml
+++ b/gp2gp-translator/src/test/resources/xml/AllergyIntolerance/allergy-without-compound-statement-availability-time.xml
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<EhrExtract xmlns="urn:hl7-org:v3" classCode="EXTRACT" moodCode="EVN">
+    <availabilityTime value="20200101000000" />
+    <component typeCode="COMP">
+        <ehrFolder classCode="FOLDER" moodCode="EVN">
+            <component typeCode="COMP">
+                <ehrComposition classCode="COMPOSITION" moodCode="EVN">
+                    <id root="62A39454-299F-432E-993E-5A6232B4E099"/>
+                    <availabilityTime value="20190708"/>
+                    <Participant2 typeCode="PRF" contextControlCode="OP" nullFlavor="UNK" />
+                    <component typeCode="COMP">
+                        <CompoundStatement classCode="CATEGORY" moodCode="EVN">
+                            <id root="394559384658936"/>
+                            <code code="14L..00" codeSystem="2.16.840.1.113883.2.1.6.2" displayName="H/O: drug allergy"/>
+                            <effectiveTime nullFlavor="UNK" />
+                            <availabilityTime nullFlavor="UNK" />
+                            <component typeCode="COMP" contextConductionInd="true">
+                                <ObservationStatement classCode="OBS" moodCode="ENV">
+                                    <id root="394559384658936"/>
+                                    <code nullFlavor="UNK"><originalText>Mocked code</originalText></code>
+                                </ObservationStatement>
+                            </component>
+                        </CompoundStatement>
+                    </component>
+                </ehrComposition>
+            </component>
+        </ehrFolder>
+    </component>
+</EhrExtract>


### PR DESCRIPTION
## What

Added parameterised unit test to test asserted date is mapped from the available primary and fallback date fields.
Added test XML files for the above test.
Removed dependency on EhrExtract for AllergyIntoleranceMapper and associated fallback to EhrExtract.AvailabilityTime Added fallback for EhrComposition.Author.Time where available Updated CHANGELOG.md

## Why

EhrExtract / availabilityTime field is described as a date which has no relevance to this field and should not be used for this case:

`System date and time of generating this extract on the system from which the message originates.`

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [x] I have performed a self-review of my code
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have updated the [Changelog](/CHANGELOG.md) with details of my change in the UNRELEASED section if this change will affect end users

Mapping Documentation will be updated once all the remapping has been done