### PR TITLE
NIAD-3067: codeable concept changes

### DIFF
--- a/gp2gp-translator/src/main/java/uk/nhs/adaptors/pss/translator/util/CodeableConceptUtil.java
+++ b/gp2gp-translator/src/main/java/uk/nhs/adaptors/pss/translator/util/CodeableConceptUtil.java
@@ -26,8 +26,8 @@ public final class CodeableConceptUtil {
 
     private static Boolean compareCodeSubElements(List<? extends CD> c1, List<? extends CD> c2) {
 
-        if (CollectionUtils.isEmpty(c1) || CollectionUtils.isEmpty(c2) || c1.size() != c2.size()) {
-            return CollectionUtils.isEmpty(c1) && CollectionUtils.isEmpty(c2);
+        if (c1.size() != c2.size()) {
+            return false;
         }
 
         for (CD c1Element : c1) {

--- a/gp2gp-translator/src/main/java/uk/nhs/adaptors/pss/translator/util/CodeableConceptUtil.java
+++ b/gp2gp-translator/src/main/java/uk/nhs/adaptors/pss/translator/util/CodeableConceptUtil.java
@@ -1,0 +1,46 @@
+package uk.nhs.adaptors.pss.translator.util;
+
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
+import org.springframework.util.CollectionUtils;
+import org.hl7.v3.CD;
+import java.util.List;
+import java.util.Objects;
+
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+public final class CodeableConceptUtil {
+
+    public static Boolean compareCodeableConcepts(CD c1, CD c2) {
+
+        if (c1 == null || c2 == null) {
+            return c1 == c2;
+        }
+
+        return Objects.equals(c1.getCode(), c2.getCode())
+                && Objects.equals(c1.getCodeSystem(), c2.getCodeSystem())
+                && Objects.equals(c1.getDisplayName(), c2.getDisplayName())
+                && Objects.equals(c1.getOriginalText(), c2.getOriginalText())
+                && compareCodeSubElements(c1.getQualifier(), c2.getQualifier())
+                && compareCodeSubElements(c1.getTranslation(), c2.getTranslation());
+    }
+
+    private static Boolean compareCodeSubElements(List<? extends CD> c1, List<? extends CD> c2) {
+
+        if (CollectionUtils.isEmpty(c1) || CollectionUtils.isEmpty(c2) || c1.size() != c2.size()) {
+            return CollectionUtils.isEmpty(c1) && CollectionUtils.isEmpty(c2);
+        }
+
+        for (CD c1Element : c1) {
+            boolean matchFound = c2
+                    .stream()
+                    .anyMatch(c2Element -> compareCodeableConcepts(c1Element, c2Element));
+
+            if (!matchFound) {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+}

--- a/gp2gp-translator/src/main/java/uk/nhs/adaptors/pss/translator/util/CodeableConceptUtil.java
+++ b/gp2gp-translator/src/main/java/uk/nhs/adaptors/pss/translator/util/CodeableConceptUtil.java
@@ -2,7 +2,6 @@ package uk.nhs.adaptors.pss.translator.util;
 
 import lombok.AccessLevel;
 import lombok.NoArgsConstructor;
-import org.springframework.util.CollectionUtils;
 import org.hl7.v3.CD;
 import java.util.List;
 import java.util.Objects;

--- a/gp2gp-translator/src/test/java/uk/nhs/adaptors/pss/translator/util/CodeableConceptUtilTest.java
+++ b/gp2gp-translator/src/test/java/uk/nhs/adaptors/pss/translator/util/CodeableConceptUtilTest.java
@@ -27,7 +27,7 @@ public class CodeableConceptUtilTest {
     }
 
     @Test
-    public void compareCodeableConceptsWithOneTransaction() {
+    public void compareCodeableConceptsWithOneTranslation() {
 
         CD c1 = new CD();
         c1.setCode("Code1");
@@ -87,7 +87,7 @@ public class CodeableConceptUtilTest {
     }
 
     @Test
-    public void compareCodeableConceptsWithTwoTransactionsPairsNotIdenticalTranslations() {
+    public void compareCodeableConceptsWithTwoTranslationsPairsNotIdenticalTranslations() {
 
         CD c1 = new CD();
         c1.setCode("Code1");
@@ -130,7 +130,7 @@ public class CodeableConceptUtilTest {
     }
 
     @Test
-    public void compareCodeableConceptsWithUniqualNumberOfTransactionPairs() {
+    public void compareCodeableConceptsWithUnequalNumberOfTranslationPairs() {
 
         CD c1 = new CD();
         c1.setCode("Code1");

--- a/gp2gp-translator/src/test/java/uk/nhs/adaptors/pss/translator/util/CodeableConceptUtilTest.java
+++ b/gp2gp-translator/src/test/java/uk/nhs/adaptors/pss/translator/util/CodeableConceptUtilTest.java
@@ -57,6 +57,49 @@ public class CodeableConceptUtilTest {
     }
 
     @Test
+    public void compareCodeableConceptsWithDifferentTranslationOrdering() {
+
+        CD c1 = new CD();
+        c1.setCode("Code1");
+        c1.setCodeSystem("CodeSystem1");
+        c1.setDisplayName("DisplayName1");
+        c1.setOriginalText("OriginalText");
+
+        CD translationCD1 = new CD();
+        translationCD1.setCode("161586000");
+        translationCD1.setCodeSystem("2.16.840.1.113883.2.1.3.2.4.15");
+        translationCD1.setDisplayName("H/O: injury");
+
+        CD translationCD2 = new CD();
+        translationCD2.setCode("161586002");
+        translationCD2.setCodeSystem("2.16.840.1.113883.2.1.3.2.4.17");
+        translationCD2.setDisplayName("H/O: injury2");
+
+        c1.getTranslation().add(translationCD1);
+        c1.getTranslation().add(translationCD2);
+
+        CD c2 = new CD();
+        c2.setCode("Code1");
+        c2.setCodeSystem("CodeSystem1");
+        c2.setDisplayName("DisplayName1");
+        c2.setOriginalText("OriginalText");
+
+        CD translationCD3 = new CD();
+        translationCD3.setCode("161586002");
+        translationCD3.setCodeSystem("2.16.840.1.113883.2.1.3.2.4.17");
+        translationCD3.setDisplayName("H/O: injury2");
+        c2.getTranslation().add(translationCD3);
+
+        CD translationCD4 = new CD();
+        translationCD4.setCode("161586000");
+        translationCD4.setCodeSystem("2.16.840.1.113883.2.1.3.2.4.15");
+        translationCD4.setDisplayName("H/O: injury");
+        c2.getTranslation().add(translationCD4);
+
+        assertTrue(CodeableConceptUtil.compareCodeableConcepts(c1, c2));
+    }
+
+    @Test
     public void compareCodeableConceptsWithOneQualifierPair() {
 
         CD c1 = new CD();
@@ -84,6 +127,36 @@ public class CodeableConceptUtilTest {
         c2.getQualifier().add(cr2);
 
         assertTrue(CodeableConceptUtil.compareCodeableConcepts(c1, c2));
+    }
+
+    @Test
+    public void compareCodeableConceptsWithDifferentQualifiers() {
+
+        CD c1 = new CD();
+        c1.setCode("Code1");
+        c1.setCodeSystem("CodeSystem1");
+        c1.setDisplayName("DisplayName1");
+        c1.setOriginalText("OriginalText");
+
+        CR cr1 = new CR();
+        cr1.setCode("QualifierCode1");
+        cr1.setCodeSystem("QualifierCodeSystemCode");
+        cr1.setDisplayName("QualifierDisplayName");
+        c1.getQualifier().add(cr1);
+
+        CD c2 = new CD();
+        c2.setCode("Code1");
+        c2.setCodeSystem("CodeSystem1");
+        c2.setDisplayName("DisplayName1");
+        c2.setOriginalText("OriginalText");
+
+        CR cr2 = new CR();
+        cr2.setCode("QualifierCode2");
+        cr2.setCodeSystem("QualifierCodeSystemCode");
+        cr2.setDisplayName("QualifierDisplayName");
+        c2.getQualifier().add(cr2);
+
+        assertFalse(CodeableConceptUtil.compareCodeableConcepts(c1, c2));
     }
 
     @Test

--- a/gp2gp-translator/src/test/java/uk/nhs/adaptors/pss/translator/util/CodeableConceptUtilTest.java
+++ b/gp2gp-translator/src/test/java/uk/nhs/adaptors/pss/translator/util/CodeableConceptUtilTest.java
@@ -1,0 +1,181 @@
+package uk.nhs.adaptors.pss.translator.util;
+
+import org.hl7.v3.CD;
+import org.hl7.v3.CR;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+public class CodeableConceptUtilTest {
+
+    @Test
+    public void compareCodeableConceptsWithNullParams() {
+        assertTrue(CodeableConceptUtil.compareCodeableConcepts(null, null));
+    }
+
+    @Test
+    public void compareCodeableConceptsWithFirstNullParam() {
+        CD c2 = new CD();
+        assertFalse(CodeableConceptUtil.compareCodeableConcepts(null, c2));
+    }
+
+    @Test
+    public void compareCodeableConceptsWithSecondNullParam() {
+        CD c1 = new CD();
+        assertFalse(CodeableConceptUtil.compareCodeableConcepts(c1, null));
+    }
+
+    @Test
+    public void compareCodeableConceptsWithOneTransaction() {
+
+        CD c1 = new CD();
+        c1.setCode("Code1");
+        c1.setCodeSystem("CodeSystem1");
+        c1.setDisplayName("DisplayName1");
+        c1.setOriginalText("OriginalText");
+
+        CD translationCD1 = new CD();
+        translationCD1.setCode("161586000");
+        translationCD1.setCodeSystem("2.16.840.1.113883.2.1.3.2.4.15");
+        translationCD1.setDisplayName("H/O: injury");
+        c1.getTranslation().add(translationCD1);
+
+        CD c2 = new CD();
+        c2.setCode("Code1");
+        c2.setCodeSystem("CodeSystem1");
+        c2.setDisplayName("DisplayName1");
+        c2.setOriginalText("OriginalText");
+
+        CD translationCD2 = new CD();
+        translationCD2.setCode("161586000");
+        translationCD2.setCodeSystem("2.16.840.1.113883.2.1.3.2.4.15");
+        translationCD2.setDisplayName("H/O: injury");
+        c2.getTranslation().add(translationCD2);
+
+        assertTrue(CodeableConceptUtil.compareCodeableConcepts(c1, c2));
+    }
+
+    @Test
+    public void compareCodeableConceptsWithOneQualifierPair() {
+
+        CD c1 = new CD();
+        c1.setCode("Code1");
+        c1.setCodeSystem("CodeSystem1");
+        c1.setDisplayName("DisplayName1");
+        c1.setOriginalText("OriginalText");
+
+        CR cr1 = new CR();
+        cr1.setCode("QualifierCode");
+        cr1.setCodeSystem("QualifierCodeSystemCode");
+        cr1.setDisplayName("QualifierDisplayName");
+        c1.getQualifier().add(cr1);
+
+        CD c2 = new CD();
+        c2.setCode("Code1");
+        c2.setCodeSystem("CodeSystem1");
+        c2.setDisplayName("DisplayName1");
+        c2.setOriginalText("OriginalText");
+
+        CR cr2 = new CR();
+        cr2.setCode("QualifierCode");
+        cr2.setCodeSystem("QualifierCodeSystemCode");
+        cr2.setDisplayName("QualifierDisplayName");
+        c2.getQualifier().add(cr2);
+
+        assertTrue(CodeableConceptUtil.compareCodeableConcepts(c1, c2));
+    }
+
+    @Test
+    public void compareCodeableConceptsWithTwoTransactionsPairsNotIdenticalTranslations() {
+
+        CD c1 = new CD();
+        c1.setCode("Code1");
+        c1.setCodeSystem("CodeSystem1");
+        c1.setDisplayName("DisplayName1");
+        c1.setOriginalText("OriginalText");
+
+        CD translationCD1 = new CD();
+        translationCD1.setCode("161586000");
+        translationCD1.setCodeSystem("2.16.840.1.113883.2.1.3.2.4.15");
+        translationCD1.setDisplayName("H/O: injury");
+        c1.getTranslation().add(translationCD1);
+
+        CD translationCD2 = new CD();
+        translationCD2.setCode("161586007");
+        translationCD2.setCodeSystem("2.16.840.1.113883.2.1.3.2.4.17");
+        translationCD2.setDisplayName("H/O: injury7");
+        c1.getTranslation().add(translationCD2);
+
+        CD c2 = new CD();
+        c2.setCode("Code1");
+        c2.setCodeSystem("CodeSystem1");
+        c2.setDisplayName("DisplayName1");
+        c2.setOriginalText("OriginalText");
+
+        CD translationCD3 = new CD();
+        translationCD3.setCode("161586000");
+        translationCD3.setCodeSystem("2.16.840.1.113883.2.1.3.2.4.15");
+        translationCD3.setDisplayName("H/O: injury");
+
+        CD translationCD4 = new CD();
+        translationCD4.setCode("161586008");
+        translationCD4.setCodeSystem("2.16.840.1.113883.2.1.3.2.4.17");
+        translationCD4.setDisplayName("H/O: injury7");
+
+        c2.getTranslation().add(translationCD3);
+        c2.getTranslation().add(translationCD4);
+
+        assertFalse(CodeableConceptUtil.compareCodeableConcepts(c1, c2));
+    }
+
+    @Test
+    public void compareCodeableConceptsWithUniqualNumberOfTransactionPairs() {
+
+        CD c1 = new CD();
+        c1.setCode("Code1");
+        c1.setCodeSystem("CodeSystem1");
+        c1.setDisplayName("DisplayName1");
+        c1.setOriginalText("OriginalText");
+
+        CD translationCD1 = new CD();
+        translationCD1.setCode("161586000");
+        translationCD1.setCodeSystem("2.16.840.1.113883.2.1.3.2.4.15");
+        translationCD1.setDisplayName("H/O: injury");
+        c1.getTranslation().add(translationCD1);
+
+        CD translationCD2 = new CD();
+        translationCD2.setCode("161586007");
+        translationCD2.setCodeSystem("2.16.840.1.113883.2.1.3.2.4.17");
+        translationCD2.setDisplayName("H/O: injury7");
+        c1.getTranslation().add(translationCD2);
+
+        CD c2 = new CD();
+        c2.setCode("Code1");
+        c2.setCodeSystem("CodeSystem1");
+        c2.setDisplayName("DisplayName1");
+        c2.setOriginalText("OriginalText");
+
+        CD translationCD3 = new CD();
+        translationCD3.setCode("161586000");
+        translationCD3.setCodeSystem("2.16.840.1.113883.2.1.3.2.4.15");
+        translationCD3.setDisplayName("H/O: injury");
+
+        CD translationCD4 = new CD();
+        translationCD4.setCode("161586008");
+        translationCD4.setCodeSystem("2.16.840.1.113883.2.1.3.2.4.17");
+        translationCD4.setDisplayName("H/O: injury7");
+
+        CD translationCD5 = new CD();
+        translationCD5.setCode("161586009");
+        translationCD5.setCodeSystem("2.16.840.1.113883.2.1.3.2.4.19");
+        translationCD5.setDisplayName("H/O: injury9");
+
+        c2.getTranslation().add(translationCD2);
+        c2.getTranslation().add(translationCD3);
+        c2.getTranslation().add(translationCD5);
+
+        assertFalse(CodeableConceptUtil.compareCodeableConcepts(c1, c2));
+    }
+
+}


### PR DESCRIPTION
## What

Codeable concept comparison

## Why

Please include details of the reasoning for these changes

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Internal change (non-breaking change with no effect on the functionality affecting end users)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:

- [x] I have performed a self-review of my code
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I have updated the [Changelog](/CHANGELOG.md) with details of my change in the UNRELEASED section if this change will affect end users
- [ ] A corresponding change has been made to the [Mapping Documentation repository][mapping-docs]

[mapping-docs]: https://github.com/NHSDigital/patient-switching-adaptors-mapping-documentation