### PR TITLE
Refactor QuanityMapper and MeasurementUtils to be fully static

### DIFF
--- a/gp2gp-translator/src/main/java/uk/nhs/adaptors/pss/translator/mapper/QuantityMapper.java
+++ b/gp2gp-translator/src/main/java/uk/nhs/adaptors/pss/translator/mapper/QuantityMapper.java
@@ -1,6 +1,5 @@
 package uk.nhs.adaptors.pss.translator.mapper;
 
-import lombok.RequiredArgsConstructor;
 import org.apache.commons.lang3.StringUtils;
 import org.hl7.fhir.dstu3.model.Quantity;
 import org.hl7.fhir.dstu3.model.Quantity.QuantityComparator;
@@ -8,20 +7,17 @@ import org.hl7.v3.IVLPQ;
 import org.hl7.v3.PQ;
 import org.hl7.v3.PQInc;
 import org.hl7.v3.PQR;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.stereotype.Service;
+
 import uk.nhs.adaptors.pss.translator.util.MeasurementUnitsUtil;
 
 import java.math.BigDecimal;
 import java.math.RoundingMode;
 import java.util.List;
 
-@Service
-@RequiredArgsConstructor(onConstructor = @__(@Autowired))
 public class QuantityMapper {
     private static final String UNIT_SYSTEM = "http://unitsofmeasure.org";
 
-    public Quantity mapValueQuantity(IVLPQ value) {
+    public static Quantity mapValueQuantity(IVLPQ value) {
         Quantity quantity = new Quantity();
 
         if (value.getHigh() != null) {
@@ -33,7 +29,7 @@ public class QuantityMapper {
         return quantity;
     }
 
-    public Quantity mapValueQuantity(PQ value) {
+    public static Quantity mapValueQuantity(PQ value) {
         Quantity quantity = new Quantity();
 
         setQuantityValueAndUnit(quantity, value.getValue(), value.getUnit(), value.getTranslation());
@@ -41,7 +37,7 @@ public class QuantityMapper {
         return quantity;
     }
 
-    public Quantity mapReferenceRangeQuantity(IVLPQ value) {
+    public static Quantity mapReferenceRangeQuantity(IVLPQ value) {
         Quantity quantity = new Quantity();
 
         if (value.getHigh() != null) {
@@ -55,7 +51,7 @@ public class QuantityMapper {
         return quantity;
     }
 
-    private void setUnit(Quantity quantity, String unit, List<PQR> translation) {
+    private static void setUnit(Quantity quantity, String unit, List<PQR> translation) {
         if (StringUtils.isNotBlank(unit)) {
             if (translation != null && !translation.isEmpty()) {
                 //If the translation is found in the MeasurementUnitsMap then add unit using this.
@@ -77,11 +73,11 @@ public class QuantityMapper {
         }
     }
 
-    private boolean foundMeasurementMatch(String unit) {
+    private static boolean foundMeasurementMatch(String unit) {
         return MeasurementUnitsUtil.getMeasurementUnitsMap().containsKey(unit);
     }
 
-    private void setQuantityWithHighComparator(Quantity quantity, PQInc high) {
+    private static void setQuantityWithHighComparator(Quantity quantity, PQInc high) {
         if (high.isInclusive()) {
             quantity.setComparator(QuantityComparator.LESS_OR_EQUAL);
         } else {
@@ -91,7 +87,7 @@ public class QuantityMapper {
         setQuantityValueAndUnit(quantity, high.getValue(), high.getUnit(), high.getTranslation());
     }
 
-    private void setQuantityWithLowComparator(Quantity quantity, PQInc low) {
+    private static void setQuantityWithLowComparator(Quantity quantity, PQInc low) {
         if (low.isInclusive()) {
             quantity.setComparator(QuantityComparator.GREATER_OR_EQUAL);
         } else {
@@ -101,7 +97,7 @@ public class QuantityMapper {
         setQuantityValueAndUnit(quantity, low.getValue(), low.getUnit(), low.getTranslation());
     }
 
-    private void setQuantityValueAndUnit(Quantity quantity, String value, String unit, List<PQR> translation) {
+    private static void setQuantityValueAndUnit(Quantity quantity, String value, String unit, List<PQR> translation) {
         setUnit(quantity, unit, translation);
         var decimalPlaceIndex = value.indexOf(".");
         var decimalPlaceCount = 0;

--- a/gp2gp-translator/src/main/java/uk/nhs/adaptors/pss/translator/util/MeasurementUnitsUtil.java
+++ b/gp2gp-translator/src/main/java/uk/nhs/adaptors/pss/translator/util/MeasurementUnitsUtil.java
@@ -1,20 +1,13 @@
 package uk.nhs.adaptors.pss.translator.util;
 
-
-import org.springframework.stereotype.Component;
-
-import javax.annotation.PostConstruct;
 import java.util.HashMap;
 import java.util.Map;
 
-@Component
 public final class MeasurementUnitsUtil {
 
-    private static final Map<String, String> UNITS = new HashMap<>();
-
-    @PostConstruct
-    @SuppressWarnings("checkstyle:methodlength")
-    private void createMeasurementUnits() {
+    private static final Map<String, String> UNITS;
+    static {
+        UNITS = new HashMap<>();
         UNITS.put("%", "percent");
         UNITS.put("%/100{WBC}", "percent / 100 WBC");
         UNITS.put("%{0to3Hours}", "percent 0to3Hours");

--- a/gp2gp-translator/src/main/java/uk/nhs/adaptors/pss/translator/util/ObservationUtil.java
+++ b/gp2gp-translator/src/main/java/uk/nhs/adaptors/pss/translator/util/ObservationUtil.java
@@ -32,19 +32,17 @@ import uk.nhs.adaptors.pss.translator.mapper.QuantityMapper;
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
 public class ObservationUtil {
 
-    private static final String VALUE_QUANTITY_EXTENSION = "https://fhir.hl7.org.uk/STU3/StructureDefinition/Extension-CareConnect"
-        + "-ValueApproximation-1";
+    private static final String VALUE_QUANTITY_EXTENSION =
+        "https://fhir.hl7.org.uk/STU3/StructureDefinition/Extension-CareConnect-ValueApproximation-1";
     private static final String CODING_SYSTEM = "http://hl7.org/fhir/v2/0078";
-
-    private static final QuantityMapper QUANTITY_MAPPER = new QuantityMapper();
 
     public static Quantity getValueQuantity(Object value, CV uncertaintyCode) {
         if (isValidValueQuantity(value)) {
             Quantity valueQuantity;
             if (value instanceof PQ pqValue) {
-                valueQuantity = QUANTITY_MAPPER.mapValueQuantity(pqValue);
+                valueQuantity = QuantityMapper.mapValueQuantity(pqValue);
             } else {
-                valueQuantity = QUANTITY_MAPPER.mapValueQuantity((IVLPQ) value);
+                valueQuantity = QuantityMapper.mapValueQuantity((IVLPQ) value);
             }
 
             if (uncertaintyCode != null) {
@@ -87,8 +85,9 @@ public class ObservationUtil {
             var referenceRangeComponent = new Observation.ObservationReferenceRangeComponent();
             referenceRangeComponent.setText(referenceRange.getReferenceInterpretationRange().getText());
 
-            var quantity = QUANTITY_MAPPER.mapReferenceRangeQuantity(
-                                                    referenceRange.getReferenceInterpretationRange().getValue());
+            var quantity = QuantityMapper.mapReferenceRangeQuantity(
+                referenceRange.getReferenceInterpretationRange().getValue()
+            );
 
             var referenceInterpretationRange = referenceRange.getReferenceInterpretationRange();
             if (referenceInterpretationRangeHasValue(referenceInterpretationRange) && referenceInterpretationRange.getValue() != null) {

--- a/gp2gp-translator/src/test/java/uk/nhs/adaptors/pss/translator/mapper/BloodPressureMapperTest.java
+++ b/gp2gp-translator/src/test/java/uk/nhs/adaptors/pss/translator/mapper/BloodPressureMapperTest.java
@@ -9,8 +9,6 @@ import static org.springframework.util.ResourceUtils.getFile;
 
 import static uk.nhs.adaptors.pss.translator.util.XmlUnmarshallUtil.unmarshallFile;
 
-import java.lang.reflect.InvocationTargetException;
-import java.lang.reflect.Method;
 import java.math.BigDecimal;
 import java.util.List;
 
@@ -22,7 +20,6 @@ import org.hl7.fhir.dstu3.model.Observation;
 import org.hl7.fhir.dstu3.model.Patient;
 import org.hl7.fhir.dstu3.model.Period;
 import org.hl7.v3.RCMRMT030101UK04EhrExtract;
-import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -33,7 +30,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import lombok.SneakyThrows;
 import uk.nhs.adaptors.pss.translator.util.DateFormatUtil;
 import uk.nhs.adaptors.pss.translator.util.DegradedCodeableConcepts;
-import uk.nhs.adaptors.pss.translator.util.MeasurementUnitsUtil;
+
 import static uk.nhs.adaptors.common.util.CodeableConceptUtils.createCodeableConcept;
 
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
@@ -76,19 +73,6 @@ public class BloodPressureMapperTest {
 
     @InjectMocks
     private BloodPressureMapper bloodPressureMapper;
-
-    private static final MeasurementUnitsUtil MEASUREMENT_UNITS_UTIL = new MeasurementUnitsUtil();
-
-    private Method getCreateMeasurementUnitsMethod() throws NoSuchMethodException {
-        Method method = MeasurementUnitsUtil.class.getDeclaredMethod("createMeasurementUnits");
-        method.setAccessible(true);
-        return method;
-    }
-
-    @BeforeAll
-    public void createMeasurementUnits() throws NoSuchMethodException, InvocationTargetException, IllegalAccessException {
-        getCreateMeasurementUnitsMethod().invoke(MEASUREMENT_UNITS_UTIL);
-    }
 
     @SneakyThrows
     private RCMRMT030101UK04EhrExtract unmarshallEhrExtractElement(String fileName) {

--- a/gp2gp-translator/src/test/java/uk/nhs/adaptors/pss/translator/mapper/ObservationMapperTest.java
+++ b/gp2gp-translator/src/test/java/uk/nhs/adaptors/pss/translator/mapper/ObservationMapperTest.java
@@ -8,8 +8,6 @@ import static org.springframework.util.ResourceUtils.getFile;
 
 import static uk.nhs.adaptors.pss.translator.util.XmlUnmarshallUtil.unmarshallFile;
 
-import java.lang.reflect.InvocationTargetException;
-import java.lang.reflect.Method;
 import java.math.BigDecimal;
 import java.util.List;
 
@@ -25,7 +23,6 @@ import org.hl7.fhir.dstu3.model.Quantity;
 import org.hl7.fhir.dstu3.model.StringType;
 import org.hl7.v3.RCMRMT030101UK04EhrExtract;
 
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
@@ -35,7 +32,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import lombok.SneakyThrows;
 import uk.nhs.adaptors.pss.translator.util.DatabaseImmunizationChecker;
 import uk.nhs.adaptors.pss.translator.util.DegradedCodeableConcepts;
-import uk.nhs.adaptors.pss.translator.util.MeasurementUnitsUtil;
+
 import static uk.nhs.adaptors.common.util.CodeableConceptUtils.createCodeableConcept;
 
 @ExtendWith(MockitoExtension.class)
@@ -82,21 +79,6 @@ public class ObservationMapperTest {
 
     @InjectMocks
     private ObservationMapper observationMapper;
-
-    private static final MeasurementUnitsUtil MEASUREMENT_UNITS_UTIL = new MeasurementUnitsUtil();
-
-    private Method getCreateMeasurementUnitsMethod() throws NoSuchMethodException {
-        Method method = MeasurementUnitsUtil.class.getDeclaredMethod("createMeasurementUnits");
-        method.setAccessible(true);
-        return method;
-    }
-
-    @BeforeEach
-    public void createMeasurementUnits() throws NoSuchMethodException, InvocationTargetException, IllegalAccessException {
-        getCreateMeasurementUnitsMethod().invoke(MEASUREMENT_UNITS_UTIL);
-    }
-
-
 
     @Test
     public void mapObservationWithValidData() {

--- a/gp2gp-translator/src/test/java/uk/nhs/adaptors/pss/translator/mapper/QuantityMapperTest.java
+++ b/gp2gp-translator/src/test/java/uk/nhs/adaptors/pss/translator/mapper/QuantityMapperTest.java
@@ -10,42 +10,22 @@ import org.hl7.fhir.dstu3.model.Quantity.QuantityComparator;
 import org.hl7.v3.IVLPQ;
 import org.hl7.v3.PQ;
 import org.hl7.v3.RCMRMT030101UK04ObservationStatement;
-import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 
 import lombok.SneakyThrows;
 import org.junit.jupiter.api.TestInstance;
-import uk.nhs.adaptors.pss.translator.util.MeasurementUnitsUtil;
-
-import java.lang.reflect.InvocationTargetException;
-import java.lang.reflect.Method;
 
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
 public class QuantityMapperTest {
     private static final String XML_RESOURCES_BASE = "xml/Quantity/";
     private static final String UNIT_SYSTEM = "http://unitsofmeasure.org";
 
-    private final QuantityMapper quantityMapper = new QuantityMapper();
-
-    private static final MeasurementUnitsUtil MEASUREMENT_UNITS_UTIL = new MeasurementUnitsUtil();
-
-    private Method getCreateMeasurementUnitsMethod() throws NoSuchMethodException {
-        Method method = MeasurementUnitsUtil.class.getDeclaredMethod("createMeasurementUnits");
-        method.setAccessible(true);
-        return method;
-    }
-
-    @BeforeAll
-    public void createMeasurementUnits() throws NoSuchMethodException, InvocationTargetException, IllegalAccessException {
-        getCreateMeasurementUnitsMethod().invoke(MEASUREMENT_UNITS_UTIL);
-    }
-
     @Test
     public void mapQuantityNoTypeStandardUnit() {
         var observationStatement = unmarshallObservationStatement("no_type_standard_unit.xml");
         var value = observationStatement.getValue();
 
-        Quantity quantity = quantityMapper.mapValueQuantity((PQ) value);
+        Quantity quantity = QuantityMapper.mapValueQuantity((PQ) value);
 
         assertQuantity(quantity, "100", "kilogram per square meter", UNIT_SYSTEM, "kg/m2", null);
     }
@@ -55,7 +35,7 @@ public class QuantityMapperTest {
         var observationStatement = unmarshallObservationStatement("no_type_arbitrary_unit.xml");
         var value = observationStatement.getValue();
 
-        Quantity quantity = quantityMapper.mapValueQuantity((PQ) value);
+        Quantity quantity = QuantityMapper.mapValueQuantity((PQ) value);
 
         assertQuantity(quantity, "100", "kua/L", null, null, null);
     }
@@ -64,7 +44,7 @@ public class QuantityMapperTest {
     public void mapQuantityPqStandardUnit() {
         var value = unmarshallValueElementForPQ("pq_standard_unit.xml");
 
-        Quantity quantity = quantityMapper.mapValueQuantity(value);
+        Quantity quantity = QuantityMapper.mapValueQuantity(value);
 
         assertQuantity(quantity, "100", "kilogram per square meter", UNIT_SYSTEM, "kg/m2", null);
     }
@@ -73,7 +53,7 @@ public class QuantityMapperTest {
     public void mapQuantityPqArbitraryUnit() {
         var value = unmarshallValueElementForPQ("pq_arbitrary_unit.xml");
 
-        Quantity quantity = quantityMapper.mapValueQuantity(value);
+        Quantity quantity = QuantityMapper.mapValueQuantity(value);
 
         assertQuantity(quantity, "100", "kua/L", null, null, null);
     }
@@ -82,7 +62,7 @@ public class QuantityMapperTest {
     public void mapQuantityIvlPqHighStandardUnit() {
         var value = unmarshallValueElementForIVLPQ("ivlpq_high_standard_unit.xml");
 
-        Quantity quantity = quantityMapper.mapValueQuantity(value);
+        Quantity quantity = QuantityMapper.mapValueQuantity(value);
 
         assertQuantity(quantity, "100", "kilogram per square meter", UNIT_SYSTEM, "kg/m2", QuantityComparator.LESS_THAN);
     }
@@ -91,7 +71,7 @@ public class QuantityMapperTest {
     public void mapQuantityIvlPqHighArbitraryUnit() {
         var value = unmarshallValueElementForIVLPQ("ivlpq_high_arbitrary_unit.xml");
 
-        Quantity quantity = quantityMapper.mapValueQuantity(value);
+        Quantity quantity = QuantityMapper.mapValueQuantity(value);
 
         assertQuantity(quantity, "100", "kua/L", null, null, QuantityComparator.LESS_THAN);
     }
@@ -100,7 +80,7 @@ public class QuantityMapperTest {
     public void mapQuantityIvlPqLowStandardUnit() {
         var value = unmarshallValueElementForIVLPQ("ivlpq_low_standard_unit.xml");
 
-        Quantity quantity = quantityMapper.mapValueQuantity(value);
+        Quantity quantity = QuantityMapper.mapValueQuantity(value);
 
         assertQuantity(quantity, "100", "kilogram per square meter", UNIT_SYSTEM, "kg/m2", QuantityComparator.GREATER_THAN);
     }
@@ -109,7 +89,7 @@ public class QuantityMapperTest {
     public void mapQuantityIvlPqLowArbitraryUnit() {
         var value = unmarshallValueElementForIVLPQ("ivlpq_low_arbitrary_unit.xml");
 
-        Quantity quantity = quantityMapper.mapValueQuantity(value);
+        Quantity quantity = QuantityMapper.mapValueQuantity(value);
 
         assertQuantity(quantity, "100", "kua/L", null, null, QuantityComparator.GREATER_THAN);
     }
@@ -118,7 +98,7 @@ public class QuantityMapperTest {
     public void mapQuantityIvlPqHighInclusive() {
         var value = unmarshallValueElementForIVLPQ("ivlpq_high_inclusive.xml");
 
-        Quantity quantity = quantityMapper.mapValueQuantity(value);
+        Quantity quantity = QuantityMapper.mapValueQuantity(value);
 
         assertQuantity(quantity, "100", "kilogram per square meter", UNIT_SYSTEM, "kg/m2", QuantityComparator.LESS_OR_EQUAL);
     }
@@ -127,7 +107,7 @@ public class QuantityMapperTest {
     public void mapQuantityIvlPqHighExclusive() {
         var value = unmarshallValueElementForIVLPQ("ivlpq_high_exclusive.xml");
 
-        Quantity quantity = quantityMapper.mapValueQuantity(value);
+        Quantity quantity = QuantityMapper.mapValueQuantity(value);
 
         assertQuantity(quantity, "100", "kilogram per square meter", UNIT_SYSTEM, "kg/m2", QuantityComparator.LESS_THAN);
     }
@@ -136,7 +116,7 @@ public class QuantityMapperTest {
     public void mapQuantityIvlPqLowInclusive() {
         var value = unmarshallValueElementForIVLPQ("ivlpq_low_inclusive.xml");
 
-        Quantity quantity = quantityMapper.mapValueQuantity(value);
+        Quantity quantity = QuantityMapper.mapValueQuantity(value);
 
         assertQuantity(quantity, "100", "kilogram per square meter", UNIT_SYSTEM, "kg/m2", QuantityComparator.GREATER_OR_EQUAL);
     }
@@ -145,7 +125,7 @@ public class QuantityMapperTest {
     public void mapQuantityIvlPqLowExclusive() {
         var value = unmarshallValueElementForIVLPQ("ivlpq_low_exclusive.xml");
 
-        Quantity quantity = quantityMapper.mapValueQuantity(value);
+        Quantity quantity = QuantityMapper.mapValueQuantity(value);
 
         assertQuantity(quantity, "100", "kilogram per square meter", UNIT_SYSTEM, "kg/m2", QuantityComparator.GREATER_THAN);
     }
@@ -155,7 +135,7 @@ public class QuantityMapperTest {
         var observationStatement = unmarshallObservationStatement("no_type_no_unit.xml");
         var value = observationStatement.getValue();
 
-        Quantity quantity = quantityMapper.mapValueQuantity((PQ) value);
+        Quantity quantity = QuantityMapper.mapValueQuantity((PQ) value);
 
         assertQuantity(quantity, "100", "1", UNIT_SYSTEM, "1", null);
     }
@@ -164,7 +144,7 @@ public class QuantityMapperTest {
     public void mapQuantityPqNoUnit() {
         var value = unmarshallValueElementForPQ("pq_no_unit.xml");
 
-        Quantity quantity = quantityMapper.mapValueQuantity(value);
+        Quantity quantity = QuantityMapper.mapValueQuantity(value);
 
         assertQuantity(quantity, "100", "1", UNIT_SYSTEM, "1", null);
     }
@@ -173,7 +153,7 @@ public class QuantityMapperTest {
     public void mapQuantityIvlPqNoUnit() {
         var value = unmarshallValueElementForIVLPQ("ivlpq_no_unit.xml");
 
-        Quantity quantity = quantityMapper.mapValueQuantity(value);
+        Quantity quantity = QuantityMapper.mapValueQuantity(value);
 
         assertQuantity(quantity, "100", null, null, null, QuantityComparator.LESS_THAN);
     }
@@ -182,7 +162,7 @@ public class QuantityMapperTest {
     public void mapQuantityUnitIsUnity() {
         var value = unmarshallValueElementForPQ("unit_is_unity.xml");
 
-        Quantity quantity = quantityMapper.mapValueQuantity(value);
+        Quantity quantity = QuantityMapper.mapValueQuantity(value);
 
         assertQuantity(quantity, "100", "1", UNIT_SYSTEM, "1", null);
     }
@@ -192,8 +172,8 @@ public class QuantityMapperTest {
         var uppercaseValue = unmarshallValueElementForPQ("pq_arbitrary_unit_uppercase_s.xml");
         var lowercaseValue = unmarshallValueElementForPQ("pq_arbitrary_unit_lowercase_s.xml");
 
-        Quantity uppercaseQuantity = quantityMapper.mapValueQuantity(uppercaseValue);
-        Quantity lowercaseQuantity = quantityMapper.mapValueQuantity(lowercaseValue);
+        Quantity uppercaseQuantity = QuantityMapper.mapValueQuantity(uppercaseValue);
+        Quantity lowercaseQuantity = QuantityMapper.mapValueQuantity(lowercaseValue);
 
         assertQuantity(uppercaseQuantity, "10", "Siemens", null, "S", null);
         assertQuantity(lowercaseQuantity, "10", "second", null, "s", null);

--- a/gp2gp-translator/src/test/java/uk/nhs/adaptors/pss/translator/util/ObservationUtilTest.java
+++ b/gp2gp-translator/src/test/java/uk/nhs/adaptors/pss/translator/util/ObservationUtilTest.java
@@ -6,7 +6,6 @@ import static org.springframework.util.ResourceUtils.getFile;
 import static uk.nhs.adaptors.pss.translator.util.XmlUnmarshallUtil.unmarshallFile;
 
 import java.math.BigDecimal;
-import java.util.Map;
 
 import org.apache.commons.lang3.StringUtils;
 import org.hl7.fhir.dstu3.model.CodeableConcept;
@@ -17,8 +16,7 @@ import org.hl7.v3.RCMRMT030101UK04EhrExtract;
 import org.hl7.v3.RCMRMT030101UKEhrComposition;
 import org.hl7.v3.RCMRMT030101UKObservationStatement;
 import org.junit.jupiter.api.Test;
-import org.mockito.MockedStatic;
-import org.mockito.Mockito;
+
 
 import lombok.SneakyThrows;
 
@@ -43,9 +41,6 @@ public class ObservationUtilTest {
     private static final Double REFERENCE_RANGE_LOW_VALUE_DECIMAL = 10.5;
     private static final Double REFERENCE_RANGE_HIGH_VALUE_DECIMAL = 12.2;
 
-    private static final Map<String, String> STUB_MEASUREMENT_UNIT_MAP = Map.of(
-        "ml", "milliliter"
-    );
 
     @SneakyThrows
     private RCMRMT030101UK04EhrExtract unmarshallEhrExtractElement(String fileName) {
@@ -71,47 +66,29 @@ public class ObservationUtilTest {
     @Test
     public void mapValueQuantityUsingPqQuantity() {
 
-        MockedStatic<MeasurementUnitsUtil> mockedMeasurementUnitUtil = Mockito.mockStatic(MeasurementUnitsUtil.class);
+        var ehrExtract = unmarshallEhrExtractElement("pq_value_quantity_observation_example.xml");
+        var observationStatement = getObservationStatementFromEhrExtract(ehrExtract);
 
-        try {
+        var quantity = ObservationUtil.getValueQuantity(
+            observationStatement.getValue(),
+            observationStatement.getUncertaintyCode()
+        );
 
-            mockedMeasurementUnitUtil.when(MeasurementUnitsUtil::getMeasurementUnitsMap).thenReturn(STUB_MEASUREMENT_UNIT_MAP);
-
-            var ehrExtract = unmarshallEhrExtractElement(
-                "pq_value_quantity_observation_example.xml");
-            var observationStatement = getObservationStatementFromEhrExtract(ehrExtract);
-
-            var quantity = ObservationUtil.getValueQuantity(observationStatement.getValue(),
-                observationStatement.getUncertaintyCode());
-
-            assertThat(quantity.getValue()).isEqualTo(PQ_QUANTITY_VALUE);
-            assertThat(quantity.getUnit()).isEqualTo(QUANTITY_UNIT);
-        } finally {
-            mockedMeasurementUnitUtil.close();
-        }
+        assertThat(quantity.getValue()).isEqualTo(PQ_QUANTITY_VALUE);
+        assertThat(quantity.getUnit()).isEqualTo(QUANTITY_UNIT);
     }
 
     @Test
     public void mapValueQuantityUsingIvlPqQuantity() {
 
-        MockedStatic<MeasurementUnitsUtil> mockedMeasurementUnitUtil = Mockito.mockStatic(MeasurementUnitsUtil.class);
+        var ehrExtract = unmarshallEhrExtractElement("ivl_pq_value_quantity_observation_example.xml");
+        var observationStatement = getObservationStatementFromEhrExtract(ehrExtract);
 
-        try {
+        var quantity = ObservationUtil.getValueQuantity(observationStatement.getValue(),
+            observationStatement.getUncertaintyCode());
 
-            mockedMeasurementUnitUtil.when(MeasurementUnitsUtil::getMeasurementUnitsMap).thenReturn(STUB_MEASUREMENT_UNIT_MAP);
-
-            var ehrExtract = unmarshallEhrExtractElement(
-                "ivl_pq_value_quantity_observation_example.xml");
-            var observationStatement = getObservationStatementFromEhrExtract(ehrExtract);
-
-            var quantity = ObservationUtil.getValueQuantity(observationStatement.getValue(),
-                observationStatement.getUncertaintyCode());
-
-            assertThat(quantity.getValue()).isEqualTo(IVL_PQ_QUANTITY_VALUE);
-            assertThat(quantity.getUnit()).isEqualTo(QUANTITY_UNIT);
-        } finally {
-            mockedMeasurementUnitUtil.close();
-        }
+        assertThat(quantity.getValue()).isEqualTo(IVL_PQ_QUANTITY_VALUE);
+        assertThat(quantity.getUnit()).isEqualTo(QUANTITY_UNIT);
     }
 
     @Test

--- a/gp2gp-translator/src/test/resources/xml/Observation/ivl_pq_value_quantity_observation_example.xml
+++ b/gp2gp-translator/src/test/resources/xml/Observation/ivl_pq_value_quantity_observation_example.xml
@@ -10,7 +10,7 @@
                             <value xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:type="IVL_PQ">
                                 <high value="200" unit="1" inclusive="false">
                                     <translation value="200">
-                                        <originalText>ml</originalText>
+                                        <originalText>mL</originalText>
                                     </translation>
                                 </high>
                             </value>

--- a/gp2gp-translator/src/test/resources/xml/Observation/pq_value_quantity_observation_example.xml
+++ b/gp2gp-translator/src/test/resources/xml/Observation/pq_value_quantity_observation_example.xml
@@ -10,7 +10,7 @@
                             <value xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:type="PQ" value="100.000"
                                    unit="1">
                                 <translation value="100">
-                                    <originalText>ml</originalText>
+                                    <originalText>mL</originalText>
                                 </translation>
                             </value>
                         </ObservationStatement>


### PR DESCRIPTION
## What

Refactor QuantityMapper and MeasurementUtils to be fully static and update unit tests accordingly

## Why

QuantityMapper and MeasurementUtils were better suited to be used as statics rather than as services and they were only being used in a static fashion.  Unit tests ontained workarounds to retrieve, change accessablity and mock responses.  This lead to messy tests to much bloat.  As the QuantityMapper and MeasurementUtils class were already tightly coupled, it made sense to refactor these accordingly

## Type of change

Please delete options that are not relevant.

- [x] Internal change (non-breaking change with no effect on the functionality affecting end users)

## Checklist:

- [x] I have performed a self-review of my code
- [ ] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes