### PR TITLE
NIAD-3058: improving naming convention and changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,8 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## [Unreleased]
 
-* Condition.onsetDateTime is set to NULL when low and center entries of effectiveTime
-  include nullFlavor="UNK"
+* Condition.onsetDateTime is set to NULL when low or center entries of effectiveTime
+  are `nullFlavor="UNK"`
 
 ## [1.4.5] - 2024-03-01
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## [Unreleased]
 
+* Condition.onsetDateTime is set to NULL when low and center entries of effectiveTime
+  include nullFlavor="UNK"
+
 ## [1.4.5] - 2024-03-01
 
 ### Fixed

--- a/gp2gp-translator/src/test/java/uk/nhs/adaptors/pss/translator/mapper/ConditionMapperTest.java
+++ b/gp2gp-translator/src/test/java/uk/nhs/adaptors/pss/translator/mapper/ConditionMapperTest.java
@@ -176,7 +176,7 @@ public class ConditionMapperTest {
     }
 
     @Test
-    public void testLinkSetWithNoDatesIsMappedCorrectly() {
+    public void testLinkSetWithNoDatesIsMappedWithNullOnsetDateTime() {
         final RCMRMT030101UK04EhrExtract ehrExtract = unmarshallEhrExtract("linkset_no_dates.xml");
         final List<Condition> conditions = conditionMapper.mapResources(ehrExtract, patient, List.of(), PRACTISE_CODE);
 
@@ -190,7 +190,7 @@ public class ConditionMapperTest {
     }
 
     @Test
-    public void testLinkSetWithEffectiveTimeLowNullFlavorUnkIsMappedCorrectly() {
+    public void testLinkSetWithEffectiveTimeLowNullFlavorUnkIsMappedWithNullOnsetDateTime() {
         when(dateTimeMapper.mapDateTime(any())).thenReturn(EHR_EXTRACT_AVAILABILITY_DATETIME);
         final RCMRMT030101UK04EhrExtract ehrExtract = unmarshallEhrExtract("linkset_with_null_flavor_unk.xml");
         final List<Condition> conditions = conditionMapper.mapResources(ehrExtract, patient, List.of(), PRACTISE_CODE);


### PR DESCRIPTION
## What

Improving the naming of some methods for OnsetDateTime.

## Why


## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Internal change (non-breaking change with no effect on the functionality affecting end users)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:

- [x] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] I have updated the [Changelog](/CHANGELOG.md) with details of my change in the UNRELEASED section if this change will affect end users
- [ ] A corresponding change has been made to the [Mapping Documentation repository][mapping-docs]

[mapping-docs]: https://github.com/NHSDigital/patient-switching-adaptors-mapping-documentation