### PR TITLE
Remove the JUnit Platforms Commons dependency

### DIFF
--- a/gpc-api-facade/build.gradle
+++ b/gpc-api-facade/build.gradle
@@ -31,7 +31,6 @@ dependencies {
     testImplementation 'org.junit.jupiter:junit-jupiter-api:5.8.2'
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
     testImplementation 'org.junit.jupiter:junit-jupiter-params:5.8.2'
-    testImplementation 'org.junit.platform:junit-platform-commons:1.8.2'
     testImplementation 'org.assertj:assertj-core:3.25.1'
     testImplementation 'org.projectlombok:lombok'
     testImplementation 'org.mockito:mockito-inline:4.2.0'


### PR DESCRIPTION
## Why

We don't have any direct dependency on this package, so removing.

## Type of change

- [x] Internal change (non-breaking change with no effect on the functionality affecting end users)

## Checklist:

- [x] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] I have updated the [Changelog](/CHANGELOG.md) with details of my change in the UNRELEASED section if this change will affect end users
- [ ] A corresponding change has been made to the [Mapping Documentation repository][mapping-docs]

[mapping-docs]: https://github.com/NHSDigital/patient-switching-adaptors-mapping-documentation