### PR TITLE
Set status to 'unknown' for filing comments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -130,9 +130,15 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
   </details>
 
-* When Filing comment `NarrativeStatements` are located within the `BATTERY` of a `Filed Report` and not located
-  at `DiagnosticReport` level now creates a new filing comment `Observation` and reference this in the results
-  of the parent `DiagnosticReport`.
+* When a `CommentType: USER COMMENT` `NarrativeStatement` is located within the `BATTERY` of a `Filed Report`,
+  the adaptor now generates a new [filing comment][filing-comment] `Observation` and [references this][diagnostic-report-result]
+  in the result property of the parent `DiagnosticReport`.
+  This change makes the adaptor more closely resemble the GP Connect specification for DiagnosticReport and filing
+  comments.
+  The generated `Observation` filing comment will have the `status` of `unknown`.
+
+[filing-comment]: https://developer.nhs.uk/apis/gpconnect-1-6-0/accessrecord_structured_development_observation_filingComments.html
+[diagnostic-report-result]: https://developer.nhs.uk/apis/gpconnect-1-6-0/accessrecord_structured_development_DiagnosticReport.html#result
 
 ## [2.0.0] - 2024-04-12
 

--- a/gp2gp-translator/src/integrationTest/resources/e2e-mapping/output-json/PWTP9-output.json
+++ b/gp2gp-translator/src/integrationTest/resources/e2e-mapping/output-json/PWTP9-output.json
@@ -15178,7 +15178,7 @@
         "system": "https://PSSAdaptor/B83002",
         "value": "00000000-0000-0000-0000-000000000005"
       } ],
-      "status": "final",
+      "status": "unknown",
       "code": {
         "coding": [ {
           "system": "http://snomed.info/sct",
@@ -15209,7 +15209,7 @@
         "system": "https://PSSAdaptor/B83002",
         "value": "00000000-0000-0000-0000-000000000006"
       } ],
-      "status": "final",
+      "status": "unknown",
       "code": {
         "coding": [ {
           "system": "http://snomed.info/sct",
@@ -15240,7 +15240,7 @@
         "system": "https://PSSAdaptor/B83002",
         "value": "00000000-0000-0000-0000-000000000007"
       } ],
-      "status": "final",
+      "status": "unknown",
       "code": {
         "coding": [ {
           "system": "http://snomed.info/sct",
@@ -15271,7 +15271,7 @@
         "system": "https://PSSAdaptor/B83002",
         "value": "00000000-0000-0000-0000-000000000008"
       } ],
-      "status": "final",
+      "status": "unknown",
       "code": {
         "coding": [ {
           "system": "http://snomed.info/sct",

--- a/gp2gp-translator/src/main/java/uk/nhs/adaptors/pss/translator/mapper/diagnosticreport/DiagnosticReportMapper.java
+++ b/gp2gp-translator/src/main/java/uk/nhs/adaptors/pss/translator/mapper/diagnosticreport/DiagnosticReportMapper.java
@@ -2,6 +2,7 @@ package uk.nhs.adaptors.pss.translator.mapper.diagnosticreport;
 
 import static java.util.stream.Collectors.toCollection;
 
+import static org.hl7.fhir.dstu3.model.Observation.ObservationStatus.UNKNOWN;
 import static uk.nhs.adaptors.pss.translator.util.CompoundStatementResourceExtractors.extractAllCompoundStatements;
 import static uk.nhs.adaptors.pss.translator.util.DateFormatUtil.parseToInstantType;
 import static uk.nhs.adaptors.pss.translator.util.ResourceUtil.buildIdentifier;
@@ -199,6 +200,7 @@ public class DiagnosticReportMapper extends AbstractMapper<DiagnosticReport> {
         filingCommentObservation.setId(filingCommentObservationId);
         filingCommentObservation.getIdentifierFirstRep().setValue(filingCommentObservationId);
         filingCommentObservation.setComment(null);
+        filingCommentObservation.setStatus(UNKNOWN);
 
         return filingCommentObservation;
     }

--- a/gp2gp-translator/src/test/java/uk/nhs/adaptors/pss/translator/mapper/diagnosticreport/DiagnosticReportMapperTest.java
+++ b/gp2gp-translator/src/test/java/uk/nhs/adaptors/pss/translator/mapper/diagnosticreport/DiagnosticReportMapperTest.java
@@ -29,6 +29,7 @@ import static org.mockito.Mockito.when;
 import lombok.SneakyThrows;
 import uk.nhs.adaptors.pss.translator.service.IdGeneratorService;
 import uk.nhs.adaptors.pss.translator.util.DateFormatUtil;
+import static org.hl7.fhir.dstu3.model.Observation.ObservationStatus.UNKNOWN;
 
 @ExtendWith(MockitoExtension.class)
 public class DiagnosticReportMapperTest {
@@ -506,7 +507,8 @@ TEST COMMENT
                         .isEqualTo(NEW_OBSERVATION_ID),
                 () -> assertThat(observationComments.get(1).getEffectiveDateTimeType().getValueAsString())
                         .isEqualTo("2024-01-01"),
-                () -> assertThat(observationComments.get(1).getComment()).isNull()
+                () -> assertThat(observationComments.get(1).getComment()).isNull(),
+                () -> assertThat(observationComments.get(1).getStatus()).isEqualTo(UNKNOWN)
         );
     }
 


### PR DESCRIPTION
## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [x] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I have updated the [Changelog](/CHANGELOG.md) with details of my change in the UNRELEASED section if this change will affect end users
- [ ] A corresponding change has been made to the [Mapping Documentation repository][mapping-docs]

[mapping-docs]: https://github.com/NHSDigital/patient-switching-adaptors-mapping-documentation