### PR TITLE
NIAD-3087: migration status

### DIFF
--- a/gp2gp-translator/src/main/java/uk/nhs/adaptors/pss/translator/service/FailedProcessHandlingService.java
+++ b/gp2gp-translator/src/main/java/uk/nhs/adaptors/pss/translator/service/FailedProcessHandlingService.java
@@ -80,6 +80,8 @@ public class FailedProcessHandlingService {
     public boolean hasProcessFailed(String conversationId) {
         MigrationStatus migrationStatus = getMigrationStatus(conversationId);
 
+        LOGGER.info("Migration status is: ", migrationStatus);
+
         return FAILED_MIGRATION_STATUSES.contains(migrationStatus);
     }
 


### PR DESCRIPTION
## What

The logging of message attachments migration status.

## Why

There are multiple status messages for failure hence it would be useful to know what status a particular message has.

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Internal change (non-breaking change with no effect on the functionality affecting end users)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:

- [x] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I have updated the [Changelog](/CHANGELOG.md) with details of my change in the UNRELEASED section if this change will affect end users
- [ ] A corresponding change has been made to the [Mapping Documentation repository][mapping-docs]

[mapping-docs]: https://github.com/NHSDigital/patient-switching-adaptors-mapping-documentation