### PR TITLE
Jenkins: Remove volumes too

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -129,7 +129,7 @@ pipeline {
                                 ]
                             )
                             sh '''
-                               docker-compose -f docker/docker-compose.yml -f docker/docker-compose-checks.yml down --rmi all --remove-orphans
+                               docker-compose -f docker/docker-compose.yml -f docker/docker-compose-checks.yml down --rmi all --remove-orphans --volumes
                                docker network rm ps-network
                             '''
                             sh "rm -rf db-connector-build"


### PR DESCRIPTION
## Why

We're currently seeing "disk space" errors on Jenkins worker nodes.

Removing volumes as part of the post-build cleanup will hopefully reduce the frequency of cleanup of this error.

## Type of change

- [x] Internal change (non-breaking change with no effect on the functionality affecting end users)

## Checklist:

- [x] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I have updated the [Changelog](/CHANGELOG.md) with details of my change in the UNRELEASED section if this change will affect end users
- [ ] A corresponding change has been made to the [Mapping Documentation repository][mapping-docs]

[mapping-docs]: https://github.com/NHSDigital/patient-switching-adaptors-mapping-documentation