### PR TITLE
Improve error for downloading non-existent file from LocalStorageService

### DIFF
--- a/gp2gp-translator/src/main/java/uk/nhs/adaptors/pss/translator/storage/LocalStorageService.java
+++ b/gp2gp-translator/src/main/java/uk/nhs/adaptors/pss/translator/storage/LocalStorageService.java
@@ -1,11 +1,7 @@
 package uk.nhs.adaptors.pss.translator.storage;
 
-import java.io.ByteArrayInputStream;
-import java.io.InputStream;
 import java.util.HashMap;
 import java.util.Map;
-
-import org.apache.commons.io.IOUtils;
 
 public class LocalStorageService implements StorageService {
 
@@ -25,12 +21,10 @@ public class LocalStorageService implements StorageService {
     }
 
     public byte[] downloadFile(String filename) throws StorageException {
-        try {
-            InputStream inputStream = downloadFileToStream(filename);
-            return IOUtils.toByteArray(inputStream);
-        } catch (Exception e) {
-            throw new StorageException("Error occurred downloading from Local Storage", e);
+        if (!storage.containsKey(filename)) {
+            throw new StorageException(String.format("Attempting to download file \"%s\" but does not exist.", filename), null);
         }
+        return storage.get(filename);
     }
 
     public void deleteFile(String filename) {
@@ -43,14 +37,5 @@ public class LocalStorageService implements StorageService {
 
     public String getFileLocation(String filename) {
         return filename;
-    }
-
-    private InputStream downloadFileToStream(String filename) throws StorageException {
-        try {
-            byte[] objectBytes = storage.get(filename);
-            return new ByteArrayInputStream(objectBytes);
-        } catch (Exception exception) {
-            throw new StorageException("Error occurred downloading from Local Storage", exception);
-        }
     }
 }


### PR DESCRIPTION
## Why

Flaky test errors are harder to interpret with the current error:
```
Caused by: java.lang.NullPointerException: Cannot read the array length because "buf" is null
```

## Type of change

- [x] Internal change (non-breaking change with no effect on the functionality affecting end users)

## Checklist:

- [x] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] I have updated the [Changelog](/CHANGELOG.md) with details of my change in the UNRELEASED section if this change will affect end users
- [ ] A corresponding change has been made to the [Mapping Documentation repository][mapping-docs]

[mapping-docs]: https://github.com/NHSDigital/patient-switching-adaptors-mapping-documentation