### PR TITLE
NIAD-2666: Battery Level Filing Comments should be referenced from DiagnosticReport

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -130,17 +130,17 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
   </details>
 
-* ** Breaking Change **: Observation comments of type `USER COMMENT` and `UNKNOWN TYPE`) located within the `BATTERY`
-  of a `Filed Report` are now additionally referenced in the results of the parent `DiagnosticReport`
+* When Filing comment `NarrativeStatements` are located within the `BATTERY` of a `Filed Report` and not located
+  at `DiagnosticReport` level now creates a new filing comment `Observation` and reference this in the results
+  of the parent `DiagnosticReport`.
 
 ## [2.0.0] - 2024-04-12
 
 ### Fixed
+
 * **Breaking Change** Identifier values and code systems where an OID is provided 
-(such as `2.16.840.1.113883.2.1.6.9`) will now be provided as a URN (i.e. `urn:oid:2.16.840.1.113883.2.1.6.9`),
-as per GP Connect specification.
-* DiagnosticReport identifier values are now presented as a URN instead of just the system code
-  when a PMIP system code is provided
+  (such as `2.16.840.1.113883.2.1.6.9`) will now be provided as a URN (i.e. `urn:oid:2.16.840.1.113883.2.1.6.9`),
+  as per GP Connect specification.
 
 ## [1.4.7] - 2024-04-02
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -130,6 +130,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
   </details>
 
+* ** Breaking Change **: Observation comments of type `USER COMMENT` and `UNKNOWN TYPE`) located within the `BATTERY`
+  of a `Filed Report` are now additionally referenced in the results of the parent `DiagnosticReport`
+
 ## [2.0.0] - 2024-04-12
 
 ### Fixed

--- a/gp2gp-translator/src/integrationTest/resources/e2e-mapping/output-json/PWTP9-output.json
+++ b/gp2gp-translator/src/integrationTest/resources/e2e-mapping/output-json/PWTP9-output.json
@@ -3830,7 +3830,7 @@
         "system": "http://unitsofmeasure.org",
         "code": "1"
       },
-      "comment": "                                                                                    DVT Prophylaxis - INR 2.0-2.5                                                                                    Treatment of DVT,PE,AF,TIA - INR 2.0-3.0                                                                                    Recurrent DVT or PE                )                                                                                    Arterial Disease                   )INR 3.0-4.5                                                                                    Mechanical Prosthetic Heart Valves )",
+      "comment": "                                                                                    DVT Prophylaxis - INR 2.0-2.5\n                                                                                    Treatment of DVT,PE,AF,TIA - INR 2.0-3.0\n                                                                                    Recurrent DVT or PE                )\n                                                                                    Arterial Disease                   )INR 3.0-4.5\n                                                                                    Mechanical Prosthetic Heart Valves )",
       "specimen": {
         "reference": "Specimen/971752A8-2F1C-478B-94D6-E6B535F534AC"
       }
@@ -4161,7 +4161,7 @@
         } ],
         "text": "Potentially abnormal"
       },
-      "comment": "                                                                                            Oral dose: 75g anhydrous glucose given as                                                                                            113ml Polycal liquid                                                                                            Plasma Glucose           Urine Results                                                                                            Time        (mmol/l)         Ketones         Glucose",
+      "comment": "                                                                                            Oral dose: 75g anhydrous glucose given as\n                                                                                            113ml Polycal liquid\n                                                                                            Plasma Glucose           Urine Results\n                                                                                            Time        (mmol/l)         Ketones         Glucose",
       "specimen": {
         "reference": "Specimen/A8A66BB2-3392-4A7C-BA19-6DD9D61A0C22"
       },
@@ -4222,7 +4222,7 @@
         } ],
         "text": "Potentially abnormal"
       },
-      "comment": "                                                                                            Fasting       4.3            negative        negative                                                                                            2 hours       7.6            negative        negative                                                                                            NORMAL              : Fasting up to 6.0 & 2 hr up to 7.7                                                                                            IMPAIRED FASTING    : Fasting 6.1-6.9 & 2 hr up to 7.7",
+      "comment": "                                                                                            Fasting       4.3            negative        negative\n                                                                                            2 hours       7.6            negative        negative\n                                                                                            NORMAL              : Fasting up to 6.0 & 2 hr up to 7.7\n                                                                                            IMPAIRED FASTING    : Fasting 6.1-6.9 & 2 hr up to 7.7",
       "specimen": {
         "reference": "Specimen/A8A66BB2-3392-4A7C-BA19-6DD9D61A0C22"
       },
@@ -4283,7 +4283,7 @@
         } ],
         "text": "Potentially abnormal"
       },
-      "comment": "                                                                                            GLYCAEMIA                                                                                            IMPAIRED GLUCOSE    : Fasting up to 6.9 & 2 hr 7.8-11.0                                                                                            TOLERANCE                                                                                            *DIABETES MELLITUS  : Fasting 7.0 or above &/or",
+      "comment": "                                                                                            GLYCAEMIA\n                                                                                            IMPAIRED GLUCOSE    : Fasting up to 6.9 & 2 hr 7.8-11.0\n                                                                                            TOLERANCE\n                                                                                            *DIABETES MELLITUS  : Fasting 7.0 or above &/or",
       "specimen": {
         "reference": "Specimen/A8A66BB2-3392-4A7C-BA19-6DD9D61A0C22"
       },
@@ -4344,7 +4344,7 @@
         } ],
         "text": "Potentially abnormal"
       },
-      "comment": "                                                                                            2 hr 11.1 or above                                                                                            *(must also have symptoms - polyuria, polydipsia,                                                                                            unexplained weight loss)",
+      "comment": "                                                                                            2 hr 11.1 or above\n                                                                                            *(must also have symptoms - polyuria, polydipsia,\n                                                                                            unexplained weight loss)",
       "specimen": {
         "reference": "Specimen/A8A66BB2-3392-4A7C-BA19-6DD9D61A0C22"
       },
@@ -4405,7 +4405,7 @@
         } ],
         "text": "Potentially abnormal"
       },
-      "comment": "                                                                                            Oral dose: 75g anhydrous glucose given as                                                                                            113ml Polycal liquid                                                                                            Plasma Glucose           Urine Results                                                                                            Time        (mmol/l)         Ketones         Glucose",
+      "comment": "                                                                                            Oral dose: 75g anhydrous glucose given as\n                                                                                            113ml Polycal liquid\n                                                                                            Plasma Glucose           Urine Results\n                                                                                            Time        (mmol/l)         Ketones         Glucose",
       "specimen": {
         "reference": "Specimen/89E2E801-4D16-4023-8EBA-BE076D479B67"
       },
@@ -4466,7 +4466,7 @@
         } ],
         "text": "Potentially abnormal"
       },
-      "comment": "                                                                                            Fasting       4.3            negative        negative                                                                                            2 hours       7.6            negative        negative                                                                                            NORMAL              : Fasting up to 6.0 & 2 hr up to 7.7                                                                                            IMPAIRED FASTING    : Fasting 6.1-6.9 & 2 hr up to 7.7",
+      "comment": "                                                                                            Fasting       4.3            negative        negative\n                                                                                            2 hours       7.6            negative        negative\n                                                                                            NORMAL              : Fasting up to 6.0 & 2 hr up to 7.7\n                                                                                            IMPAIRED FASTING    : Fasting 6.1-6.9 & 2 hr up to 7.7",
       "specimen": {
         "reference": "Specimen/89E2E801-4D16-4023-8EBA-BE076D479B67"
       },
@@ -4527,7 +4527,7 @@
         } ],
         "text": "Potentially abnormal"
       },
-      "comment": "                                                                                            GLYCAEMIA                                                                                            IMPAIRED GLUCOSE    : Fasting up to 6.9 & 2 hr 7.8-11.0                                                                                            TOLERANCE                                                                                            *DIABETES MELLITUS  : Fasting 7.0 or above &/or",
+      "comment": "                                                                                            GLYCAEMIA\n                                                                                            IMPAIRED GLUCOSE    : Fasting up to 6.9 & 2 hr 7.8-11.0\n                                                                                            TOLERANCE\n                                                                                            *DIABETES MELLITUS  : Fasting 7.0 or above &/or",
       "specimen": {
         "reference": "Specimen/89E2E801-4D16-4023-8EBA-BE076D479B67"
       },
@@ -4588,7 +4588,7 @@
         } ],
         "text": "Potentially abnormal"
       },
-      "comment": "                                                                                            2 hr 11.1 or above                                                                                            *(must also have symptoms - polyuria, polydipsia,                                                                                            unexplained weight loss)",
+      "comment": "                                                                                            2 hr 11.1 or above\n                                                                                            *(must also have symptoms - polyuria, polydipsia,\n                                                                                            unexplained weight loss)",
       "specimen": {
         "reference": "Specimen/89E2E801-4D16-4023-8EBA-BE076D479B67"
       },
@@ -4649,7 +4649,7 @@
         } ],
         "text": "Potentially abnormal"
       },
-      "comment": "                                                                                            Oral dose: 75g anhydrous glucose given as                                                                                            113ml Polycal liquid                                                                                            Plasma Glucose           Urine Results                                                                                            Time        (mmol/l)         Ketones         Glucose",
+      "comment": "                                                                                            Oral dose: 75g anhydrous glucose given as\n                                                                                            113ml Polycal liquid\n                                                                                            Plasma Glucose           Urine Results\n                                                                                            Time        (mmol/l)         Ketones         Glucose",
       "specimen": {
         "reference": "Specimen/E5CE0B1B-E29B-4823-B29D-2B75B0DC0356"
       },
@@ -4710,7 +4710,7 @@
         } ],
         "text": "Potentially abnormal"
       },
-      "comment": "                                                                                            Fasting       4.3            negative        negative                                                                                            2 hours       7.6            negative        negative                                                                                            NORMAL              : Fasting up to 6.0 & 2 hr up to 7.7                                                                                            IMPAIRED FASTING    : Fasting 6.1-6.9 & 2 hr up to 7.7",
+      "comment": "                                                                                            Fasting       4.3            negative        negative\n                                                                                            2 hours       7.6            negative        negative\n                                                                                            NORMAL              : Fasting up to 6.0 & 2 hr up to 7.7\n                                                                                            IMPAIRED FASTING    : Fasting 6.1-6.9 & 2 hr up to 7.7",
       "specimen": {
         "reference": "Specimen/E5CE0B1B-E29B-4823-B29D-2B75B0DC0356"
       },
@@ -4771,7 +4771,7 @@
         } ],
         "text": "Potentially abnormal"
       },
-      "comment": "                                                                                            GLYCAEMIA                                                                                            IMPAIRED GLUCOSE    : Fasting up to 6.9 & 2 hr 7.8-11.0                                                                                            TOLERANCE                                                                                            *DIABETES MELLITUS  : Fasting 7.0 or above &/or",
+      "comment": "                                                                                            GLYCAEMIA\n                                                                                            IMPAIRED GLUCOSE    : Fasting up to 6.9 & 2 hr 7.8-11.0\n                                                                                            TOLERANCE\n                                                                                            *DIABETES MELLITUS  : Fasting 7.0 or above &/or",
       "specimen": {
         "reference": "Specimen/E5CE0B1B-E29B-4823-B29D-2B75B0DC0356"
       },
@@ -4832,7 +4832,7 @@
         } ],
         "text": "Potentially abnormal"
       },
-      "comment": "                                                                                            2 hr 11.1 or above                                                                                            *(must also have symptoms - polyuria, polydipsia,                                                                                            unexplained weight loss)",
+      "comment": "                                                                                            2 hr 11.1 or above\n                                                                                            *(must also have symptoms - polyuria, polydipsia,\n                                                                                            unexplained weight loss)",
       "specimen": {
         "reference": "Specimen/E5CE0B1B-E29B-4823-B29D-2B75B0DC0356"
       },
@@ -5341,7 +5341,7 @@
         } ],
         "text": "Above high reference limit"
       },
-      "comment": "                                                                                            Cholesterol 6.5 - 7.8 Moderate Risk of CHD                                                                                            Cholesterol     > 7.8 Marked Risk of CHD",
+      "comment": "                                                                                            Cholesterol 6.5 - 7.8 Moderate Risk of CHD\n                                                                                            Cholesterol     > 7.8 Marked Risk of CHD",
       "specimen": {
         "reference": "Specimen/DBF83E10-237E-427C-A0B0-F43957A1276F"
       },
@@ -6938,7 +6938,7 @@
       "performer": [ {
         "reference": "Practitioner/1E473786-E7FA-785E-C911-A8D38FB56F20"
       } ],
-      "comment": "                                                                                            U=Unsuitable for analysis                                                                                            U=Unsuitable,due to delay in delivery.",
+      "comment": "                                                                                            U=Unsuitable for analysis\n                                                                                            U=Unsuitable,due to delay in delivery.",
       "specimen": {
         "reference": "Specimen/0DB91FFF-DC9C-4246-A8D0-A3D340A2D822"
       },
@@ -9070,7 +9070,7 @@
         } ],
         "text": "Potentially abnormal"
       },
-      "comment": "                                                                                    Negative                                                                                    I.M.Screen",
+      "comment": "                                                                                    Negative\n                                                                                    I.M.Screen",
       "specimen": {
         "reference": "Specimen/7D57ADE4-B274-44FE-91A2-7E794CB5DA42"
       }
@@ -9124,7 +9124,7 @@
       "performer": [ {
         "reference": "Practitioner/1E473786-E7FA-785E-C911-A8D38FB56F20"
       } ],
-      "comment": "                                                                                    WBC MORPHOLOGY NORMAL                                                                                    RBC MORPHOLOGY NORMAL",
+      "comment": "                                                                                    WBC MORPHOLOGY NORMAL\n                                                                                    RBC MORPHOLOGY NORMAL",
       "specimen": {
         "reference": "Specimen/7D57ADE4-B274-44FE-91A2-7E794CB5DA42"
       }
@@ -13744,7 +13744,7 @@
       }, {
         "reference": "Observation/CDC2077F-F701-47F9-AFF9-87E8C07E8C69"
       } ],
-      "conclusion": "                                                                    Clinical Details:                                                                    NOTE:Specimen date"
+      "conclusion": "                                                                    Clinical Details:\n                                                                    NOTE:Specimen date"
     }
   }, {
     "resource": {
@@ -14338,7 +14338,7 @@
         "collectedDateTime": "2003-06-02"
       },
       "note": [ {
-        "text": "                                                                            Another                                                                            Specimen                                                                            Comment"
+        "text": "                                                                            Another\n                                                                            Specimen\n                                                                            Comment"
       } ]
     }
   }, {
@@ -15343,7 +15343,7 @@
       "performer": [ {
         "reference": "Practitioner/C5DEFBF3-0174-BC6F-182C-B777B9C6FF43"
       } ],
-      "comment": "                                                                                    NB NEW WHO/DIABETES UK CLASSIFICATION CRITERIA FROM 01.06.00                                                                                    Dr. N.O'Connell",
+      "comment": "                                                                                    NB NEW WHO/DIABETES UK CLASSIFICATION CRITERIA FROM 01.06.00\n                                                                                    Dr. N.O'Connell",
       "specimen": {
         "reference": "Specimen/A8A66BB2-3392-4A7C-BA19-6DD9D61A0C22"
       },
@@ -15421,7 +15421,7 @@
       "performer": [ {
         "reference": "Practitioner/C5DEFBF3-0174-BC6F-182C-B777B9C6FF43"
       } ],
-      "comment": "                                                                                    NB NEW WHO/DIABETES UK CLASSIFICATION CRITERIA FROM 01.06.00                                                                                    Dr. N.O'Connell",
+      "comment": "                                                                                    NB NEW WHO/DIABETES UK CLASSIFICATION CRITERIA FROM 01.06.00\n                                                                                    Dr. N.O'Connell",
       "specimen": {
         "reference": "Specimen/89E2E801-4D16-4023-8EBA-BE076D479B67"
       },
@@ -15499,7 +15499,7 @@
       "performer": [ {
         "reference": "Practitioner/C5DEFBF3-0174-BC6F-182C-B777B9C6FF43"
       } ],
-      "comment": "                                                                                    NB NEW WHO/DIABETES UK CLASSIFICATION CRITERIA FROM 01.06.00                                                                                    Dr. N.O'Connell",
+      "comment": "                                                                                    NB NEW WHO/DIABETES UK CLASSIFICATION CRITERIA FROM 01.06.00\n                                                                                    Dr. N.O'Connell",
       "specimen": {
         "reference": "Specimen/E5CE0B1B-E29B-4823-B29D-2B75B0DC0356"
       },
@@ -16226,7 +16226,7 @@
       "performer": [ {
         "reference": "Practitioner/C5DEFBF3-0174-BC6F-182C-B777B9C6FF43"
       } ],
-      "comment": "                                                                                    These LTG comments only apply to the Anti-nuclear factor and the                                                                                    rheumatoid factor tests.",
+      "comment": "                                                                                    These LTG comments only apply to the Anti-nuclear factor and the\n                                                                                    rheumatoid factor tests.",
       "specimen": {
         "reference": "Specimen/EC494B1A-FFEF-41E2-94AB-B287AE516361"
       },

--- a/gp2gp-translator/src/integrationTest/resources/e2e-mapping/output-json/PWTP9-output.json
+++ b/gp2gp-translator/src/integrationTest/resources/e2e-mapping/output-json/PWTP9-output.json
@@ -3830,7 +3830,7 @@
         "system": "http://unitsofmeasure.org",
         "code": "1"
       },
-      "comment": "                                                                                    DVT Prophylaxis - INR 2.0-2.5                                                                                    Treatment of DVT,PE,AF,TIA - INR 2.0-3.0                                                                                    Recurrent DVT or PE                )                                                                                    Arterial Disease                   )INR 3.0-4.5                                                                                    Mechanical Prosthetic Heart Valves )",
+      "comment": "                                                                                    DVT Prophylaxis - INR 2.0-2.5\n                                                                                    Treatment of DVT,PE,AF,TIA - INR 2.0-3.0\n                                                                                    Recurrent DVT or PE                )\n                                                                                    Arterial Disease                   )INR 3.0-4.5\n                                                                                    Mechanical Prosthetic Heart Valves )",
       "specimen": {
         "reference": "Specimen/971752A8-2F1C-478B-94D6-E6B535F534AC"
       }
@@ -4161,7 +4161,7 @@
         } ],
         "text": "Potentially abnormal"
       },
-      "comment": "                                                                                            Oral dose: 75g anhydrous glucose given as                                                                                            113ml Polycal liquid                                                                                            Plasma Glucose           Urine Results                                                                                            Time        (mmol/l)         Ketones         Glucose",
+      "comment": "                                                                                            Oral dose: 75g anhydrous glucose given as\n                                                                                            113ml Polycal liquid\n                                                                                            Plasma Glucose           Urine Results\n                                                                                            Time        (mmol/l)         Ketones         Glucose",
       "specimen": {
         "reference": "Specimen/A8A66BB2-3392-4A7C-BA19-6DD9D61A0C22"
       },
@@ -4222,7 +4222,7 @@
         } ],
         "text": "Potentially abnormal"
       },
-      "comment": "                                                                                            Fasting       4.3            negative        negative                                                                                            2 hours       7.6            negative        negative                                                                                            NORMAL              : Fasting up to 6.0 & 2 hr up to 7.7                                                                                            IMPAIRED FASTING    : Fasting 6.1-6.9 & 2 hr up to 7.7",
+      "comment": "                                                                                            Fasting       4.3            negative        negative\n                                                                                            2 hours       7.6            negative        negative\n                                                                                            NORMAL              : Fasting up to 6.0 & 2 hr up to 7.7\n                                                                                            IMPAIRED FASTING    : Fasting 6.1-6.9 & 2 hr up to 7.7",
       "specimen": {
         "reference": "Specimen/A8A66BB2-3392-4A7C-BA19-6DD9D61A0C22"
       },
@@ -4283,7 +4283,7 @@
         } ],
         "text": "Potentially abnormal"
       },
-      "comment": "                                                                                            GLYCAEMIA                                                                                            IMPAIRED GLUCOSE    : Fasting up to 6.9 & 2 hr 7.8-11.0                                                                                            TOLERANCE                                                                                            *DIABETES MELLITUS  : Fasting 7.0 or above &/or",
+      "comment": "                                                                                            GLYCAEMIA\n                                                                                            IMPAIRED GLUCOSE    : Fasting up to 6.9 & 2 hr 7.8-11.0\n                                                                                            TOLERANCE\n                                                                                            *DIABETES MELLITUS  : Fasting 7.0 or above &/or",
       "specimen": {
         "reference": "Specimen/A8A66BB2-3392-4A7C-BA19-6DD9D61A0C22"
       },
@@ -4344,7 +4344,7 @@
         } ],
         "text": "Potentially abnormal"
       },
-      "comment": "                                                                                            2 hr 11.1 or above                                                                                            *(must also have symptoms - polyuria, polydipsia,                                                                                            unexplained weight loss)",
+      "comment": "                                                                                            2 hr 11.1 or above\n                                                                                            *(must also have symptoms - polyuria, polydipsia,\n                                                                                            unexplained weight loss)",
       "specimen": {
         "reference": "Specimen/A8A66BB2-3392-4A7C-BA19-6DD9D61A0C22"
       },
@@ -4405,7 +4405,7 @@
         } ],
         "text": "Potentially abnormal"
       },
-      "comment": "                                                                                            Oral dose: 75g anhydrous glucose given as                                                                                            113ml Polycal liquid                                                                                            Plasma Glucose           Urine Results                                                                                            Time        (mmol/l)         Ketones         Glucose",
+      "comment": "                                                                                            Oral dose: 75g anhydrous glucose given as\n                                                                                            113ml Polycal liquid\n                                                                                            Plasma Glucose           Urine Results\n                                                                                            Time        (mmol/l)         Ketones         Glucose",
       "specimen": {
         "reference": "Specimen/89E2E801-4D16-4023-8EBA-BE076D479B67"
       },
@@ -4466,7 +4466,7 @@
         } ],
         "text": "Potentially abnormal"
       },
-      "comment": "                                                                                            Fasting       4.3            negative        negative                                                                                            2 hours       7.6            negative        negative                                                                                            NORMAL              : Fasting up to 6.0 & 2 hr up to 7.7                                                                                            IMPAIRED FASTING    : Fasting 6.1-6.9 & 2 hr up to 7.7",
+      "comment": "                                                                                            Fasting       4.3            negative        negative\n                                                                                            2 hours       7.6            negative        negative\n                                                                                            NORMAL              : Fasting up to 6.0 & 2 hr up to 7.7\n                                                                                            IMPAIRED FASTING    : Fasting 6.1-6.9 & 2 hr up to 7.7",
       "specimen": {
         "reference": "Specimen/89E2E801-4D16-4023-8EBA-BE076D479B67"
       },
@@ -4527,7 +4527,7 @@
         } ],
         "text": "Potentially abnormal"
       },
-      "comment": "                                                                                            GLYCAEMIA                                                                                            IMPAIRED GLUCOSE    : Fasting up to 6.9 & 2 hr 7.8-11.0                                                                                            TOLERANCE                                                                                            *DIABETES MELLITUS  : Fasting 7.0 or above &/or",
+      "comment": "                                                                                            GLYCAEMIA\n                                                                                            IMPAIRED GLUCOSE    : Fasting up to 6.9 & 2 hr 7.8-11.0\n                                                                                            TOLERANCE\n                                                                                            *DIABETES MELLITUS  : Fasting 7.0 or above &/or",
       "specimen": {
         "reference": "Specimen/89E2E801-4D16-4023-8EBA-BE076D479B67"
       },
@@ -4588,7 +4588,7 @@
         } ],
         "text": "Potentially abnormal"
       },
-      "comment": "                                                                                            2 hr 11.1 or above                                                                                            *(must also have symptoms - polyuria, polydipsia,                                                                                            unexplained weight loss)",
+      "comment": "                                                                                            2 hr 11.1 or above\n                                                                                            *(must also have symptoms - polyuria, polydipsia,\n                                                                                            unexplained weight loss)",
       "specimen": {
         "reference": "Specimen/89E2E801-4D16-4023-8EBA-BE076D479B67"
       },
@@ -4649,7 +4649,7 @@
         } ],
         "text": "Potentially abnormal"
       },
-      "comment": "                                                                                            Oral dose: 75g anhydrous glucose given as                                                                                            113ml Polycal liquid                                                                                            Plasma Glucose           Urine Results                                                                                            Time        (mmol/l)         Ketones         Glucose",
+      "comment": "                                                                                            Oral dose: 75g anhydrous glucose given as\n                                                                                            113ml Polycal liquid\n                                                                                            Plasma Glucose           Urine Results\n                                                                                            Time        (mmol/l)         Ketones         Glucose",
       "specimen": {
         "reference": "Specimen/E5CE0B1B-E29B-4823-B29D-2B75B0DC0356"
       },
@@ -4710,7 +4710,7 @@
         } ],
         "text": "Potentially abnormal"
       },
-      "comment": "                                                                                            Fasting       4.3            negative        negative                                                                                            2 hours       7.6            negative        negative                                                                                            NORMAL              : Fasting up to 6.0 & 2 hr up to 7.7                                                                                            IMPAIRED FASTING    : Fasting 6.1-6.9 & 2 hr up to 7.7",
+      "comment": "                                                                                            Fasting       4.3            negative        negative\n                                                                                            2 hours       7.6            negative        negative\n                                                                                            NORMAL              : Fasting up to 6.0 & 2 hr up to 7.7\n                                                                                            IMPAIRED FASTING    : Fasting 6.1-6.9 & 2 hr up to 7.7",
       "specimen": {
         "reference": "Specimen/E5CE0B1B-E29B-4823-B29D-2B75B0DC0356"
       },
@@ -4771,7 +4771,7 @@
         } ],
         "text": "Potentially abnormal"
       },
-      "comment": "                                                                                            GLYCAEMIA                                                                                            IMPAIRED GLUCOSE    : Fasting up to 6.9 & 2 hr 7.8-11.0                                                                                            TOLERANCE                                                                                            *DIABETES MELLITUS  : Fasting 7.0 or above &/or",
+      "comment": "                                                                                            GLYCAEMIA\n                                                                                            IMPAIRED GLUCOSE    : Fasting up to 6.9 & 2 hr 7.8-11.0\n                                                                                            TOLERANCE\n                                                                                            *DIABETES MELLITUS  : Fasting 7.0 or above &/or",
       "specimen": {
         "reference": "Specimen/E5CE0B1B-E29B-4823-B29D-2B75B0DC0356"
       },
@@ -4832,7 +4832,7 @@
         } ],
         "text": "Potentially abnormal"
       },
-      "comment": "                                                                                            2 hr 11.1 or above                                                                                            *(must also have symptoms - polyuria, polydipsia,                                                                                            unexplained weight loss)",
+      "comment": "                                                                                            2 hr 11.1 or above\n                                                                                            *(must also have symptoms - polyuria, polydipsia,\n                                                                                            unexplained weight loss)",
       "specimen": {
         "reference": "Specimen/E5CE0B1B-E29B-4823-B29D-2B75B0DC0356"
       },
@@ -5341,7 +5341,7 @@
         } ],
         "text": "Above high reference limit"
       },
-      "comment": "                                                                                            Cholesterol 6.5 - 7.8 Moderate Risk of CHD                                                                                            Cholesterol     > 7.8 Marked Risk of CHD",
+      "comment": "                                                                                            Cholesterol 6.5 - 7.8 Moderate Risk of CHD\n                                                                                            Cholesterol     > 7.8 Marked Risk of CHD",
       "specimen": {
         "reference": "Specimen/DBF83E10-237E-427C-A0B0-F43957A1276F"
       },
@@ -6938,7 +6938,7 @@
       "performer": [ {
         "reference": "Practitioner/1E473786-E7FA-785E-C911-A8D38FB56F20"
       } ],
-      "comment": "                                                                                            U=Unsuitable for analysis                                                                                            U=Unsuitable,due to delay in delivery.",
+      "comment": "                                                                                            U=Unsuitable for analysis\n                                                                                            U=Unsuitable,due to delay in delivery.",
       "specimen": {
         "reference": "Specimen/0DB91FFF-DC9C-4246-A8D0-A3D340A2D822"
       },
@@ -9070,7 +9070,7 @@
         } ],
         "text": "Potentially abnormal"
       },
-      "comment": "                                                                                    Negative                                                                                    I.M.Screen",
+      "comment": "                                                                                    Negative\n                                                                                    I.M.Screen",
       "specimen": {
         "reference": "Specimen/7D57ADE4-B274-44FE-91A2-7E794CB5DA42"
       }
@@ -9124,7 +9124,7 @@
       "performer": [ {
         "reference": "Practitioner/1E473786-E7FA-785E-C911-A8D38FB56F20"
       } ],
-      "comment": "                                                                                    WBC MORPHOLOGY NORMAL                                                                                    RBC MORPHOLOGY NORMAL",
+      "comment": "                                                                                    WBC MORPHOLOGY NORMAL\n                                                                                    RBC MORPHOLOGY NORMAL",
       "specimen": {
         "reference": "Specimen/7D57ADE4-B274-44FE-91A2-7E794CB5DA42"
       }
@@ -13746,7 +13746,7 @@
       }, {
         "reference": "Observation/CDC2077F-F701-47F9-AFF9-87E8C07E8C69"
       } ],
-      "conclusion": "                                                                    Clinical Details:                                                                    NOTE:Specimen date"
+      "conclusion": "                                                                    Clinical Details:\n                                                                    NOTE:Specimen date"
     }
   }, {
     "resource": {
@@ -14340,7 +14340,7 @@
         "collectedDateTime": "2003-06-02"
       },
       "note": [ {
-        "text": "                                                                            Another                                                                            Specimen                                                                            Comment"
+        "text": "                                                                            Another\n                                                                            Specimen\n                                                                            Comment"
       } ]
     }
   }, {
@@ -15221,7 +15221,7 @@
       "performer": [ {
         "reference": "Practitioner/C5DEFBF3-0174-BC6F-182C-B777B9C6FF43"
       } ],
-      "comment": "                                                                                    NB NEW WHO/DIABETES UK CLASSIFICATION CRITERIA FROM 01.06.00                                                                                    Dr. N.O'Connell",
+      "comment": "                                                                                    NB NEW WHO/DIABETES UK CLASSIFICATION CRITERIA FROM 01.06.00\n                                                                                    Dr. N.O'Connell",
       "specimen": {
         "reference": "Specimen/A8A66BB2-3392-4A7C-BA19-6DD9D61A0C22"
       },
@@ -15299,7 +15299,7 @@
       "performer": [ {
         "reference": "Practitioner/C5DEFBF3-0174-BC6F-182C-B777B9C6FF43"
       } ],
-      "comment": "                                                                                    NB NEW WHO/DIABETES UK CLASSIFICATION CRITERIA FROM 01.06.00                                                                                    Dr. N.O'Connell",
+      "comment": "                                                                                    NB NEW WHO/DIABETES UK CLASSIFICATION CRITERIA FROM 01.06.00\n                                                                                    Dr. N.O'Connell",
       "specimen": {
         "reference": "Specimen/89E2E801-4D16-4023-8EBA-BE076D479B67"
       },
@@ -15377,7 +15377,7 @@
       "performer": [ {
         "reference": "Practitioner/C5DEFBF3-0174-BC6F-182C-B777B9C6FF43"
       } ],
-      "comment": "                                                                                    NB NEW WHO/DIABETES UK CLASSIFICATION CRITERIA FROM 01.06.00                                                                                    Dr. N.O'Connell",
+      "comment": "                                                                                    NB NEW WHO/DIABETES UK CLASSIFICATION CRITERIA FROM 01.06.00\n                                                                                    Dr. N.O'Connell",
       "specimen": {
         "reference": "Specimen/E5CE0B1B-E29B-4823-B29D-2B75B0DC0356"
       },
@@ -16104,7 +16104,7 @@
       "performer": [ {
         "reference": "Practitioner/C5DEFBF3-0174-BC6F-182C-B777B9C6FF43"
       } ],
-      "comment": "                                                                                    These LTG comments only apply to the Anti-nuclear factor and the                                                                                    rheumatoid factor tests.",
+      "comment": "                                                                                    These LTG comments only apply to the Anti-nuclear factor and the\n                                                                                    rheumatoid factor tests.",
       "specimen": {
         "reference": "Specimen/EC494B1A-FFEF-41E2-94AB-B287AE516361"
       },

--- a/gp2gp-translator/src/integrationTest/resources/e2e-mapping/output-json/PWTP9-output.json
+++ b/gp2gp-translator/src/integrationTest/resources/e2e-mapping/output-json/PWTP9-output.json
@@ -3830,7 +3830,7 @@
         "system": "http://unitsofmeasure.org",
         "code": "1"
       },
-      "comment": "                                                                                    DVT Prophylaxis - INR 2.0-2.5\n                                                                                    Treatment of DVT,PE,AF,TIA - INR 2.0-3.0\n                                                                                    Recurrent DVT or PE                )\n                                                                                    Arterial Disease                   )INR 3.0-4.5\n                                                                                    Mechanical Prosthetic Heart Valves )",
+      "comment": "                                                                                    DVT Prophylaxis - INR 2.0-2.5                                                                                    Treatment of DVT,PE,AF,TIA - INR 2.0-3.0                                                                                    Recurrent DVT or PE                )                                                                                    Arterial Disease                   )INR 3.0-4.5                                                                                    Mechanical Prosthetic Heart Valves )",
       "specimen": {
         "reference": "Specimen/971752A8-2F1C-478B-94D6-E6B535F534AC"
       }
@@ -4161,7 +4161,7 @@
         } ],
         "text": "Potentially abnormal"
       },
-      "comment": "                                                                                            Oral dose: 75g anhydrous glucose given as\n                                                                                            113ml Polycal liquid\n                                                                                            Plasma Glucose           Urine Results\n                                                                                            Time        (mmol/l)         Ketones         Glucose",
+      "comment": "                                                                                            Oral dose: 75g anhydrous glucose given as                                                                                            113ml Polycal liquid                                                                                            Plasma Glucose           Urine Results                                                                                            Time        (mmol/l)         Ketones         Glucose",
       "specimen": {
         "reference": "Specimen/A8A66BB2-3392-4A7C-BA19-6DD9D61A0C22"
       },
@@ -4222,7 +4222,7 @@
         } ],
         "text": "Potentially abnormal"
       },
-      "comment": "                                                                                            Fasting       4.3            negative        negative\n                                                                                            2 hours       7.6            negative        negative\n                                                                                            NORMAL              : Fasting up to 6.0 & 2 hr up to 7.7\n                                                                                            IMPAIRED FASTING    : Fasting 6.1-6.9 & 2 hr up to 7.7",
+      "comment": "                                                                                            Fasting       4.3            negative        negative                                                                                            2 hours       7.6            negative        negative                                                                                            NORMAL              : Fasting up to 6.0 & 2 hr up to 7.7                                                                                            IMPAIRED FASTING    : Fasting 6.1-6.9 & 2 hr up to 7.7",
       "specimen": {
         "reference": "Specimen/A8A66BB2-3392-4A7C-BA19-6DD9D61A0C22"
       },
@@ -4283,7 +4283,7 @@
         } ],
         "text": "Potentially abnormal"
       },
-      "comment": "                                                                                            GLYCAEMIA\n                                                                                            IMPAIRED GLUCOSE    : Fasting up to 6.9 & 2 hr 7.8-11.0\n                                                                                            TOLERANCE\n                                                                                            *DIABETES MELLITUS  : Fasting 7.0 or above &/or",
+      "comment": "                                                                                            GLYCAEMIA                                                                                            IMPAIRED GLUCOSE    : Fasting up to 6.9 & 2 hr 7.8-11.0                                                                                            TOLERANCE                                                                                            *DIABETES MELLITUS  : Fasting 7.0 or above &/or",
       "specimen": {
         "reference": "Specimen/A8A66BB2-3392-4A7C-BA19-6DD9D61A0C22"
       },
@@ -4344,7 +4344,7 @@
         } ],
         "text": "Potentially abnormal"
       },
-      "comment": "                                                                                            2 hr 11.1 or above\n                                                                                            *(must also have symptoms - polyuria, polydipsia,\n                                                                                            unexplained weight loss)",
+      "comment": "                                                                                            2 hr 11.1 or above                                                                                            *(must also have symptoms - polyuria, polydipsia,                                                                                            unexplained weight loss)",
       "specimen": {
         "reference": "Specimen/A8A66BB2-3392-4A7C-BA19-6DD9D61A0C22"
       },
@@ -4405,7 +4405,7 @@
         } ],
         "text": "Potentially abnormal"
       },
-      "comment": "                                                                                            Oral dose: 75g anhydrous glucose given as\n                                                                                            113ml Polycal liquid\n                                                                                            Plasma Glucose           Urine Results\n                                                                                            Time        (mmol/l)         Ketones         Glucose",
+      "comment": "                                                                                            Oral dose: 75g anhydrous glucose given as                                                                                            113ml Polycal liquid                                                                                            Plasma Glucose           Urine Results                                                                                            Time        (mmol/l)         Ketones         Glucose",
       "specimen": {
         "reference": "Specimen/89E2E801-4D16-4023-8EBA-BE076D479B67"
       },
@@ -4466,7 +4466,7 @@
         } ],
         "text": "Potentially abnormal"
       },
-      "comment": "                                                                                            Fasting       4.3            negative        negative\n                                                                                            2 hours       7.6            negative        negative\n                                                                                            NORMAL              : Fasting up to 6.0 & 2 hr up to 7.7\n                                                                                            IMPAIRED FASTING    : Fasting 6.1-6.9 & 2 hr up to 7.7",
+      "comment": "                                                                                            Fasting       4.3            negative        negative                                                                                            2 hours       7.6            negative        negative                                                                                            NORMAL              : Fasting up to 6.0 & 2 hr up to 7.7                                                                                            IMPAIRED FASTING    : Fasting 6.1-6.9 & 2 hr up to 7.7",
       "specimen": {
         "reference": "Specimen/89E2E801-4D16-4023-8EBA-BE076D479B67"
       },
@@ -4527,7 +4527,7 @@
         } ],
         "text": "Potentially abnormal"
       },
-      "comment": "                                                                                            GLYCAEMIA\n                                                                                            IMPAIRED GLUCOSE    : Fasting up to 6.9 & 2 hr 7.8-11.0\n                                                                                            TOLERANCE\n                                                                                            *DIABETES MELLITUS  : Fasting 7.0 or above &/or",
+      "comment": "                                                                                            GLYCAEMIA                                                                                            IMPAIRED GLUCOSE    : Fasting up to 6.9 & 2 hr 7.8-11.0                                                                                            TOLERANCE                                                                                            *DIABETES MELLITUS  : Fasting 7.0 or above &/or",
       "specimen": {
         "reference": "Specimen/89E2E801-4D16-4023-8EBA-BE076D479B67"
       },
@@ -4588,7 +4588,7 @@
         } ],
         "text": "Potentially abnormal"
       },
-      "comment": "                                                                                            2 hr 11.1 or above\n                                                                                            *(must also have symptoms - polyuria, polydipsia,\n                                                                                            unexplained weight loss)",
+      "comment": "                                                                                            2 hr 11.1 or above                                                                                            *(must also have symptoms - polyuria, polydipsia,                                                                                            unexplained weight loss)",
       "specimen": {
         "reference": "Specimen/89E2E801-4D16-4023-8EBA-BE076D479B67"
       },
@@ -4649,7 +4649,7 @@
         } ],
         "text": "Potentially abnormal"
       },
-      "comment": "                                                                                            Oral dose: 75g anhydrous glucose given as\n                                                                                            113ml Polycal liquid\n                                                                                            Plasma Glucose           Urine Results\n                                                                                            Time        (mmol/l)         Ketones         Glucose",
+      "comment": "                                                                                            Oral dose: 75g anhydrous glucose given as                                                                                            113ml Polycal liquid                                                                                            Plasma Glucose           Urine Results                                                                                            Time        (mmol/l)         Ketones         Glucose",
       "specimen": {
         "reference": "Specimen/E5CE0B1B-E29B-4823-B29D-2B75B0DC0356"
       },
@@ -4710,7 +4710,7 @@
         } ],
         "text": "Potentially abnormal"
       },
-      "comment": "                                                                                            Fasting       4.3            negative        negative\n                                                                                            2 hours       7.6            negative        negative\n                                                                                            NORMAL              : Fasting up to 6.0 & 2 hr up to 7.7\n                                                                                            IMPAIRED FASTING    : Fasting 6.1-6.9 & 2 hr up to 7.7",
+      "comment": "                                                                                            Fasting       4.3            negative        negative                                                                                            2 hours       7.6            negative        negative                                                                                            NORMAL              : Fasting up to 6.0 & 2 hr up to 7.7                                                                                            IMPAIRED FASTING    : Fasting 6.1-6.9 & 2 hr up to 7.7",
       "specimen": {
         "reference": "Specimen/E5CE0B1B-E29B-4823-B29D-2B75B0DC0356"
       },
@@ -4771,7 +4771,7 @@
         } ],
         "text": "Potentially abnormal"
       },
-      "comment": "                                                                                            GLYCAEMIA\n                                                                                            IMPAIRED GLUCOSE    : Fasting up to 6.9 & 2 hr 7.8-11.0\n                                                                                            TOLERANCE\n                                                                                            *DIABETES MELLITUS  : Fasting 7.0 or above &/or",
+      "comment": "                                                                                            GLYCAEMIA                                                                                            IMPAIRED GLUCOSE    : Fasting up to 6.9 & 2 hr 7.8-11.0                                                                                            TOLERANCE                                                                                            *DIABETES MELLITUS  : Fasting 7.0 or above &/or",
       "specimen": {
         "reference": "Specimen/E5CE0B1B-E29B-4823-B29D-2B75B0DC0356"
       },
@@ -4832,7 +4832,7 @@
         } ],
         "text": "Potentially abnormal"
       },
-      "comment": "                                                                                            2 hr 11.1 or above\n                                                                                            *(must also have symptoms - polyuria, polydipsia,\n                                                                                            unexplained weight loss)",
+      "comment": "                                                                                            2 hr 11.1 or above                                                                                            *(must also have symptoms - polyuria, polydipsia,                                                                                            unexplained weight loss)",
       "specimen": {
         "reference": "Specimen/E5CE0B1B-E29B-4823-B29D-2B75B0DC0356"
       },
@@ -5341,7 +5341,7 @@
         } ],
         "text": "Above high reference limit"
       },
-      "comment": "                                                                                            Cholesterol 6.5 - 7.8 Moderate Risk of CHD\n                                                                                            Cholesterol     > 7.8 Marked Risk of CHD",
+      "comment": "                                                                                            Cholesterol 6.5 - 7.8 Moderate Risk of CHD                                                                                            Cholesterol     > 7.8 Marked Risk of CHD",
       "specimen": {
         "reference": "Specimen/DBF83E10-237E-427C-A0B0-F43957A1276F"
       },
@@ -6938,7 +6938,7 @@
       "performer": [ {
         "reference": "Practitioner/1E473786-E7FA-785E-C911-A8D38FB56F20"
       } ],
-      "comment": "                                                                                            U=Unsuitable for analysis\n                                                                                            U=Unsuitable,due to delay in delivery.",
+      "comment": "                                                                                            U=Unsuitable for analysis                                                                                            U=Unsuitable,due to delay in delivery.",
       "specimen": {
         "reference": "Specimen/0DB91FFF-DC9C-4246-A8D0-A3D340A2D822"
       },
@@ -9070,7 +9070,7 @@
         } ],
         "text": "Potentially abnormal"
       },
-      "comment": "                                                                                    Negative\n                                                                                    I.M.Screen",
+      "comment": "                                                                                    Negative                                                                                    I.M.Screen",
       "specimen": {
         "reference": "Specimen/7D57ADE4-B274-44FE-91A2-7E794CB5DA42"
       }
@@ -9124,7 +9124,7 @@
       "performer": [ {
         "reference": "Practitioner/1E473786-E7FA-785E-C911-A8D38FB56F20"
       } ],
-      "comment": "                                                                                    WBC MORPHOLOGY NORMAL\n                                                                                    RBC MORPHOLOGY NORMAL",
+      "comment": "                                                                                    WBC MORPHOLOGY NORMAL                                                                                    RBC MORPHOLOGY NORMAL",
       "specimen": {
         "reference": "Specimen/7D57ADE4-B274-44FE-91A2-7E794CB5DA42"
       }
@@ -13648,6 +13648,8 @@
         "reference": "Specimen/E5CE0B1B-E29B-4823-B29D-2B75B0DC0356"
       } ],
       "result": [ {
+        "reference": "Observation/CA8C4119-3CC7-40A3-AC9D-168067F66079"
+      }, {
         "reference": "Observation/1834153D-6DB1-43FB-BE4E-8F53C62882FE"
       } ]
     }
@@ -13730,6 +13732,10 @@
         "reference": "Specimen/0DB91FFF-DC9C-4246-A8D0-A3D340A2D822"
       } ],
       "result": [ {
+        "reference": "Observation/FA1B0FA9-C9BC-4399-B506-52D0286DFD06"
+      }, {
+        "reference": "Observation/E47265C2-CE59-4F24-B203-5A73CEB79D84"
+      }, {
         "reference": "Observation/05E6D1C6-9B66-4D02-8FC3-C5CF3CC0EB1C"
       }, {
         "reference": "Observation/CFAF8307-C6B6-4EB4-A69D-81DDE4D2CD91"
@@ -13740,7 +13746,7 @@
       }, {
         "reference": "Observation/CDC2077F-F701-47F9-AFF9-87E8C07E8C69"
       } ],
-      "conclusion": "                                                                    Clinical Details:\n                                                                    NOTE:Specimen date"
+      "conclusion": "                                                                    Clinical Details:                                                                    NOTE:Specimen date"
     }
   }, {
     "resource": {
@@ -13775,6 +13781,8 @@
         "reference": "Specimen/9608BE52-16AF-4065-AECC-513856303FE0"
       } ],
       "result": [ {
+        "reference": "Observation/260C5AA5-9904-4543-88A8-6A87596F2C12"
+      }, {
         "reference": "Observation/471FD197-79B8-47C0-B5D1-6A4AFBA3D31D"
       }, {
         "reference": "Observation/59F968AD-21F1-4B97-96DE-D1AE22091132"
@@ -13856,6 +13864,8 @@
         "reference": "Specimen/7D57ADE4-B274-44FE-91A2-7E794CB5DA42"
       } ],
       "result": [ {
+        "reference": "Observation/C4F029C5-D175-4935-B064-BAD3BC9FBB2B"
+      }, {
         "reference": "Observation/768BF90A-8E36-49D0-9D29-BD3FF0DE733D"
       }, {
         "reference": "Observation/69832EFE-727E-4270-BDF5-179851BDF295"
@@ -14330,7 +14340,7 @@
         "collectedDateTime": "2003-06-02"
       },
       "note": [ {
-        "text": "                                                                            Another\n                                                                            Specimen\n                                                                            Comment"
+        "text": "                                                                            Another                                                                            Specimen                                                                            Comment"
       } ]
     }
   }, {
@@ -15211,7 +15221,7 @@
       "performer": [ {
         "reference": "Practitioner/C5DEFBF3-0174-BC6F-182C-B777B9C6FF43"
       } ],
-      "comment": "                                                                                    NB NEW WHO/DIABETES UK CLASSIFICATION CRITERIA FROM 01.06.00\n                                                                                    Dr. N.O'Connell",
+      "comment": "                                                                                    NB NEW WHO/DIABETES UK CLASSIFICATION CRITERIA FROM 01.06.00                                                                                    Dr. N.O'Connell",
       "specimen": {
         "reference": "Specimen/A8A66BB2-3392-4A7C-BA19-6DD9D61A0C22"
       },
@@ -15289,7 +15299,7 @@
       "performer": [ {
         "reference": "Practitioner/C5DEFBF3-0174-BC6F-182C-B777B9C6FF43"
       } ],
-      "comment": "                                                                                    NB NEW WHO/DIABETES UK CLASSIFICATION CRITERIA FROM 01.06.00\n                                                                                    Dr. N.O'Connell",
+      "comment": "                                                                                    NB NEW WHO/DIABETES UK CLASSIFICATION CRITERIA FROM 01.06.00                                                                                    Dr. N.O'Connell",
       "specimen": {
         "reference": "Specimen/89E2E801-4D16-4023-8EBA-BE076D479B67"
       },
@@ -15367,7 +15377,7 @@
       "performer": [ {
         "reference": "Practitioner/C5DEFBF3-0174-BC6F-182C-B777B9C6FF43"
       } ],
-      "comment": "                                                                                    NB NEW WHO/DIABETES UK CLASSIFICATION CRITERIA FROM 01.06.00\n                                                                                    Dr. N.O'Connell",
+      "comment": "                                                                                    NB NEW WHO/DIABETES UK CLASSIFICATION CRITERIA FROM 01.06.00                                                                                    Dr. N.O'Connell",
       "specimen": {
         "reference": "Specimen/E5CE0B1B-E29B-4823-B29D-2B75B0DC0356"
       },
@@ -16094,7 +16104,7 @@
       "performer": [ {
         "reference": "Practitioner/C5DEFBF3-0174-BC6F-182C-B777B9C6FF43"
       } ],
-      "comment": "                                                                                    These LTG comments only apply to the Anti-nuclear factor and the\n                                                                                    rheumatoid factor tests.",
+      "comment": "                                                                                    These LTG comments only apply to the Anti-nuclear factor and the                                                                                    rheumatoid factor tests.",
       "specimen": {
         "reference": "Specimen/EC494B1A-FFEF-41E2-94AB-B287AE516361"
       },

--- a/gp2gp-translator/src/integrationTest/resources/e2e-mapping/output-json/PWTP9-output.json
+++ b/gp2gp-translator/src/integrationTest/resources/e2e-mapping/output-json/PWTP9-output.json
@@ -3830,7 +3830,7 @@
         "system": "http://unitsofmeasure.org",
         "code": "1"
       },
-      "comment": "                                                                                    DVT Prophylaxis - INR 2.0-2.5\n                                                                                    Treatment of DVT,PE,AF,TIA - INR 2.0-3.0\n                                                                                    Recurrent DVT or PE                )\n                                                                                    Arterial Disease                   )INR 3.0-4.5\n                                                                                    Mechanical Prosthetic Heart Valves )",
+      "comment": "                                                                                    DVT Prophylaxis - INR 2.0-2.5                                                                                    Treatment of DVT,PE,AF,TIA - INR 2.0-3.0                                                                                    Recurrent DVT or PE                )                                                                                    Arterial Disease                   )INR 3.0-4.5                                                                                    Mechanical Prosthetic Heart Valves )",
       "specimen": {
         "reference": "Specimen/971752A8-2F1C-478B-94D6-E6B535F534AC"
       }
@@ -4161,7 +4161,7 @@
         } ],
         "text": "Potentially abnormal"
       },
-      "comment": "                                                                                            Oral dose: 75g anhydrous glucose given as\n                                                                                            113ml Polycal liquid\n                                                                                            Plasma Glucose           Urine Results\n                                                                                            Time        (mmol/l)         Ketones         Glucose",
+      "comment": "                                                                                            Oral dose: 75g anhydrous glucose given as                                                                                            113ml Polycal liquid                                                                                            Plasma Glucose           Urine Results                                                                                            Time        (mmol/l)         Ketones         Glucose",
       "specimen": {
         "reference": "Specimen/A8A66BB2-3392-4A7C-BA19-6DD9D61A0C22"
       },
@@ -4222,7 +4222,7 @@
         } ],
         "text": "Potentially abnormal"
       },
-      "comment": "                                                                                            Fasting       4.3            negative        negative\n                                                                                            2 hours       7.6            negative        negative\n                                                                                            NORMAL              : Fasting up to 6.0 & 2 hr up to 7.7\n                                                                                            IMPAIRED FASTING    : Fasting 6.1-6.9 & 2 hr up to 7.7",
+      "comment": "                                                                                            Fasting       4.3            negative        negative                                                                                            2 hours       7.6            negative        negative                                                                                            NORMAL              : Fasting up to 6.0 & 2 hr up to 7.7                                                                                            IMPAIRED FASTING    : Fasting 6.1-6.9 & 2 hr up to 7.7",
       "specimen": {
         "reference": "Specimen/A8A66BB2-3392-4A7C-BA19-6DD9D61A0C22"
       },
@@ -4283,7 +4283,7 @@
         } ],
         "text": "Potentially abnormal"
       },
-      "comment": "                                                                                            GLYCAEMIA\n                                                                                            IMPAIRED GLUCOSE    : Fasting up to 6.9 & 2 hr 7.8-11.0\n                                                                                            TOLERANCE\n                                                                                            *DIABETES MELLITUS  : Fasting 7.0 or above &/or",
+      "comment": "                                                                                            GLYCAEMIA                                                                                            IMPAIRED GLUCOSE    : Fasting up to 6.9 & 2 hr 7.8-11.0                                                                                            TOLERANCE                                                                                            *DIABETES MELLITUS  : Fasting 7.0 or above &/or",
       "specimen": {
         "reference": "Specimen/A8A66BB2-3392-4A7C-BA19-6DD9D61A0C22"
       },
@@ -4344,7 +4344,7 @@
         } ],
         "text": "Potentially abnormal"
       },
-      "comment": "                                                                                            2 hr 11.1 or above\n                                                                                            *(must also have symptoms - polyuria, polydipsia,\n                                                                                            unexplained weight loss)",
+      "comment": "                                                                                            2 hr 11.1 or above                                                                                            *(must also have symptoms - polyuria, polydipsia,                                                                                            unexplained weight loss)",
       "specimen": {
         "reference": "Specimen/A8A66BB2-3392-4A7C-BA19-6DD9D61A0C22"
       },
@@ -4405,7 +4405,7 @@
         } ],
         "text": "Potentially abnormal"
       },
-      "comment": "                                                                                            Oral dose: 75g anhydrous glucose given as\n                                                                                            113ml Polycal liquid\n                                                                                            Plasma Glucose           Urine Results\n                                                                                            Time        (mmol/l)         Ketones         Glucose",
+      "comment": "                                                                                            Oral dose: 75g anhydrous glucose given as                                                                                            113ml Polycal liquid                                                                                            Plasma Glucose           Urine Results                                                                                            Time        (mmol/l)         Ketones         Glucose",
       "specimen": {
         "reference": "Specimen/89E2E801-4D16-4023-8EBA-BE076D479B67"
       },
@@ -4466,7 +4466,7 @@
         } ],
         "text": "Potentially abnormal"
       },
-      "comment": "                                                                                            Fasting       4.3            negative        negative\n                                                                                            2 hours       7.6            negative        negative\n                                                                                            NORMAL              : Fasting up to 6.0 & 2 hr up to 7.7\n                                                                                            IMPAIRED FASTING    : Fasting 6.1-6.9 & 2 hr up to 7.7",
+      "comment": "                                                                                            Fasting       4.3            negative        negative                                                                                            2 hours       7.6            negative        negative                                                                                            NORMAL              : Fasting up to 6.0 & 2 hr up to 7.7                                                                                            IMPAIRED FASTING    : Fasting 6.1-6.9 & 2 hr up to 7.7",
       "specimen": {
         "reference": "Specimen/89E2E801-4D16-4023-8EBA-BE076D479B67"
       },
@@ -4527,7 +4527,7 @@
         } ],
         "text": "Potentially abnormal"
       },
-      "comment": "                                                                                            GLYCAEMIA\n                                                                                            IMPAIRED GLUCOSE    : Fasting up to 6.9 & 2 hr 7.8-11.0\n                                                                                            TOLERANCE\n                                                                                            *DIABETES MELLITUS  : Fasting 7.0 or above &/or",
+      "comment": "                                                                                            GLYCAEMIA                                                                                            IMPAIRED GLUCOSE    : Fasting up to 6.9 & 2 hr 7.8-11.0                                                                                            TOLERANCE                                                                                            *DIABETES MELLITUS  : Fasting 7.0 or above &/or",
       "specimen": {
         "reference": "Specimen/89E2E801-4D16-4023-8EBA-BE076D479B67"
       },
@@ -4588,7 +4588,7 @@
         } ],
         "text": "Potentially abnormal"
       },
-      "comment": "                                                                                            2 hr 11.1 or above\n                                                                                            *(must also have symptoms - polyuria, polydipsia,\n                                                                                            unexplained weight loss)",
+      "comment": "                                                                                            2 hr 11.1 or above                                                                                            *(must also have symptoms - polyuria, polydipsia,                                                                                            unexplained weight loss)",
       "specimen": {
         "reference": "Specimen/89E2E801-4D16-4023-8EBA-BE076D479B67"
       },
@@ -4649,7 +4649,7 @@
         } ],
         "text": "Potentially abnormal"
       },
-      "comment": "                                                                                            Oral dose: 75g anhydrous glucose given as\n                                                                                            113ml Polycal liquid\n                                                                                            Plasma Glucose           Urine Results\n                                                                                            Time        (mmol/l)         Ketones         Glucose",
+      "comment": "                                                                                            Oral dose: 75g anhydrous glucose given as                                                                                            113ml Polycal liquid                                                                                            Plasma Glucose           Urine Results                                                                                            Time        (mmol/l)         Ketones         Glucose",
       "specimen": {
         "reference": "Specimen/E5CE0B1B-E29B-4823-B29D-2B75B0DC0356"
       },
@@ -4710,7 +4710,7 @@
         } ],
         "text": "Potentially abnormal"
       },
-      "comment": "                                                                                            Fasting       4.3            negative        negative\n                                                                                            2 hours       7.6            negative        negative\n                                                                                            NORMAL              : Fasting up to 6.0 & 2 hr up to 7.7\n                                                                                            IMPAIRED FASTING    : Fasting 6.1-6.9 & 2 hr up to 7.7",
+      "comment": "                                                                                            Fasting       4.3            negative        negative                                                                                            2 hours       7.6            negative        negative                                                                                            NORMAL              : Fasting up to 6.0 & 2 hr up to 7.7                                                                                            IMPAIRED FASTING    : Fasting 6.1-6.9 & 2 hr up to 7.7",
       "specimen": {
         "reference": "Specimen/E5CE0B1B-E29B-4823-B29D-2B75B0DC0356"
       },
@@ -4771,7 +4771,7 @@
         } ],
         "text": "Potentially abnormal"
       },
-      "comment": "                                                                                            GLYCAEMIA\n                                                                                            IMPAIRED GLUCOSE    : Fasting up to 6.9 & 2 hr 7.8-11.0\n                                                                                            TOLERANCE\n                                                                                            *DIABETES MELLITUS  : Fasting 7.0 or above &/or",
+      "comment": "                                                                                            GLYCAEMIA                                                                                            IMPAIRED GLUCOSE    : Fasting up to 6.9 & 2 hr 7.8-11.0                                                                                            TOLERANCE                                                                                            *DIABETES MELLITUS  : Fasting 7.0 or above &/or",
       "specimen": {
         "reference": "Specimen/E5CE0B1B-E29B-4823-B29D-2B75B0DC0356"
       },
@@ -4832,7 +4832,7 @@
         } ],
         "text": "Potentially abnormal"
       },
-      "comment": "                                                                                            2 hr 11.1 or above\n                                                                                            *(must also have symptoms - polyuria, polydipsia,\n                                                                                            unexplained weight loss)",
+      "comment": "                                                                                            2 hr 11.1 or above                                                                                            *(must also have symptoms - polyuria, polydipsia,                                                                                            unexplained weight loss)",
       "specimen": {
         "reference": "Specimen/E5CE0B1B-E29B-4823-B29D-2B75B0DC0356"
       },
@@ -5341,7 +5341,7 @@
         } ],
         "text": "Above high reference limit"
       },
-      "comment": "                                                                                            Cholesterol 6.5 - 7.8 Moderate Risk of CHD\n                                                                                            Cholesterol     > 7.8 Marked Risk of CHD",
+      "comment": "                                                                                            Cholesterol 6.5 - 7.8 Moderate Risk of CHD                                                                                            Cholesterol     > 7.8 Marked Risk of CHD",
       "specimen": {
         "reference": "Specimen/DBF83E10-237E-427C-A0B0-F43957A1276F"
       },
@@ -6938,7 +6938,7 @@
       "performer": [ {
         "reference": "Practitioner/1E473786-E7FA-785E-C911-A8D38FB56F20"
       } ],
-      "comment": "                                                                                            U=Unsuitable for analysis\n                                                                                            U=Unsuitable,due to delay in delivery.",
+      "comment": "                                                                                            U=Unsuitable for analysis                                                                                            U=Unsuitable,due to delay in delivery.",
       "specimen": {
         "reference": "Specimen/0DB91FFF-DC9C-4246-A8D0-A3D340A2D822"
       },
@@ -9070,7 +9070,7 @@
         } ],
         "text": "Potentially abnormal"
       },
-      "comment": "                                                                                    Negative\n                                                                                    I.M.Screen",
+      "comment": "                                                                                    Negative                                                                                    I.M.Screen",
       "specimen": {
         "reference": "Specimen/7D57ADE4-B274-44FE-91A2-7E794CB5DA42"
       }
@@ -9124,7 +9124,7 @@
       "performer": [ {
         "reference": "Practitioner/1E473786-E7FA-785E-C911-A8D38FB56F20"
       } ],
-      "comment": "                                                                                    WBC MORPHOLOGY NORMAL\n                                                                                    RBC MORPHOLOGY NORMAL",
+      "comment": "                                                                                    WBC MORPHOLOGY NORMAL                                                                                    RBC MORPHOLOGY NORMAL",
       "specimen": {
         "reference": "Specimen/7D57ADE4-B274-44FE-91A2-7E794CB5DA42"
       }
@@ -13648,7 +13648,7 @@
         "reference": "Specimen/E5CE0B1B-E29B-4823-B29D-2B75B0DC0356"
       } ],
       "result": [ {
-        "reference": "Observation/CA8C4119-3CC7-40A3-AC9D-168067F66079"
+        "reference": "Observation/00000000-0000-0000-0000-000000000005"
       }, {
         "reference": "Observation/1834153D-6DB1-43FB-BE4E-8F53C62882FE"
       } ]
@@ -13732,9 +13732,7 @@
         "reference": "Specimen/0DB91FFF-DC9C-4246-A8D0-A3D340A2D822"
       } ],
       "result": [ {
-        "reference": "Observation/FA1B0FA9-C9BC-4399-B506-52D0286DFD06"
-      }, {
-        "reference": "Observation/E47265C2-CE59-4F24-B203-5A73CEB79D84"
+        "reference": "Observation/00000000-0000-0000-0000-000000000006"
       }, {
         "reference": "Observation/05E6D1C6-9B66-4D02-8FC3-C5CF3CC0EB1C"
       }, {
@@ -13746,7 +13744,7 @@
       }, {
         "reference": "Observation/CDC2077F-F701-47F9-AFF9-87E8C07E8C69"
       } ],
-      "conclusion": "                                                                    Clinical Details:\n                                                                    NOTE:Specimen date"
+      "conclusion": "                                                                    Clinical Details:                                                                    NOTE:Specimen date"
     }
   }, {
     "resource": {
@@ -13781,7 +13779,7 @@
         "reference": "Specimen/9608BE52-16AF-4065-AECC-513856303FE0"
       } ],
       "result": [ {
-        "reference": "Observation/260C5AA5-9904-4543-88A8-6A87596F2C12"
+        "reference": "Observation/00000000-0000-0000-0000-000000000007"
       }, {
         "reference": "Observation/471FD197-79B8-47C0-B5D1-6A4AFBA3D31D"
       }, {
@@ -13864,7 +13862,7 @@
         "reference": "Specimen/7D57ADE4-B274-44FE-91A2-7E794CB5DA42"
       } ],
       "result": [ {
-        "reference": "Observation/C4F029C5-D175-4935-B064-BAD3BC9FBB2B"
+        "reference": "Observation/00000000-0000-0000-0000-000000000008"
       }, {
         "reference": "Observation/768BF90A-8E36-49D0-9D29-BD3FF0DE733D"
       }, {
@@ -14340,7 +14338,7 @@
         "collectedDateTime": "2003-06-02"
       },
       "note": [ {
-        "text": "                                                                            Another\n                                                                            Specimen\n                                                                            Comment"
+        "text": "                                                                            Another                                                                            Specimen                                                                            Comment"
       } ]
     }
   }, {
@@ -15172,6 +15170,130 @@
   }, {
     "resource": {
       "resourceType": "Observation",
+      "id": "00000000-0000-0000-0000-000000000005",
+      "meta": {
+        "profile": [ "https://fhir.nhs.uk/STU3/StructureDefinition/CareConnect-GPC-Observation-1" ]
+      },
+      "identifier": [ {
+        "system": "https://PSSAdaptor/B83002",
+        "value": "00000000-0000-0000-0000-000000000005"
+      } ],
+      "status": "final",
+      "code": {
+        "coding": [ {
+          "system": "http://snomed.info/sct",
+          "code": "37331000000100",
+          "display": "Comment note"
+        } ]
+      },
+      "subject": {
+        "reference": "Patient/00000000-0000-0000-0000-000000000003"
+      },
+      "context": {
+        "reference": "Encounter/DD64A383-7DC5-4E15-A0FF-20F2C4D195A5"
+      },
+      "effectiveDateTime": "2010-01-20T16:27:23+00:00",
+      "issued": "2010-03-26T14:04:43.000+00:00",
+      "performer": [ {
+        "reference": "Practitioner/C5DEFBF3-0174-BC6F-182C-B777B9C6FF43"
+      } ]
+    }
+  }, {
+    "resource": {
+      "resourceType": "Observation",
+      "id": "00000000-0000-0000-0000-000000000006",
+      "meta": {
+        "profile": [ "https://fhir.nhs.uk/STU3/StructureDefinition/CareConnect-GPC-Observation-1" ]
+      },
+      "identifier": [ {
+        "system": "https://PSSAdaptor/B83002",
+        "value": "00000000-0000-0000-0000-000000000006"
+      } ],
+      "status": "final",
+      "code": {
+        "coding": [ {
+          "system": "http://snomed.info/sct",
+          "code": "37331000000100",
+          "display": "Comment note"
+        } ]
+      },
+      "subject": {
+        "reference": "Patient/00000000-0000-0000-0000-000000000003"
+      },
+      "context": {
+        "reference": "Encounter/9096889B-4D56-4668-86F7-1E1C63011A46"
+      },
+      "effectiveDateTime": "2010-01-20T10:46:22+00:00",
+      "issued": "2010-03-26T13:45:44.000+00:00",
+      "performer": [ {
+        "reference": "Practitioner/1E473786-E7FA-785E-C911-A8D38FB56F20"
+      } ]
+    }
+  }, {
+    "resource": {
+      "resourceType": "Observation",
+      "id": "00000000-0000-0000-0000-000000000007",
+      "meta": {
+        "profile": [ "https://fhir.nhs.uk/STU3/StructureDefinition/CareConnect-GPC-Observation-1" ]
+      },
+      "identifier": [ {
+        "system": "https://PSSAdaptor/B83002",
+        "value": "00000000-0000-0000-0000-000000000007"
+      } ],
+      "status": "final",
+      "code": {
+        "coding": [ {
+          "system": "http://snomed.info/sct",
+          "code": "37331000000100",
+          "display": "Comment note"
+        } ]
+      },
+      "subject": {
+        "reference": "Patient/00000000-0000-0000-0000-000000000003"
+      },
+      "context": {
+        "reference": "Encounter/730C507B-32CE-4270-80BA-42F4B62BA064"
+      },
+      "effectiveDateTime": "2010-01-20T10:46:22+00:00",
+      "issued": "2010-02-09T12:21:06.000+00:00",
+      "performer": [ {
+        "reference": "Practitioner/1E473786-E7FA-785E-C911-A8D38FB56F20"
+      } ]
+    }
+  }, {
+    "resource": {
+      "resourceType": "Observation",
+      "id": "00000000-0000-0000-0000-000000000008",
+      "meta": {
+        "profile": [ "https://fhir.nhs.uk/STU3/StructureDefinition/CareConnect-GPC-Observation-1" ]
+      },
+      "identifier": [ {
+        "system": "https://PSSAdaptor/B83002",
+        "value": "00000000-0000-0000-0000-000000000008"
+      } ],
+      "status": "final",
+      "code": {
+        "coding": [ {
+          "system": "http://snomed.info/sct",
+          "code": "37331000000100",
+          "display": "Comment note"
+        } ]
+      },
+      "subject": {
+        "reference": "Patient/00000000-0000-0000-0000-000000000003"
+      },
+      "context": {
+        "reference": "Encounter/B0696913-F11D-4EAA-8BB7-41350B296F3F"
+      },
+      "effectiveDateTime": "2010-01-20T16:27:23+00:00",
+      "issued": "2010-02-01T09:33:13.000+00:00",
+      "performer": [ {
+        "reference": "Practitioner/1E473786-E7FA-785E-C911-A8D38FB56F20"
+      } ]
+    }
+  }, {
+    "resource": {
+      "resourceType": "Observation",
       "id": "5668ACD3-4700-4C6B-B6EE-A9F28A80A780",
       "meta": {
         "profile": [ "https://fhir.nhs.uk/STU3/StructureDefinition/CareConnect-GPC-Observation-1" ]
@@ -15221,7 +15343,7 @@
       "performer": [ {
         "reference": "Practitioner/C5DEFBF3-0174-BC6F-182C-B777B9C6FF43"
       } ],
-      "comment": "                                                                                    NB NEW WHO/DIABETES UK CLASSIFICATION CRITERIA FROM 01.06.00\n                                                                                    Dr. N.O'Connell",
+      "comment": "                                                                                    NB NEW WHO/DIABETES UK CLASSIFICATION CRITERIA FROM 01.06.00                                                                                    Dr. N.O'Connell",
       "specimen": {
         "reference": "Specimen/A8A66BB2-3392-4A7C-BA19-6DD9D61A0C22"
       },
@@ -15299,7 +15421,7 @@
       "performer": [ {
         "reference": "Practitioner/C5DEFBF3-0174-BC6F-182C-B777B9C6FF43"
       } ],
-      "comment": "                                                                                    NB NEW WHO/DIABETES UK CLASSIFICATION CRITERIA FROM 01.06.00\n                                                                                    Dr. N.O'Connell",
+      "comment": "                                                                                    NB NEW WHO/DIABETES UK CLASSIFICATION CRITERIA FROM 01.06.00                                                                                    Dr. N.O'Connell",
       "specimen": {
         "reference": "Specimen/89E2E801-4D16-4023-8EBA-BE076D479B67"
       },
@@ -15377,7 +15499,7 @@
       "performer": [ {
         "reference": "Practitioner/C5DEFBF3-0174-BC6F-182C-B777B9C6FF43"
       } ],
-      "comment": "                                                                                    NB NEW WHO/DIABETES UK CLASSIFICATION CRITERIA FROM 01.06.00\n                                                                                    Dr. N.O'Connell",
+      "comment": "                                                                                    NB NEW WHO/DIABETES UK CLASSIFICATION CRITERIA FROM 01.06.00                                                                                    Dr. N.O'Connell",
       "specimen": {
         "reference": "Specimen/E5CE0B1B-E29B-4823-B29D-2B75B0DC0356"
       },
@@ -16104,7 +16226,7 @@
       "performer": [ {
         "reference": "Practitioner/C5DEFBF3-0174-BC6F-182C-B777B9C6FF43"
       } ],
-      "comment": "                                                                                    These LTG comments only apply to the Anti-nuclear factor and the\n                                                                                    rheumatoid factor tests.",
+      "comment": "                                                                                    These LTG comments only apply to the Anti-nuclear factor and the                                                                                    rheumatoid factor tests.",
       "specimen": {
         "reference": "Specimen/EC494B1A-FFEF-41E2-94AB-B287AE516361"
       },

--- a/gp2gp-translator/src/main/java/uk/nhs/adaptors/pss/translator/mapper/ObservationCommentMapper.java
+++ b/gp2gp-translator/src/main/java/uk/nhs/adaptors/pss/translator/mapper/ObservationCommentMapper.java
@@ -8,6 +8,7 @@ import static uk.nhs.adaptors.pss.translator.util.ResourceUtil.addContextToObser
 import static uk.nhs.adaptors.pss.translator.util.ResourceUtil.buildIdentifier;
 import static uk.nhs.adaptors.pss.translator.util.ResourceUtil.generateMeta;
 
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
 import java.util.stream.Collectors;
@@ -38,15 +39,15 @@ public class ObservationCommentMapper extends AbstractMapper<Observation> {
     private static final String CODING_CODE = "37331000000100";
     private static final String CODING_DISPLAY = "Comment note";
 
-    public List<Observation> mapResources(RCMRMT030101UKEhrExtract ehrExtract, Patient patient, List<Encounter> encounters,
-                                          String practiseCode) {
+    public ArrayList<Observation> mapResources(RCMRMT030101UKEhrExtract ehrExtract, Patient patient, List<Encounter> encounters,
+                                               String practiseCode) {
 
         return mapEhrExtractToFhirResource(ehrExtract, (extract, composition, component) ->
             extractAllNonBloodPressureNarrativeStatements(component)
                 .filter(Objects::nonNull)
                 .filter(narrativeStatement -> !isDocumentReference(narrativeStatement))
                 .map(narrativeStatement -> mapObservation(ehrExtract, composition, narrativeStatement, patient, encounters, practiseCode)))
-            .collect(Collectors.toList());
+            .collect((Collectors.toCollection(ArrayList::new)));
     }
 
     private Observation mapObservation(RCMRMT030101UKEhrExtract ehrExtract, RCMRMT030101UKEhrComposition ehrComposition,

--- a/gp2gp-translator/src/main/java/uk/nhs/adaptors/pss/translator/mapper/diagnosticreport/SpecimenMapper.java
+++ b/gp2gp-translator/src/main/java/uk/nhs/adaptors/pss/translator/mapper/diagnosticreport/SpecimenMapper.java
@@ -5,6 +5,7 @@ import static uk.nhs.adaptors.pss.translator.util.ResourceUtil.buildIdentifier;
 import static uk.nhs.adaptors.pss.translator.util.ResourceUtil.generateMeta;
 import static uk.nhs.adaptors.pss.translator.util.TextUtil.extractPmipComment;
 
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
@@ -58,8 +59,8 @@ public class SpecimenMapper {
             .toList();
     }
 
-    public List<Observation> removeSurplusObservationComments(RCMRMT030101UK04EhrExtract ehrExtract,
-        List<Observation> observationComments) {
+    public ArrayList<Observation> removeSurplusObservationComments(RCMRMT030101UK04EhrExtract ehrExtract,
+        ArrayList<Observation> observationComments) {
 
         var specimenCompoundStatements = findAllSpecimenCompoundStatements(ehrExtract);
 

--- a/gp2gp-translator/src/main/java/uk/nhs/adaptors/pss/translator/service/BundleMapperService.java
+++ b/gp2gp-translator/src/main/java/uk/nhs/adaptors/pss/translator/service/BundleMapperService.java
@@ -167,8 +167,8 @@ public class BundleMapperService {
     }
 
     private void mapDiagnosticReports(Bundle bundle, RCMRMT030101UK04EhrExtract ehrExtract, Patient patient, List<Encounter> encounters,
-        List<Observation> observations, List<Observation> observationComments, String practiceCode) {
-        var diagnosticReports = diagnosticReportMapper.mapResources(ehrExtract, patient, encounters, practiceCode);
+        List<Observation> observations, ArrayList<Observation> observationComments, String practiceCode) {
+        var diagnosticReports = diagnosticReportMapper.mapResources(ehrExtract, patient, encounters, practiceCode, observationComments);
 
         diagnosticReportMapper.handleChildObservationComments(ehrExtract, observationComments);
 

--- a/gp2gp-translator/src/test/java/uk/nhs/adaptors/pss/translator/mapper/diagnosticreport/DiagnosticReportMapperTest.java
+++ b/gp2gp-translator/src/test/java/uk/nhs/adaptors/pss/translator/mapper/diagnosticreport/DiagnosticReportMapperTest.java
@@ -74,10 +74,6 @@ public class DiagnosticReportMapperTest {
                     </component>
                 </EhrExtract>
                 """;
-
-//    @Mock
-//    private CodeableConceptMapper codeableConceptMapper;
-
     @Mock
     private IdGeneratorService idGeneratorService;
 
@@ -509,7 +505,8 @@ TEST COMMENT
                 () -> assertThat(observationComments.get(1).getIdentifierFirstRep().getValue())
                         .isEqualTo(NEW_OBSERVATION_ID),
                 () -> assertThat(observationComments.get(1).getEffectiveDateTimeType().getValueAsString())
-                        .isEqualTo("2024-01-01")
+                        .isEqualTo("2024-01-01"),
+                () -> assertThat(observationComments.get(1).getComment()).isNull()
         );
     }
 

--- a/gp2gp-translator/src/test/java/uk/nhs/adaptors/pss/translator/mapper/diagnosticreport/DiagnosticReportMapperTest.java
+++ b/gp2gp-translator/src/test/java/uk/nhs/adaptors/pss/translator/mapper/diagnosticreport/DiagnosticReportMapperTest.java
@@ -4,15 +4,18 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import static org.junit.jupiter.api.Assertions.assertAll;
 
+
 import static uk.nhs.adaptors.pss.translator.util.DateFormatUtil.parseToInstantType;
 import static uk.nhs.adaptors.pss.translator.util.XmlUnmarshallUtil.unmarshallString;
 
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
 
 import org.hl7.fhir.dstu3.model.DateTimeType;
 import org.hl7.fhir.dstu3.model.Encounter;
+import org.hl7.fhir.dstu3.model.Identifier;
 import org.hl7.fhir.dstu3.model.InstantType;
 import org.hl7.fhir.dstu3.model.Observation;
 import org.hl7.fhir.dstu3.model.Patient;
@@ -20,9 +23,12 @@ import org.hl7.v3.RCMRMT030101UK04EhrExtract;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
+import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
-
+import static org.mockito.Mockito.when;
 import lombok.SneakyThrows;
+import uk.nhs.adaptors.pss.translator.service.IdGeneratorService;
+import uk.nhs.adaptors.pss.translator.util.DateFormatUtil;
 
 @ExtendWith(MockitoExtension.class)
 public class DiagnosticReportMapperTest {
@@ -35,6 +41,7 @@ public class DiagnosticReportMapperTest {
     private static final String NARRATIVE_STATEMENT_2_TEXT = "TEST COMMENT";
     private static final String COMPOUND_STATEMENT_CHILD_ID = "COMPOUND_STATEMENT_CHILD_ID";
     private static final String ENCOUNTER_ID = "EHR_COMPOSITION_ID_1";
+    private static final String NEW_OBSERVATION_ID = "NEW_OBSERVATION_ID";
     private static final InstantType ISSUED_ELEMENT = parseToInstantType("20100225154100");
     private static final Patient PATIENT = (Patient) new Patient().setId("PATIENT_TEST_ID");
     private static final String CONCLUSION_FIELD_TEXT = "TEXT_OF_DIRECT_COMPOUND_STATEMENT_CHILD_NARRATIVE_STATEMENT_1\n"
@@ -71,8 +78,12 @@ public class DiagnosticReportMapperTest {
 //    @Mock
 //    private CodeableConceptMapper codeableConceptMapper;
 
+    @Mock
+    private IdGeneratorService idGeneratorService;
+
     @InjectMocks
     private DiagnosticReportMapper diagnosticReportMapper;
+
 
     @Test
     public void When_DiagnosticReportWithNoReferenceIsMapped_Expect_DiagnosticReportIsCorrectlyMapped() {
@@ -84,6 +95,7 @@ public class DiagnosticReportMapperTest {
                     <availabilityTime value="20100225154100"/>
                 </CompoundStatement>
                 """);
+
         var ehrExtract = unmarshallEhrExtractFromXmlString(inputXml);
 
         var diagnosticReports = diagnosticReportMapper.mapResources(ehrExtract, PATIENT, List.of(), PRACTICE_CODE);
@@ -373,7 +385,7 @@ TEST COMMENT
     }
 
     @Test
-    public void When_MappingWithUserCommentInBattery_Expect_DiagnosticReportToReferenceTheUserCommentObservation() {
+    public void When_MappingWithUserCommentInBattery_Expect_DiagnosticReportToReferenceFilingComment() {
         var inputXml = buildEhrExtractStringFromDiagnosticReportXml(
                 """
                 <CompoundStatement classCode="CLUSTER" moodCode="EVN">
@@ -401,6 +413,7 @@ TEST COMMENT
                                     <component typeCode="COMP" contextConductionInd="true">
                                         <NarrativeStatement classCode="OBS" moodCode="EVN">
                                             <id root="C515E722-2473-11EE-808B-AC162D1F16F0"/>
+                                            <effectiveTime value="01012024"/>
                                             <text mediaType="text/x-h7uk-pmip">
                                                 CommentType:USER COMMENT
                                             </text>
@@ -413,13 +426,18 @@ TEST COMMENT
                 </CompoundStatement>
                 """);
         final var ehrExtract = unmarshallEhrExtractFromXmlString(inputXml);
-        final var expectedReference = "Observation/C515E722-2473-11EE-808B-AC162D1F16F0";
+        final var batteryLevelFilingComment = createBatteryLevelFilingComment();
+        final var expectedReference = "Observation/" + NEW_OBSERVATION_ID;
+
+        when(idGeneratorService.generateUuid()).thenReturn(NEW_OBSERVATION_ID);
 
         final var diagnosticReports = diagnosticReportMapper.mapResources(
                 ehrExtract,
                 PATIENT,
                 createEncounterList(),
-                PRACTICE_CODE);
+                PRACTICE_CODE,
+                new ArrayList<>(Collections.singleton(batteryLevelFilingComment)));
+
         final var diagnosticReport = diagnosticReports.get(0);
 
         assertAll(
@@ -431,7 +449,7 @@ TEST COMMENT
     }
 
     @Test
-    public void When_MappingWithUnknownCommentInBattery_Expect_DiagnosticReportToReferenceTheUserCommentObservation() {
+    public void When_MappingWithUserCommentInBattery_Expect_NewFilingCommentObservationCreatedWithCommentField() {
         var inputXml = buildEhrExtractStringFromDiagnosticReportXml(
                 """
                 <CompoundStatement classCode="CLUSTER" moodCode="EVN">
@@ -459,8 +477,9 @@ TEST COMMENT
                                     <component typeCode="COMP" contextConductionInd="true">
                                         <NarrativeStatement classCode="OBS" moodCode="EVN">
                                             <id root="C515E722-2473-11EE-808B-AC162D1F16F0"/>
+                                            <effectiveTime value="01012024"/>
                                             <text mediaType="text/x-h7uk-pmip">
-                                                CommentType:UNKNOWN TYPE
+                                                CommentType:USER COMMENT
                                             </text>
                                         </NarrativeStatement>
                                     </component>
@@ -471,20 +490,26 @@ TEST COMMENT
                 </CompoundStatement>
                 """);
         final var ehrExtract = unmarshallEhrExtractFromXmlString(inputXml);
-        final var expectedReference = "Observation/C515E722-2473-11EE-808B-AC162D1F16F0";
+        final var batteryLevelFilingComment = createBatteryLevelFilingComment();
+        var observationComments = new ArrayList<>(Collections.singleton(batteryLevelFilingComment));
 
-        final var diagnosticReports = diagnosticReportMapper.mapResources(
-                ehrExtract,
+        when(idGeneratorService.generateUuid()).thenReturn(NEW_OBSERVATION_ID);
+
+        diagnosticReportMapper.mapResources(ehrExtract,
                 PATIENT,
                 createEncounterList(),
-                PRACTICE_CODE);
-        final var diagnosticReport = diagnosticReports.get(0);
+                PRACTICE_CODE,
+                observationComments);
 
         assertAll(
-                () -> assertThat(diagnosticReport.getResult())
-                        .hasSize(1),
-                () -> assertThat(diagnosticReport.getResult().get(0).getReference())
-                        .isEqualTo(expectedReference)
+                () -> assertThat(observationComments)
+                        .hasSize(2),
+                () -> assertThat(observationComments.get(1).getId())
+                        .isEqualTo(NEW_OBSERVATION_ID),
+                () -> assertThat(observationComments.get(1).getIdentifierFirstRep().getValue())
+                        .isEqualTo(NEW_OBSERVATION_ID),
+                () -> assertThat(observationComments.get(1).getEffectiveDateTimeType().getValueAsString())
+                        .isEqualTo("2024-01-01")
         );
     }
 
@@ -499,6 +524,17 @@ TEST COMMENT
                         .setComment(NARRATIVE_STATEMENT_COMMENT_BLOCK_2)
                         .setId(NARRATIVE_STATEMENT_ID_2)
         ));
+    }
+
+    private Observation createBatteryLevelFilingComment() {
+        var identifier = new Identifier();
+        identifier.setSystem("https://PSSAdaptor/" + PRACTICE_CODE);
+        identifier.setValue("C515E722-2473-11EE-808B-AC162D1F16F0");
+        return (Observation) new Observation()
+                        .setEffective(new DateTimeType())
+                        .setComment("This is a comment from the doctor")
+                        .setEffective(DateFormatUtil.parseToDateTimeType("20240101"))
+                        .setId("C515E722-2473-11EE-808B-AC162D1F16F0");
     }
 
     private List<Encounter> createEncounterList() {

--- a/gp2gp-translator/src/test/java/uk/nhs/adaptors/pss/translator/mapper/diagnosticreport/SpecimenMapperTest.java
+++ b/gp2gp-translator/src/test/java/uk/nhs/adaptors/pss/translator/mapper/diagnosticreport/SpecimenMapperTest.java
@@ -124,7 +124,7 @@ public class SpecimenMapperTest {
     public void When_RemoveSurplusObservationComments_Without_NoChildNarrativeStatements_Expect_CommentsUnchanged() {
         RCMRMT030101UK04EhrExtract ehrExtract = unmarshallEhrExtract("specimen_valid_without_comment.xml");
 
-        List<Observation> observationComments = getObservationComments();
+        var observationComments = getObservationComments();
 
         var outputList = specimenMapper
             .removeSurplusObservationComments(ehrExtract, observationComments);
@@ -132,8 +132,8 @@ public class SpecimenMapperTest {
         assertThat(outputList).isEqualTo(observationComments);
     }
 
-    private List<Observation> getObservationComments() {
-        List<Observation> observationComments = new ArrayList<>();
+    private ArrayList<Observation> getObservationComments() {
+        var observationComments = new ArrayList<Observation>();
 
         var comment = new Observation();
         comment.setId(NARRATIVE_STATEMENT_ID);

--- a/gp2gp-translator/src/test/java/uk/nhs/adaptors/pss/translator/service/BundleMapperServiceTest.java
+++ b/gp2gp-translator/src/test/java/uk/nhs/adaptors/pss/translator/service/BundleMapperServiceTest.java
@@ -18,9 +18,9 @@ import java.util.Map;
 
 import org.hl7.fhir.dstu3.model.Bundle;
 import org.hl7.fhir.dstu3.model.DomainResource;
+import org.hl7.fhir.dstu3.model.Location;
 import org.hl7.fhir.dstu3.model.Organization;
 import org.hl7.fhir.dstu3.model.Patient;
-import org.hl7.fhir.dstu3.model.Location;
 import org.hl7.v3.RCMRIN030000UK06Message;
 import org.hl7.v3.RCMRMT030101UK04AgentDirectory;
 import org.hl7.v3.RCMRMT030101UK04EhrExtract;
@@ -148,6 +148,7 @@ public class BundleMapperServiceTest {
     }
 
     @Test
+    @SuppressWarnings("unchecked")
     public void testAllMappersHaveBeenUsed() throws BundleMappingException {
         final RCMRIN030000UK06Message xml = unmarshallCodeElement(STRUCTURED_RECORD_XML);
         Bundle bundle = bundleMapperService.mapToBundle(xml, LOSING_ODS_CODE, new ArrayList<>());
@@ -187,8 +188,7 @@ public class BundleMapperServiceTest {
             anyString());
         verify(allergyIntoleranceMapper).mapResources(any(RCMRMT030101UK04EhrExtract.class), any(Patient.class), anyList(), anyString());
         verify(diagnosticReportMapper).mapResources(
-            any(RCMRMT030101UK04EhrExtract.class), any(Patient.class), anyList(), any(String.class)
-        );
+            any(RCMRMT030101UK04EhrExtract.class), any(Patient.class), anyList(), any(String.class), any(ArrayList.class));
         verify(specimenMapper).mapSpecimen(any(RCMRMT030101UK04EhrExtract.class), anyList(), any(Patient.class), anyString());
         verify(diagnosticReportMapper).handleChildObservationComments(any(RCMRMT030101UK04EhrExtract.class), anyList());
         verify(specimenCompoundsMapper).handleSpecimenChildComponents(


### PR DESCRIPTION
## What

Having Mapping out the TPP and current adaptor behaviour, we have identified the differences between the mapping.  Discussed this further and it appears that the behaviour should be:

* If a comment note narrative statement appears at the a diagnostic report level, then this should be referenced to in the result references.  This observation is determined to be the filing comment
* If there is no comment not narrative statement at diagnostic report level, the it could appear in one or more nested “battery” results.  In this case a new observation comment should be created to be used as the filing comment and referenced to in the results references.  This observation filing comment should not contain a comment text field.

This is a breaking change as it will be adding new references to the `result` references in a `DiagnosticReport` and the consuming system will need to handle this.

## Why

As part of the comparisons under ["Compare Investigations data across TPP and the PS Adaptor, identifying all bugs and issues with an SME"](https://nhse-dsic.atlassian.net/browse/NIAD-2666), it has been identified that filing comments are being linked to the TGH rather than the Diagnostic Report, so is the issue that they should be linked to the Report.  Under GP Connect rules this would present a filed report as un-filed.

## Type of change

Please delete options that are not relevant.

- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:

- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have updated the [Changelog](/CHANGELOG.md) with details of my change in the UNRELEASED section if this change will affect end users
- [ ] A corresponding change has been made to the [Mapping Documentation repository][mapping-docs]

[mapping-docs]: https://github.com/NHSDigital/patient-switching-adaptors-mapping-documentation