### PR TITLE
Use gradle command instead of wrapper inside of Docker

### DIFF
--- a/docker/db-migration/Dockerfile
+++ b/docker/db-migration/Dockerfile
@@ -6,4 +6,4 @@ COPY --chown=gradle:gradle ./config /home/gradle/service/config
 COPY --chown=gradle:gradle ./db-connector /home/gradle/service/db-connector
 WORKDIR /home/gradle/service/db-connector
 
-ENTRYPOINT ["./gradlew", "update"]
+ENTRYPOINT ["gradle", "update"]

--- a/docker/gp2gp-translator/Dockerfile
+++ b/docker/gp2gp-translator/Dockerfile
@@ -7,7 +7,7 @@ COPY --chown=gradle:gradle ./schema /home/gradle/service/schema
 COPY --chown=gradle:gradle ./config /home/gradle/service/config
 
 WORKDIR /home/gradle/service/gp2gp-translator
-RUN ./gradlew --build-cache bootJar
+RUN gradle --build-cache bootJar
 
 FROM eclipse-temurin:17-jre-jammy
 

--- a/docker/gpc-facade/Dockerfile
+++ b/docker/gpc-facade/Dockerfile
@@ -6,7 +6,7 @@ COPY --chown=gradle:gradle ./db-connector /home/gradle/service/db-connector
 COPY --chown=gradle:gradle ./config /home/gradle/service/config
 
 WORKDIR /home/gradle/service/gpc-api-facade
-RUN ./gradlew --build-cache bootJar
+RUN gradle --build-cache bootJar
 
 FROM eclipse-temurin:17-jre-jammy
 


### PR DESCRIPTION
These docker images already have the correct version of gradle installed.

Using the wrapper means that another copy of gradle gets downloaded which is wasteful given we already have the correct version available.

This should speed up the building of these images.

## Type of change

- [x] Internal change (non-breaking change with no effect on the functionality affecting end users)

## Checklist:

- [x] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I have updated the [Changelog](/CHANGELOG.md) with details of my change in the UNRELEASED section if this change will affect end users
- [ ] A corresponding change has been made to the [Mapping Documentation repository][mapping-docs]

[mapping-docs]: https://github.com/NHSDigital/patient-switching-adaptors-mapping-documentation