### PR TITLE
NIAD-3038 & 3039: Plan Statement (Recall) Statuses

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## [Unreleased]
 
+### Fixed
+* Fixed an issue where Plan Statements (Recalls) used a fixed value for Status instead of taking a provided text value into account.
+
 ## [1.4.3] - 2024-02-15
 
 ### Added

--- a/gp2gp-translator/src/integrationTest/resources/e2e-mapping/output-json/PWTP10-output.json
+++ b/gp2gp-translator/src/integrationTest/resources/e2e-mapping/output-json/PWTP10-output.json
@@ -2699,7 +2699,7 @@
             "value": "58EF971E-B8F0-46E5-A403-B3432C17FD70"
           }
         ],
-        "status": "active",
+        "status": "unknown",
         "intent": "plan",
         "code": {
           "coding": [
@@ -2761,7 +2761,7 @@
             "value": "B301E01E-61D2-45BB-ACE9-C960C9041E8C"
           }
         ],
-        "status": "active",
+        "status": "unknown",
         "intent": "plan",
         "code": {
           "coding": [

--- a/gp2gp-translator/src/integrationTest/resources/e2e-mapping/output-json/PWTP11-output.json
+++ b/gp2gp-translator/src/integrationTest/resources/e2e-mapping/output-json/PWTP11-output.json
@@ -2644,7 +2644,7 @@
             "value": "D9B1F929-832C-4D9F-9AE9-1BFDD68D2467"
           }
         ],
-        "status": "active",
+        "status": "unknown",
         "intent": "plan",
         "code": {
           "coding": [

--- a/gp2gp-translator/src/integrationTest/resources/e2e-mapping/output-json/PWTP2-output.json
+++ b/gp2gp-translator/src/integrationTest/resources/e2e-mapping/output-json/PWTP2-output.json
@@ -2755,7 +2755,7 @@
             "value": "EEF7FF16-513F-4D40-AAF5-C9CA29F79C85"
           }
         ],
-        "status": "active",
+        "status": "unknown",
         "intent": "plan",
         "code": {
           "coding": [
@@ -2817,7 +2817,7 @@
             "value": "7CBC48DF-68DD-4306-87EA-1CA0DC25DE6A"
           }
         ],
-        "status": "active",
+        "status": "unknown",
         "intent": "plan",
         "code": {
           "coding": [

--- a/gp2gp-translator/src/integrationTest/resources/e2e-mapping/output-json/PWTP3-output.json
+++ b/gp2gp-translator/src/integrationTest/resources/e2e-mapping/output-json/PWTP3-output.json
@@ -559,7 +559,7 @@
             "value": "2FD02B22-C71D-4022-B800-04718374D0EC"
           }
         ],
-        "status": "active",
+        "status": "unknown",
         "intent": "plan",
         "code": {
           "coding": [
@@ -606,7 +606,7 @@
             "value": "1B1C6F50-D8BE-4480-83D6-EF25AC5F1836"
           }
         ],
-        "status": "active",
+        "status": "unknown",
         "intent": "plan",
         "code": {
           "coding": [

--- a/gp2gp-translator/src/integrationTest/resources/e2e-mapping/output-json/PWTP4-output.json
+++ b/gp2gp-translator/src/integrationTest/resources/e2e-mapping/output-json/PWTP4-output.json
@@ -2299,7 +2299,7 @@
             "value": "D0EE1E80-15DE-4452-A973-BA140A6B8550"
           }
         ],
-        "status": "active",
+        "status": "unknown",
         "intent": "plan",
         "code": {
           "coding": [
@@ -2361,7 +2361,7 @@
             "value": "89623C08-C8F3-4227-8B9E-732406B15B7D"
           }
         ],
-        "status": "active",
+        "status": "unknown",
         "intent": "plan",
         "code": {
           "coding": [

--- a/gp2gp-translator/src/integrationTest/resources/e2e-mapping/output-json/PWTP6-output.json
+++ b/gp2gp-translator/src/integrationTest/resources/e2e-mapping/output-json/PWTP6-output.json
@@ -2352,7 +2352,7 @@
             "value": "4A0BBD26-0D6C-4DD4-A522-5C4FAE78F97B"
           }
         ],
-        "status": "active",
+        "status": "unknown",
         "intent": "plan",
         "code": {
           "coding": [
@@ -2414,7 +2414,7 @@
             "value": "40FD7C16-2D1C-4B09-BE35-C50B56B5FC5A"
           }
         ],
-        "status": "active",
+        "status": "unknown",
         "intent": "plan",
         "code": {
           "coding": [

--- a/gp2gp-translator/src/integrationTest/resources/json/expectedBundle.json
+++ b/gp2gp-translator/src/integrationTest/resources/json/expectedBundle.json
@@ -2920,7 +2920,7 @@
             "value": "3316531F-5705-424C-9E1A-EE694FB411B4"
           }
         ],
-        "status": "active",
+        "status": "unknown",
         "intent": "plan",
         "code": {
           "coding": [
@@ -2977,7 +2977,7 @@
             "value": "procedure-request-id"
           }
         ],
-        "status": "active",
+        "status": "unknown",
         "intent": "plan",
         "code": {
           "coding": [
@@ -3034,7 +3034,7 @@
             "value": "7BF97563-C89A-4265-9532-1F2332653497"
           }
         ],
-        "status": "active",
+        "status": "unknown",
         "intent": "plan",
         "code": {
           "coding": [

--- a/gp2gp-translator/src/test/java/uk/nhs/adaptors/pss/translator/mapper/ProcedureRequestMapperTest.java
+++ b/gp2gp-translator/src/test/java/uk/nhs/adaptors/pss/translator/mapper/ProcedureRequestMapperTest.java
@@ -216,8 +216,7 @@ public class ProcedureRequestMapperTest {
     @MethodSource("planStatementStatuses")
     public void When_PlanStatementTextStartsWithStatus_Expect_CorrectStatusIsMapped(
             String statusIdentifier,
-            ProcedureRequestStatus expectedStatus)
-    {
+            ProcedureRequestStatus expectedStatus) {
         var inputXml = """
                 <EhrExtract xmlns="urn:hl7-org:v3" classCode="EXTRACT" moodCode="EVN">
                     <component typeCode="COMP">
@@ -253,8 +252,7 @@ public class ProcedureRequestMapperTest {
     }
 
     @Test
-    public void When_PlanStatementDoesNotContainText_Expect_StatusIsSetToUnknown()
-    {
+    public void When_PlanStatementDoesNotContainText_Expect_StatusIsSetToUnknown() {
         var inputXml = """
                 <EhrExtract xmlns="urn:hl7-org:v3" classCode="EXTRACT" moodCode="EVN">
                     <component typeCode="COMP">

--- a/gp2gp-translator/src/test/java/uk/nhs/adaptors/pss/translator/mapper/ProcedureRequestMapperTest.java
+++ b/gp2gp-translator/src/test/java/uk/nhs/adaptors/pss/translator/mapper/ProcedureRequestMapperTest.java
@@ -10,6 +10,7 @@ import static org.springframework.util.ResourceUtils.getFile;
 import static uk.nhs.adaptors.pss.translator.util.XmlUnmarshallUtil.unmarshallFile;
 
 import java.util.List;
+import java.util.stream.Stream;
 
 import org.hl7.fhir.dstu3.model.CodeableConcept;
 import org.hl7.fhir.dstu3.model.Encounter;
@@ -22,6 +23,9 @@ import org.hl7.v3.RCMRMT030101UKEhrComposition;
 import org.hl7.v3.RCMRMT030101UKPlanStatement;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
@@ -30,6 +34,7 @@ import lombok.SneakyThrows;
 import uk.nhs.adaptors.pss.translator.util.DateFormatUtil;
 import uk.nhs.adaptors.pss.translator.util.DegradedCodeableConcepts;
 import static uk.nhs.adaptors.common.util.CodeableConceptUtils.createCodeableConcept;
+import static uk.nhs.adaptors.pss.translator.util.XmlUnmarshallUtil.unmarshallString;
 
 @ExtendWith(MockitoExtension.class)
 public class ProcedureRequestMapperTest {
@@ -42,8 +47,22 @@ public class ProcedureRequestMapperTest {
     private static final String CODING_CODE = "2534664018";
     private static final String CODING_SYSTEM = "http://snomed.info/sct";
     private static final String ENCOUNTER_ID = "62A39454-299F-432E-993E-5A6232B4E099";
+    private static final String STATUS_PENDING = "Status: Pending";
+    private static final String STATUS_CLINICIAN_CANCELLED = "Status: Cancelled by clinician";
+    private static final String STATUS_SUPERSEDED = "Status: Superseded";
+    private static final String STATUS_SEEN = "Status: Seen";
     private static final List<Encounter> ENCOUNTERS = getEncounterList();
     private static final Patient SUBJECT = createPatient();
+
+    private static Stream<Arguments> planStatementStatuses() {
+        return Stream.of(
+                Arguments.of("", ProcedureRequestStatus.UNKNOWN),
+                Arguments.of(STATUS_PENDING, ProcedureRequestStatus.ACTIVE),
+                Arguments.of(STATUS_CLINICIAN_CANCELLED, ProcedureRequestStatus.CANCELLED),
+                Arguments.of(STATUS_SUPERSEDED, ProcedureRequestStatus.CANCELLED),
+                Arguments.of(STATUS_SEEN, ProcedureRequestStatus.COMPLETED)
+        );
+    }
 
     @Mock
     private CodeableConceptMapper codeableConceptMapper;
@@ -193,10 +212,87 @@ public class ProcedureRequestMapperTest {
         assertThat(procedureRequest.getContext().getResource().getIdElement().getValue()).isEqualTo(ENCOUNTER_ID);
     }
 
+    @ParameterizedTest
+    @MethodSource("planStatementStatuses")
+    public void When_PlanStatementTextStartsWithStatus_Expect_CorrectStatusIsMapped(
+            String statusIdentifier,
+            ProcedureRequestStatus expectedStatus)
+    {
+        var inputXml = """
+                <EhrExtract xmlns="urn:hl7-org:v3" classCode="EXTRACT" moodCode="EVN">
+                    <component typeCode="COMP">
+                        <ehrFolder classCode="FOLDER" moodCode="EVN">
+                            <component typeCode="COMP">
+                                <ehrComposition classCode="COMPOSITION" moodCode="EVN">
+                                    <id root="7DFFAEC4-7527-4D80-A2BD-81BDEBA04400" />
+                                    <component typeCode="COMP" >
+                                        <PlanStatement classCode="OBS" moodCode="INT">
+                                            <id root="6DFFAEC4-7527-4D80-A2BD-81BDEBA04400" />
+                                            <text>{statusIdentifier} this is some text after the status</text>
+                                            <code code="123456" codeSystem="1.2.3.4.5" displayName="12345"></code>
+                                            <statusCode code="COMPLETE" />
+                                        </PlanStatement>
+                                    </component>
+                                </ehrComposition>
+                            </component>
+                        </ehrFolder>
+                    </component>
+                </EhrExtract>
+                """.replace("{statusIdentifier}", statusIdentifier);
+
+        var ehrExtract = unmarshallCodeElementFromString(inputXml);
+        var planStatement = getPlanStatement(ehrExtract);
+
+        when(codeableConceptMapper.mapToCodeableConcept(any()))
+                .thenReturn(new CodeableConcept());
+
+        ProcedureRequest procedureRequest = procedureRequestMapper.mapToProcedureRequest(getEhrComposition(ehrExtract),
+                planStatement, SUBJECT, ENCOUNTERS, PRACTISE_CODE);
+
+        assertThat(procedureRequest.getStatus()).isEqualTo(expectedStatus);
+    }
+
+    @Test
+    public void When_PlanStatementDoesNotContainText_Expect_StatusIsSetToUnknown()
+    {
+        var inputXml = """
+                <EhrExtract xmlns="urn:hl7-org:v3" classCode="EXTRACT" moodCode="EVN">
+                    <component typeCode="COMP">
+                        <ehrFolder classCode="FOLDER" moodCode="EVN">
+                            <component typeCode="COMP">
+                                <ehrComposition classCode="COMPOSITION" moodCode="EVN">
+                                    <id root="7DFFAEC4-7527-4D80-A2BD-81BDEBA04400" />
+                                    <component typeCode="COMP" >
+                                        <PlanStatement classCode="OBS" moodCode="INT">
+                                            <id root="6DFFAEC4-7527-4D80-A2BD-81BDEBA04400" />
+                                            <code code="123456" codeSystem="1.2.3.4.5" displayName="12345"></code>
+                                            <statusCode code="COMPLETE" />
+                                        </PlanStatement>
+                                    </component>
+                                </ehrComposition>
+                            </component>
+                        </ehrFolder>
+                    </component>
+                </EhrExtract>
+                """;
+
+        var ehrExtract = unmarshallCodeElementFromString(inputXml);
+        var planStatement = getPlanStatement(ehrExtract);
+
+        when(codeableConceptMapper.mapToCodeableConcept(any()))
+                .thenReturn(new CodeableConcept());
+
+        ProcedureRequest procedureRequest = procedureRequestMapper.mapToProcedureRequest(getEhrComposition(ehrExtract),
+                planStatement, SUBJECT, ENCOUNTERS, PRACTISE_CODE);
+
+        assertThat(procedureRequest.getStatus()).isEqualTo(ProcedureRequestStatus.UNKNOWN);
+    }
+
+
+
     private void assertFixedValues(RCMRMT030101UKPlanStatement planStatement, ProcedureRequest procedureRequest) {
         assertThat(procedureRequest.getId()).isEqualTo(planStatement.getId().getRoot());
         assertThat(procedureRequest.getIntent()).isEqualTo(ProcedureRequestIntent.PLAN);
-        assertThat(procedureRequest.getStatus()).isEqualTo(ProcedureRequestStatus.ACTIVE);
         assertThat(procedureRequest.getIdentifierFirstRep().getSystem()).isEqualTo(IDENTIFIER_SYSTEM);
         assertThat(procedureRequest.getIdentifierFirstRep().getValue()).isEqualTo(planStatement.getId().getRoot());
         assertThat(procedureRequest.getMeta().getProfile().get(0).getValue()).isEqualTo(META_PROFILE);
@@ -225,5 +321,10 @@ public class ProcedureRequestMapperTest {
     @SneakyThrows
     private RCMRMT030101UK04EhrExtract unmarshallCodeElement(String fileName) {
         return unmarshallFile(getFile("classpath:" + XML_RESOURCES_BASE + fileName), RCMRMT030101UK04EhrExtract.class);
+    }
+
+    @SneakyThrows
+    private RCMRMT030101UK04EhrExtract unmarshallCodeElementFromString(String inputXml) {
+        return unmarshallString(inputXml, RCMRMT030101UK04EhrExtract.class);
     }
 }


### PR DESCRIPTION
## What

Previously the adaptor had a fixed value of `Active` for Plan Statements, this has now been changed so that the following mapping occurs when `PlanStatement.text` starts with `Status:`:

`Status: Pending` -> `active`
`Status: Cancelled by clinician` -> `cancelled`
`Status: Superseded` -> `cancelled`
`Status: Seen` -> `completed`

When `PlanStatement.text` is not present or does not not start with `Status:` then a fallback of `unknown` is used.

## Why

The adaptor has a fixed value of `Status: active` for Plan Statements, but this does not reflect the status being returned by **SystmOne**.   When a recall is generated by **SystmOne** they consistently provide a value for `PlanStatement.text` with starts with 'Status: `; The value immediately following this should be used to set the appropriate status in the resource.

Although this is consistently output by **SystmOne**, **EMIS Web** does not output a `PlanStatement.Text` value at all for Diary Entries.  This means that fallback was necessary for when the `PlanStatement.Text` does not exist or does not contain a status.  
This was covered in [NIAD-3039](https://gpitbjss.atlassian.net/browse/NIAD-3039) and so made sense to implement this at the same time.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [x] I have performed a self-review of my code
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have updated the [Changelog](/CHANGELOG.md) with details of my change in the UNRELEASED section if this change will affect end users
- [x] A corresponding change has been made to the [Mapping Documentation repository][mapping-docs]

[mapping-docs]: https://github.com/NHSDigital/patient-switching-adaptors-mapping-documentation