### PR TITLE
Add util class to check / parse if a string is an OID

### DIFF
--- a/common/src/main/java/uk/nhs/adaptors/common/util/OidUtil.java
+++ b/common/src/main/java/uk/nhs/adaptors/common/util/OidUtil.java
@@ -1,0 +1,25 @@
+package uk.nhs.adaptors.common.util;
+
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
+import org.apache.commons.lang3.StringUtils;
+
+import java.util.Optional;
+
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+public class OidUtil {
+
+    private static final String URN_PREFIX = "urn:oid:";
+    public static Optional<String> tryParseToUrn(String value) {
+        if (isOid(value)) {
+            return Optional.of(URN_PREFIX + value);
+        }
+
+        return Optional.empty();
+    }
+
+    public static boolean isOid(String value) {
+        //regex taken from https://hl7.org/fhir/STU3/datatypes.html#oid
+        return !StringUtils.isBlank(value) && value.matches("[0-2](\\.[1-9]\\d*)+");
+    }
+}

--- a/gp2gp-translator/src/test/java/uk/nhs/adaptors/pss/translator/util/OidUtilTest.java
+++ b/gp2gp-translator/src/test/java/uk/nhs/adaptors/pss/translator/util/OidUtilTest.java
@@ -1,0 +1,48 @@
+package uk.nhs.adaptors.pss.translator.util;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.NullAndEmptySource;
+import org.junit.jupiter.params.provider.ValueSource;
+import uk.nhs.adaptors.common.util.OidUtil;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class OidUtilTest {
+    @ParameterizedTest
+    @ValueSource(strings = {"1.1", "1.2.3", "1.2.4.3", "0.1.2.3.4.5", "2.16.840.1.113883.2.1.4.5.5"})
+    public void When_IsOidIsPassedAValueWhichIsAnOID_Expect_True(String value) {
+        var actual = OidUtil.isOid(value);
+
+        assertThat(actual).isTrue();
+    }
+
+    @ParameterizedTest
+    @NullAndEmptySource
+    @ValueSource(strings = {"1", "1.0", "1-1", "1.a.3", "1.2.3.", "not-oid", "not.oid", "not an oid", "3.1.2.3"})
+    public void When_IsOidIsPassedAValueWhichIsNotAnOID_Expect_False(String value) {
+        var actual = OidUtil.isOid(value);
+
+        assertThat(actual).isFalse();
+    }
+
+    @Test
+    public void When_TryParseToUrnWithAnOid_Expect_OidIsReturnedAsUrn() {
+        final var oid = "2.16.840.1.113883.2.1.4.5.5";
+        final var expected = "urn:oid:" + oid;
+
+        final var actual = OidUtil.tryParseToUrn(oid);
+        assert actual.isPresent();
+
+        assertThat(actual.get()).isEqualTo(expected);
+    }
+
+    @Test
+    public void When_TryParseToUrnWithAnNonOid_Expect_ResultIsNotPresent() {
+        final var nonOid = "not.an.oid";
+
+        final var actual = OidUtil.tryParseToUrn(nonOid);
+
+        assertThat(actual).isNotPresent();
+    }
+}


### PR DESCRIPTION
## What

Add util class and associated tests to check / parse if a string is an OID

## Why

As part of [NIAD-2848](https://nhse-dsic.atlassian.net/browse/NIAD-2848) it is required to check and return an string value as a URN (ie: `"urn:oid:1.2.3.4.5"`) if it is a valid OID.  This util class is introduced to allow this check to be completed in multiple places

- A valid OID is determined to be a string of only numerical elements separated by `.`. 
- As an OID is used to represent a hierarchical structure, there could be any amount of elements each separated by `.`.
- An OID will not end in a `.`.
- An OID will start with the numerical value 0, 1 or 2.
- An OID will contain at least 2 elements.
- The second element will not be `0` if the OID only has two elements (ie: `1.0` is not valid, whereas `1.1` is)

```
An OID represented as a URI ([RFC 3001 ](http://www.ietf.org/rfc/rfc3001.txt)); 
e.g. urn:oid:1.2.3.4.5	
Regex: urn:oid:[0-2](\.[1-9]\d*)+
```

## Type of change

Please delete options that are not relevant.

- [x] Internal change (non-breaking change with no effect on the functionality affecting end users)

## Checklist:

- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes