### PR TITLE
NIAD-2911 Fix `Issued` element in SpecimenBatteryMapper to use correct date when populating 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ### Changed
 * Cron time schedule has been changed from 6h to 2h so that the timeouts can be identified earlier
+* Mapping of `issued` for `Test Group Headers` has been updated to use correct timestamps as per [GP Connect 
+Documentation](https://developer.nhs.uk/apis/gpconnect-1-5-1/accessrecord_structured_development_observation_testGroup.html#issued)
+and use author time if these values are not available.
 
 ## [2.1.0] - 2024-04-17
 ### Added

--- a/gp2gp-translator/src/integrationTest/resources/e2e-mapping/output-json/PWTP9-output.json
+++ b/gp2gp-translator/src/integrationTest/resources/e2e-mapping/output-json/PWTP9-output.json
@@ -15339,7 +15339,7 @@
         "reference": "Encounter/9A47C85C-7A97-4656-8CAF-572B29B3A591"
       },
       "effectiveDateTime": "2010-01-20T16:27:19+00:00",
-      "issued": "2010-03-26T13:52:58.000+00:00",
+      "issued": "2010-01-20T16:27:19.000+00:00",
       "performer": [ {
         "reference": "Practitioner/C5DEFBF3-0174-BC6F-182C-B777B9C6FF43"
       } ],
@@ -15417,7 +15417,7 @@
         "reference": "Encounter/B2410617-E36D-4B94-8DAF-24449E3A0297"
       },
       "effectiveDateTime": "2010-01-20T16:27:20+00:00",
-      "issued": "2010-03-26T13:53:28.000+00:00",
+      "issued": "2010-01-20T16:27:20.000+00:00",
       "performer": [ {
         "reference": "Practitioner/C5DEFBF3-0174-BC6F-182C-B777B9C6FF43"
       } ],
@@ -15495,7 +15495,7 @@
         "reference": "Encounter/DD64A383-7DC5-4E15-A0FF-20F2C4D195A5"
       },
       "effectiveDateTime": "2010-01-20T16:27:23+00:00",
-      "issued": "2010-03-26T14:04:43.000+00:00",
+      "issued": "2010-01-20T16:27:23.000+00:00",
       "performer": [ {
         "reference": "Practitioner/C5DEFBF3-0174-BC6F-182C-B777B9C6FF43"
       } ],
@@ -15578,7 +15578,7 @@
         "reference": "Encounter/6ACDA770-F676-4ECB-AE41-3BECCE24D02C"
       },
       "effectiveDateTime": "2010-01-20T10:46:22+00:00",
-      "issued": "2010-03-26T13:49:25.000+00:00",
+      "issued": "2010-01-20T10:46:22.000+00:00",
       "performer": [ {
         "reference": "Practitioner/1E473786-E7FA-785E-C911-A8D38FB56F20"
       } ],
@@ -15647,7 +15647,7 @@
         "reference": "Encounter/6ACDA770-F676-4ECB-AE41-3BECCE24D02C"
       },
       "effectiveDateTime": "2010-01-20T10:46:22+00:00",
-      "issued": "2010-03-26T13:49:25.000+00:00",
+      "issued": "2010-01-20T10:46:22.000+00:00",
       "performer": [ {
         "reference": "Practitioner/1E473786-E7FA-785E-C911-A8D38FB56F20"
       } ],
@@ -15721,7 +15721,7 @@
         "reference": "Encounter/6ACDA770-F676-4ECB-AE41-3BECCE24D02C"
       },
       "effectiveDateTime": "2010-01-20T10:46:22+00:00",
-      "issued": "2010-03-26T13:49:25.000+00:00",
+      "issued": "2010-01-20T10:46:22.000+00:00",
       "performer": [ {
         "reference": "Practitioner/1E473786-E7FA-785E-C911-A8D38FB56F20"
       } ],
@@ -15838,7 +15838,7 @@
         "reference": "Encounter/9096889B-4D56-4668-86F7-1E1C63011A46"
       },
       "effectiveDateTime": "2010-01-20T10:46:22+00:00",
-      "issued": "2010-03-26T13:45:44.000+00:00",
+      "issued": "2010-01-20T10:46:22.000+00:00",
       "performer": [ {
         "reference": "Practitioner/1E473786-E7FA-785E-C911-A8D38FB56F20"
       } ],
@@ -15930,7 +15930,7 @@
         "reference": "Encounter/9096889B-4D56-4668-86F7-1E1C63011A46"
       },
       "effectiveDateTime": "2010-01-20T10:46:22+00:00",
-      "issued": "2010-03-26T13:45:44.000+00:00",
+      "issued": "2010-01-20T10:46:22.000+00:00",
       "performer": [ {
         "reference": "Practitioner/1E473786-E7FA-785E-C911-A8D38FB56F20"
       } ],
@@ -16012,7 +16012,7 @@
         "reference": "Encounter/730C507B-32CE-4270-80BA-42F4B62BA064"
       },
       "effectiveDateTime": "2010-01-20T10:46:22+00:00",
-      "issued": "2010-02-09T12:21:06.000+00:00",
+      "issued": "2010-01-20T10:46:22.000+00:00",
       "performer": [ {
         "reference": "Practitioner/1E473786-E7FA-785E-C911-A8D38FB56F20"
       } ],
@@ -16085,7 +16085,7 @@
         "reference": "Encounter/B0696913-F11D-4EAA-8BB7-41350B296F3F"
       },
       "effectiveDateTime": "2010-01-20T16:27:23+00:00",
-      "issued": "2010-02-01T09:33:13.000+00:00",
+      "issued": "2010-01-20T16:27:23.000+00:00",
       "performer": [ {
         "reference": "Practitioner/1E473786-E7FA-785E-C911-A8D38FB56F20"
       } ],
@@ -16222,7 +16222,7 @@
         "reference": "Encounter/6AF1549E-55BC-481D-A498-19B213312DB7"
       },
       "effectiveDateTime": "2010-01-20T10:46:22+00:00",
-      "issued": "2010-02-09T12:08:18.000+00:00",
+      "issued": "2010-01-20T10:46:22.000+00:00",
       "performer": [ {
         "reference": "Practitioner/C5DEFBF3-0174-BC6F-182C-B777B9C6FF43"
       } ],
@@ -16290,7 +16290,7 @@
         "reference": "Encounter/1449860E-3953-4D71-A867-3E1E79D2E11B"
       },
       "effectiveDateTime": "2010-01-20T10:46:22+00:00",
-      "issued": "2010-03-26T13:49:48.000+00:00",
+      "issued": "2010-01-20T10:46:22.000+00:00",
       "performer": [ {
         "reference": "Practitioner/1E473786-E7FA-785E-C911-A8D38FB56F20"
       } ],
@@ -16353,7 +16353,7 @@
         "reference": "Encounter/1449860E-3953-4D71-A867-3E1E79D2E11B"
       },
       "effectiveDateTime": "2010-01-20T10:46:22+00:00",
-      "issued": "2010-03-26T13:49:48.000+00:00",
+      "issued": "2010-01-20T10:46:22.000+00:00",
       "performer": [ {
         "reference": "Practitioner/1E473786-E7FA-785E-C911-A8D38FB56F20"
       } ],

--- a/gp2gp-translator/src/integrationTest/resources/json/expectedBundle.json
+++ b/gp2gp-translator/src/integrationTest/resources/json/expectedBundle.json
@@ -24880,7 +24880,7 @@
         "reference": "Encounter/9FB8560B-A7FF-4F04-9E0B-CFBB4D0AF4E9"
       },
       "effectiveDateTime": "2010-02-23T00:00:00+00:00",
-      "issued": "2010-01-13T15:13:32.000+00:00",
+      "issued": "2010-02-25T15:41:00.000+00:00",
       "performer": [ {
         "reference": "Practitioner/70555A33-0550-405D-BB67-E9805440B38C"
       } ],

--- a/gp2gp-translator/src/test/java/uk/nhs/adaptors/pss/translator/mapper/diagnosticreport/SpecimenBatteryMapperTest.java
+++ b/gp2gp-translator/src/test/java/uk/nhs/adaptors/pss/translator/mapper/diagnosticreport/SpecimenBatteryMapperTest.java
@@ -2,6 +2,7 @@ package uk.nhs.adaptors.pss.translator.mapper.diagnosticreport;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.hl7.fhir.dstu3.model.Observation.ObservationStatus;
+import static org.junit.jupiter.api.Assertions.assertAll;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.when;
 import static org.springframework.util.ResourceUtils.getFile;
@@ -17,7 +18,6 @@ import org.hl7.fhir.dstu3.model.CodeableConcept;
 import org.hl7.fhir.dstu3.model.DateTimeType;
 import org.hl7.fhir.dstu3.model.DiagnosticReport;
 import org.hl7.fhir.dstu3.model.Encounter;
-import org.hl7.fhir.dstu3.model.InstantType;
 import org.hl7.fhir.dstu3.model.Observation;
 import org.hl7.fhir.dstu3.model.Observation.ObservationRelationshipType;
 import org.hl7.fhir.dstu3.model.Patient;
@@ -37,10 +37,22 @@ import uk.nhs.adaptors.pss.translator.mapper.diagnosticreport.SpecimenBatteryMap
 import uk.nhs.adaptors.pss.translator.util.CompoundStatementResourceExtractors;
 import uk.nhs.adaptors.pss.translator.util.DegradedCodeableConcepts;
 import static uk.nhs.adaptors.common.util.CodeableConceptUtils.createCodeableConcept;
+import static uk.nhs.adaptors.pss.translator.util.XmlUnmarshallUtil.unmarshallString;
 
 @ExtendWith(MockitoExtension.class)
 public class SpecimenBatteryMapperTest {
 
+    public static final String EHR_EXTRACT_WRAPPER = """
+        <EhrExtract xmlns="urn:hl7-org:v3" classCode="EXTRACT" moodCode="EVN">
+            <component>
+                <ehrFolder>
+                    <component>
+                        {{ehrComposition}}
+                    </component>
+                </ehrFolder>
+            </component>
+        </EhrExtract>
+        """;
     private static final String RESOURCES_BASE = "xml/SpecimenBattery/";
 
     private static final String BATTERY_CLASSCODE = "BATTERY";
@@ -48,15 +60,12 @@ public class SpecimenBatteryMapperTest {
     private static final String OBSERVATION_ID = "SPECIMEN_CHILD_BATTERY_COMPOUND_STATEMENT_ID_1";
     private static final String OBSERVATION_STATEMENT_ID_1 = "BATTERY_DIRECT_CHILD_OBSERVATION_STATEMENT";
     private static final String OBSERVATION_STATEMENT_ID_2 = "OBSERVATION_STATEMENT_ID";
-    private static final String DIAGNOSTIC_REPORT_ID = "DIAGNOSTIC_REPORT_ID";
     private static final String ENCOUNTER_ID = "ENCOUNTER_ID";
     private static final String PATIENT_ID = "TEST_PATIENT_ID";
     private static final String SPECIMEN_ID = "TEST_SPECIMEN_ID_1";
     private static final String META_PROFILE_SUFFIX = "Observation-1";
     private static final String EXPECTED_COMMENT = "Looks like Covid";
     private static final Patient PATIENT = (Patient) new Patient().setId(PATIENT_ID);
-    private static final DiagnosticReport DIAGNOSTIC_REPORT = (DiagnosticReport) new DiagnosticReport().setId(DIAGNOSTIC_REPORT_ID);
-    private static final InstantType OBSERVATION_ISSUED = parseToInstantType("202203021160700");
     private static final DateTimeType OBSERVATION_EFFECTIVE = parseToDateTimeType("20100223000000");
     private static final String CODING_DISPLAY_MOCK = "Test Display";
     private static final String SNOMED_SYSTEM = "http://snomed.info/sct";
@@ -69,54 +78,203 @@ public class SpecimenBatteryMapperTest {
     @InjectMocks
     private SpecimenBatteryMapper specimenBatteryMapper;
 
-    @Test
-    public void testMappingObservationFromBatteryCompoundStatement() {
-        final RCMRMT030101UK04EhrExtract ehrExtract = unmarshallEhrExtract("specimen_battery_compound_statement.xml");
-        var batteryCompoundStatement = getBatteryCompoundStatements(ehrExtract);
+    @Test void When_MappingObservationWithEffectiveTimeInBatteryCompoundStatement_Expect_IssuedUsesThisValue() {
+        final var ehrCompositionXml = """
+            <ehrComposition>
+                <id root="ENCOUNTER_ID"/>
+                <component>
+                    <CompoundStatement classCode="CLUSTER">
+                        <id root="DR_TEST_ID"/>
+                        <component>
+                            <CompoundStatement classCode="CLUSTER">
+                                <id root="TEST_SPECIMEN_ID_1"/>
+                                <component typeCode="COMP" contextConductionInd="true">
+                                    <CompoundStatement classCode="BATTERY" moodCode="EVN">
+                                        <id root="SPECIMEN_CHILD_BATTERY_COMPOUND_STATEMENT_ID_1"/>
+                                        <availabilityTime value="20100225154300"/>
+                                    </CompoundStatement>
+                                </component>
+                            </CompoundStatement>
+                        </component>
+                    </CompoundStatement>
+                </component>
+            </ehrComposition>
+            """;
 
-        final List<Observation> observations = getObservations();
-        final List<Observation> observationComments = getObservationComments();
-
-        var batteryParameters = SpecimenBatteryParameters.builder()
-            .ehrExtract(ehrExtract)
-            .batteryCompoundStatement(batteryCompoundStatement)
-            .specimenCompoundStatement(getSpecimenCompoundStatement(ehrExtract))
-            .ehrComposition(getEhrComposition(ehrExtract))
-            .diagnosticReport(DIAGNOSTIC_REPORT)
-            .patient(PATIENT)
-            .encounters(encounters)
-            .practiseCode(PRACTISE_CODE)
-            .observations(observations)
-            .observationComments(observationComments)
-            .build();
+        final var ehrExtract = unmarshallEhrExtractFromEhrCompositionXml(ehrCompositionXml);
+        final var batteryCompoundStatement = getBatteryCompoundStatements(ehrExtract);
+        final var batteryParameters = getSpecimenBatteryParameters(
+            ehrExtract,
+            batteryCompoundStatement,
+            getObservations(),
+            getObservationComments()
+        );
 
         final Observation observation = specimenBatteryMapper.mapBatteryObservation(batteryParameters);
 
-        assertThat(observation.getId()).isEqualTo(OBSERVATION_ID);
-        assertThat(observation.getIdentifierFirstRep().getSystem()).contains(PRACTISE_CODE);
-        assertThat(observation.getEffectiveDateTimeType().getValueAsString()).isEqualTo(OBSERVATION_EFFECTIVE.getValueAsString());
-        assertThat(observation.getIssuedElement().getValueAsString()).isEqualTo(OBSERVATION_ISSUED.getValueAsString());
-        assertThat(observation.getSpecimen().hasReference()).isTrue();
-        assertThat(observation.getSpecimen().getReference()).contains(SPECIMEN_ID);
-        assertThat(observation.getStatus()).isEqualTo(ObservationStatus.FINAL);
-        assertThat(observation.getMeta().getProfile().get(0).getValue()).contains(META_PROFILE_SUFFIX);
-        assertThat(observation.getComment()).isEqualTo(EXPECTED_COMMENT);
-        assertThat(observation.getContext().hasReference()).isTrue();
-        assertThat(observation.getContext().getReference()).contains(ENCOUNTER_ID);
+        assertThat(observation.getIssuedElement().asStringValue())
+            .isEqualTo(parseToInstantType("20100225154300").asStringValue());
+    }
 
-        assertThat(observations.get(0).getRelated()).isNotEmpty();
-        assertThat(observations.get(0).getRelatedFirstRep().getType()).isEqualTo(ObservationRelationshipType.DERIVEDFROM);
+    @SneakyThrows
+    private RCMRMT030101UK04EhrExtract unmarshallEhrExtractFromEhrCompositionXml(String ehrCompositionXml) {
+        var ehrExtractXml = EHR_EXTRACT_WRAPPER.replace("{{ehrComposition}}", ehrCompositionXml);
+        return unmarshallString(ehrExtractXml, RCMRMT030101UK04EhrExtract.class);
+    }
 
-        assertSubject(observation);
-        assertRelated(observation);
+    @Test void When_MappingObservationWithEffectiveTimeInDiagnosticReport_Expect_IssuedUsesThisValue() {
+        final var ehrCompositionXml = """
+            <ehrComposition>
+                <id root="ENCOUNTER_ID"/>
+                <component>
+                    <CompoundStatement classCode="CLUSTER">
+                        <id root="DR_TEST_ID"/>
+                        <availabilityTime value="20100225154200"/>
+                        <component>
+                            <CompoundStatement classCode="CLUSTER">
+                                <id root="TEST_SPECIMEN_ID_1"/>
+                                <component typeCode="COMP" contextConductionInd="true">
+                                    <CompoundStatement classCode="BATTERY" moodCode="EVN">
+                                        <id root="SPECIMEN_CHILD_BATTERY_COMPOUND_STATEMENT_ID_1"/>
+                                    </CompoundStatement>
+                                </component>
+                            </CompoundStatement>
+                        </component>
+                    </CompoundStatement>
+                </component>
+            </ehrComposition>
+            """;
 
-        assertThat(observationComments).hasSize(2);
+        final var ehrExtract = unmarshallEhrExtractFromEhrCompositionXml(ehrCompositionXml);
+        final var batteryCompoundStatement = getBatteryCompoundStatements(ehrExtract);
+        final var batteryParameters = getSpecimenBatteryParameters(
+            ehrExtract,
+            batteryCompoundStatement,
+            getObservations(),
+            getObservationComments()
+        );
 
-        var observationCommentIds = observationComments.stream()
-            .map(Observation::getId)
-            .toList();
+        final Observation observation = specimenBatteryMapper.mapBatteryObservation(batteryParameters);
 
-        assertThat(observationCommentIds).doesNotContain("BATTERY_DIRECT_CHILD_NARRATIVE_STATEMENT_ID");
+        assertThat(observation.getIssuedElement().asStringValue())
+            .isEqualTo(parseToInstantType("20100225154200").asStringValue());
+    }
+
+    @Test void When_MappingObservationOnlyEhrCompositionAuthorTime_Expect_IssuedUsesThisValue() {
+        final var ehrCompositionXml = """
+            <ehrComposition>
+                <id root="ENCOUNTER_ID"/>
+                <author typeCode="AUT" contextControlCode="OP">
+                    <time value="20220302105070"/>
+                    <agentRef classCode="AGNT">
+                        <id root="749107A2-4975-441F-8EDF-ADFF451FD12D"/>
+                    </agentRef>
+                </author>
+                <component>
+                    <CompoundStatement classCode="CLUSTER">
+                        <id root="DR_TEST_ID"/>
+                        <component>
+                            <CompoundStatement classCode="CLUSTER">
+                                <id root="TEST_SPECIMEN_ID_1"/>
+                                <component typeCode="COMP" contextConductionInd="true">
+                                    <CompoundStatement classCode="BATTERY" moodCode="EVN">
+                                        <id root="SPECIMEN_CHILD_BATTERY_COMPOUND_STATEMENT_ID_1"/>
+                                    </CompoundStatement>
+                                </component>
+                            </CompoundStatement>
+                        </component>
+                    </CompoundStatement>
+                </component>
+            </ehrComposition>
+            """;
+
+        final var ehrExtract = unmarshallEhrExtractFromEhrCompositionXml(ehrCompositionXml);
+        final var batteryCompoundStatement = getBatteryCompoundStatements(ehrExtract);
+        final var batteryParameters = getSpecimenBatteryParameters(
+            ehrExtract,
+            batteryCompoundStatement,
+            getObservations(),
+            getObservationComments()
+        );
+
+        final Observation observation = specimenBatteryMapper.mapBatteryObservation(batteryParameters);
+
+        assertThat(observation.getIssuedElement().asStringValue())
+            .isEqualTo(parseToInstantType("20220302105070").asStringValue());
+    }
+
+    @Test
+    public void When_MappingObservation_Expect_ObservationCorrectlyMapped() {
+        final var ehrExtract = unmarshallEhrExtract("specimen_battery_compound_statement.xml");
+        final var batteryCompoundStatement = getBatteryCompoundStatements(ehrExtract);
+        final var batteryParameters = getSpecimenBatteryParameters(
+            ehrExtract,
+            batteryCompoundStatement,
+            getObservations(),
+            getObservationComments()
+        );
+
+        final Observation observation = specimenBatteryMapper.mapBatteryObservation(batteryParameters);
+
+        assertAll(
+            () -> assertThat(observation.getId()).isEqualTo(OBSERVATION_ID),
+            () -> assertThat(observation.getIdentifierFirstRep().getSystem()).contains(PRACTISE_CODE),
+            () -> assertThat(observation.getEffectiveDateTimeType().getValueAsString())
+                .isEqualTo(OBSERVATION_EFFECTIVE.getValueAsString()),
+            () -> assertThat(observation.getSpecimen().hasReference()).isTrue(),
+            () -> assertThat(observation.getSpecimen().getReference()).contains(SPECIMEN_ID),
+            () -> assertThat(observation.getStatus()).isEqualTo(ObservationStatus.FINAL),
+            () -> assertThat(observation.getMeta().getProfile().get(0).getValue()).contains(META_PROFILE_SUFFIX),
+            () -> assertThat(observation.getComment()).isEqualTo(EXPECTED_COMMENT),
+            () -> assertThat(observation.getContext().hasReference()).isTrue(),
+            () -> assertThat(observation.getContext().getReference()).contains(ENCOUNTER_ID),
+            () -> assertSubject(observation)
+        );
+    }
+
+    @Test
+    public void When_MappingObservation_Expect_ObservationRelationshipsSet() {
+        final var ehrExtract = unmarshallEhrExtract("specimen_battery_compound_statement.xml");
+        final var batteryCompoundStatement = getBatteryCompoundStatements(ehrExtract);
+        final var observations = getObservations();
+        final var batteryParameters = getSpecimenBatteryParameters(
+            ehrExtract,
+            batteryCompoundStatement,
+            observations,
+            getObservationComments());
+
+        final Observation observation = specimenBatteryMapper.mapBatteryObservation(batteryParameters);
+
+        assertAll(
+            () -> assertThat(observations.get(0).getRelated())
+                .isNotEmpty(),
+            () -> assertThat(observations.get(0).getRelatedFirstRep().getType())
+                .isEqualTo(ObservationRelationshipType.DERIVEDFROM),
+            () -> assertRelated(observation)
+        );
+    }
+
+    @Test
+    public void When_MappingObservation_Expect_ObservationCommentsDoNotContainBatteryDirectChildNarrativeStatement() {
+        final var ehrExtract = unmarshallEhrExtract("specimen_battery_compound_statement.xml");
+        final var batteryCompoundStatement = getBatteryCompoundStatements(ehrExtract);
+        final var observationComments = getObservationComments();
+        final var batteryParameters = getSpecimenBatteryParameters(
+            ehrExtract,
+            batteryCompoundStatement,
+            getObservations(),
+            observationComments);
+
+        specimenBatteryMapper.mapBatteryObservation(batteryParameters);
+
+        final var observationCommentIds = observationComments.stream().map(Observation::getId).toList();
+
+        assertAll(
+            () -> assertThat(observationComments)
+                .hasSize(2),
+            () -> assertThat(observationCommentIds)
+                .doesNotContain("BATTERY_DIRECT_CHILD_NARRATIVE_STATEMENT_ID")
+        );
     }
 
     @Test
@@ -126,21 +284,11 @@ public class SpecimenBatteryMapperTest {
         final RCMRMT030101UK04EhrExtract ehrExtract = unmarshallEhrExtract("specimen_battery_compound_statement.xml");
         var batteryCompoundStatement = getBatteryCompoundStatements(ehrExtract);
 
-        final List<Observation> observations = getObservations();
-        final List<Observation> observationComments = getObservationComments();
-
-        var batteryParameters = SpecimenBatteryParameters.builder()
-            .ehrExtract(ehrExtract)
-            .batteryCompoundStatement(batteryCompoundStatement)
-            .specimenCompoundStatement(getSpecimenCompoundStatement(ehrExtract))
-            .ehrComposition(getEhrComposition(ehrExtract))
-            .diagnosticReport(DIAGNOSTIC_REPORT)
-            .patient(PATIENT)
-            .encounters(encounters)
-            .practiseCode(PRACTISE_CODE)
-            .observations(observations)
-            .observationComments(observationComments)
-            .build();
+        var batteryParameters = getSpecimenBatteryParameters(
+            ehrExtract,
+            batteryCompoundStatement,
+            getObservations(),
+            getObservationComments());
 
         final Observation observation = specimenBatteryMapper.mapBatteryObservation(batteryParameters);
 
@@ -159,18 +307,7 @@ public class SpecimenBatteryMapperTest {
         final List<Observation> observations = getObservations();
         final List<Observation> observationComments = getObservationComments();
 
-        var batteryParameters = SpecimenBatteryParameters.builder()
-            .ehrExtract(ehrExtract)
-            .batteryCompoundStatement(batteryCompoundStatement)
-            .specimenCompoundStatement(getSpecimenCompoundStatement(ehrExtract))
-            .ehrComposition(getEhrComposition(ehrExtract))
-            .diagnosticReport(DIAGNOSTIC_REPORT)
-            .patient(PATIENT)
-            .encounters(encounters)
-            .practiseCode(PRACTISE_CODE)
-            .observations(observations)
-            .observationComments(observationComments)
-            .build();
+        var batteryParameters = getSpecimenBatteryParameters(ehrExtract, batteryCompoundStatement, observations, observationComments);
 
         final Observation observation = specimenBatteryMapper.mapBatteryObservation(batteryParameters);
 
@@ -229,14 +366,47 @@ public class SpecimenBatteryMapperTest {
         assertThat(observation.getSubject().getResource().getIdElement().getValue()).isEqualTo(PATIENT_ID);
     }
 
+    private SpecimenBatteryParameters getSpecimenBatteryParameters(
+        RCMRMT030101UK04EhrExtract ehrExtract,
+        RCMRMT030101UKCompoundStatement batteryCompoundStatement,
+        List<Observation> observations,
+        List<Observation> observationComments) {
+
+        return SpecimenBatteryParameters.builder()
+            .ehrExtract(ehrExtract)
+            .batteryCompoundStatement(batteryCompoundStatement)
+            .specimenCompoundStatement(getSpecimenCompoundStatement(ehrExtract))
+            .ehrComposition(getEhrComposition(ehrExtract))
+            .diagnosticReport(getDiagnosticReport(ehrExtract))
+            .patient(PATIENT)
+            .encounters(encounters)
+            .practiseCode(PRACTISE_CODE)
+            .observations(observations)
+            .observationComments(observationComments)
+            .build();
+    }
+
     private RCMRMT030101UKEhrComposition getEhrComposition(RCMRMT030101UK04EhrExtract ehrExtract) {
         return ehrExtract.getComponent().get(0).getEhrFolder().getComponent().get(0).getEhrComposition();
     }
 
     private RCMRMT030101UKCompoundStatement getSpecimenCompoundStatement(RCMRMT030101UK04EhrExtract ehrExtract) {
-
         return getEhrComposition(ehrExtract).getComponent().get(0).getCompoundStatement()
             .getComponent().get(0).getCompoundStatement();
+    }
+
+    private DiagnosticReport getDiagnosticReport(RCMRMT030101UK04EhrExtract ehrExtract) {
+        var compoundStatement = getEhrComposition(ehrExtract).getComponent().get(0).getCompoundStatement();
+        var diagnosticReport = new DiagnosticReport();
+        diagnosticReport.setId(compoundStatement.getId().get(0).getRoot());
+
+        if (compoundStatement.getAvailabilityTime() != null) {
+            diagnosticReport.setIssued(
+                parseToDateTimeType(compoundStatement.getAvailabilityTime().getValue()).getValue()
+            );
+        }
+
+        return diagnosticReport;
     }
 
     private List<Observation> getObservations() {

--- a/gp2gp-translator/src/test/java/uk/nhs/adaptors/pss/translator/mapper/diagnosticreport/SpecimenBatteryMapperTest.java
+++ b/gp2gp-translator/src/test/java/uk/nhs/adaptors/pss/translator/mapper/diagnosticreport/SpecimenBatteryMapperTest.java
@@ -14,8 +14,6 @@ import static uk.nhs.adaptors.pss.translator.util.XmlUnmarshallUtil.unmarshallFi
 import java.util.ArrayList;
 import java.util.List;
 
-import org.hl7.fhir.dstu3.model.CodeableConcept;
-import org.hl7.fhir.dstu3.model.DateTimeType;
 import org.hl7.fhir.dstu3.model.DiagnosticReport;
 import org.hl7.fhir.dstu3.model.Encounter;
 import org.hl7.fhir.dstu3.model.Observation;
@@ -53,24 +51,6 @@ public class SpecimenBatteryMapperTest {
             </component>
         </EhrExtract>
         """;
-    private static final String RESOURCES_BASE = "xml/SpecimenBattery/";
-
-    private static final String BATTERY_CLASSCODE = "BATTERY";
-    private static final String PRACTISE_CODE = "TEST_PRACTISE_CODE";
-    private static final String OBSERVATION_ID = "SPECIMEN_CHILD_BATTERY_COMPOUND_STATEMENT_ID_1";
-    private static final String OBSERVATION_STATEMENT_ID_1 = "BATTERY_DIRECT_CHILD_OBSERVATION_STATEMENT";
-    private static final String OBSERVATION_STATEMENT_ID_2 = "OBSERVATION_STATEMENT_ID";
-    private static final String ENCOUNTER_ID = "ENCOUNTER_ID";
-    private static final String PATIENT_ID = "TEST_PATIENT_ID";
-    private static final String SPECIMEN_ID = "TEST_SPECIMEN_ID_1";
-    private static final String META_PROFILE_SUFFIX = "Observation-1";
-    private static final String EXPECTED_COMMENT = "Looks like Covid";
-    private static final Patient PATIENT = (Patient) new Patient().setId(PATIENT_ID);
-    private static final DateTimeType OBSERVATION_EFFECTIVE = parseToDateTimeType("20100223000000");
-    private static final String CODING_DISPLAY_MOCK = "Test Display";
-    private static final String SNOMED_SYSTEM = "http://snomed.info/sct";
-    private static final CodeableConcept CODEABLE_CONCEPT = createCodeableConcept(null, SNOMED_SYSTEM, CODING_DISPLAY_MOCK);
-    private final List<Encounter> encounters = generateEncounters();
 
     @Mock
     private CodeableConceptMapper codeableConceptMapper;
@@ -114,12 +94,6 @@ public class SpecimenBatteryMapperTest {
 
         assertThat(observation.getIssuedElement().asStringValue())
             .isEqualTo(parseToInstantType("20100225154300").asStringValue());
-    }
-
-    @SneakyThrows
-    private RCMRMT030101UK04EhrExtract unmarshallEhrExtractFromEhrCompositionXml(String ehrCompositionXml) {
-        var ehrExtractXml = EHR_EXTRACT_WRAPPER.replace("{{ehrComposition}}", ehrCompositionXml);
-        return unmarshallString(ehrExtractXml, RCMRMT030101UK04EhrExtract.class);
     }
 
     @Test void When_MappingObservationWithEffectiveTimeInDiagnosticReport_Expect_IssuedUsesThisValue() {
@@ -205,7 +179,38 @@ public class SpecimenBatteryMapperTest {
 
     @Test
     public void When_MappingObservation_Expect_ObservationCorrectlyMapped() {
-        final var ehrExtract = unmarshallEhrExtract("specimen_battery_compound_statement.xml");
+        final var ehrCompositionXml =
+            """
+            <ehrComposition classCode="COMPOSITION" moodCode="EVN">
+                <id root="ENCOUNTER_ID" />
+                <component typeCode="COMP">
+                    <CompoundStatement classCode="CLUSTER" moodCode="EVN">
+                        <id root="DR_TEST_ID" />
+                        <component typeCode="COMP" contextConductionInd="true">
+                            <CompoundStatement classCode="CLUSTER" moodCode="EVN">
+                                <id root="TEST_SPECIMEN_ID_1" />
+                                <component typeCode="COMP" contextConductionInd="true">
+                                    <CompoundStatement classCode="BATTERY" moodCode="EVN">
+                                        <id root="SPECIMEN_CHILD_BATTERY_COMPOUND_STATEMENT_ID_1" />
+                                        <effectiveTime>
+                                            <center value="20100223000000" />
+                                        </effectiveTime>
+                                        <component typeCode="COMP" contextConductionInd="true">
+                                            <NarrativeStatement classCode="OBS" moodCode="EVN">
+                                                    <id root="BATTERY_DIRECT_CHILD_NARRATIVE_STATEMENT_ID"/>
+                                                    <text mediaType="text/x-h7uk-pmip">Looks like Covid</text>
+                                            </NarrativeStatement>
+                                        </component>
+                                    </CompoundStatement>
+                                </component>
+                            </CompoundStatement>
+                        </component>
+                    </CompoundStatement>
+                </component>
+            </ehrComposition>
+            """;
+
+        final var ehrExtract = unmarshallEhrExtractFromEhrCompositionXml(ehrCompositionXml);
         final var batteryCompoundStatement = getBatteryCompoundStatements(ehrExtract);
         final var batteryParameters = getSpecimenBatteryParameters(
             ehrExtract,
@@ -217,24 +222,30 @@ public class SpecimenBatteryMapperTest {
         final Observation observation = specimenBatteryMapper.mapBatteryObservation(batteryParameters);
 
         assertAll(
-            () -> assertThat(observation.getId()).isEqualTo(OBSERVATION_ID),
-            () -> assertThat(observation.getIdentifierFirstRep().getSystem()).contains(PRACTISE_CODE),
+            () -> assertThat(observation.getId())
+                .isEqualTo("SPECIMEN_CHILD_BATTERY_COMPOUND_STATEMENT_ID_1"),
+            () -> assertThat(observation.getIdentifierFirstRep().getSystem())
+                .contains("TEST_PRACTISE_CODE"),
             () -> assertThat(observation.getEffectiveDateTimeType().getValueAsString())
-                .isEqualTo(OBSERVATION_EFFECTIVE.getValueAsString()),
-            () -> assertThat(observation.getSpecimen().hasReference()).isTrue(),
-            () -> assertThat(observation.getSpecimen().getReference()).contains(SPECIMEN_ID),
-            () -> assertThat(observation.getStatus()).isEqualTo(ObservationStatus.FINAL),
-            () -> assertThat(observation.getMeta().getProfile().get(0).getValue()).contains(META_PROFILE_SUFFIX),
-            () -> assertThat(observation.getComment()).isEqualTo(EXPECTED_COMMENT),
-            () -> assertThat(observation.getContext().hasReference()).isTrue(),
-            () -> assertThat(observation.getContext().getReference()).contains(ENCOUNTER_ID),
-            () -> assertSubject(observation)
+                .isEqualTo(parseToDateTimeType("20100223000000").getValueAsString()),
+            () -> assertThat(observation.getSpecimen().getReference())
+                .contains("TEST_SPECIMEN_ID_1"),
+            () -> assertThat(observation.getStatus())
+                .isEqualTo(ObservationStatus.FINAL),
+            () -> assertThat(observation.getMeta().getProfile().get(0).getValue())
+                .contains("Observation-1"),
+            () -> assertThat(observation.getComment())
+                .isEqualTo("Looks like Covid"),
+            () -> assertThat(observation.getContext().getReference())
+                .contains("ENCOUNTER_ID"),
+            () -> assertThat(observation.getSubject().getResource().getIdElement().getValue())
+                .isEqualTo("TEST_PATIENT_ID")
         );
     }
 
     @Test
     public void When_MappingObservation_Expect_ObservationRelationshipsSet() {
-        final var ehrExtract = unmarshallEhrExtract("specimen_battery_compound_statement.xml");
+        final var ehrExtract = getSpecimenBatteryEhrExtract();
         final var batteryCompoundStatement = getBatteryCompoundStatements(ehrExtract);
         final var observations = getObservations();
         final var batteryParameters = getSpecimenBatteryParameters(
@@ -246,17 +257,18 @@ public class SpecimenBatteryMapperTest {
         final Observation observation = specimenBatteryMapper.mapBatteryObservation(batteryParameters);
 
         assertAll(
-            () -> assertThat(observations.get(0).getRelated())
-                .isNotEmpty(),
             () -> assertThat(observations.get(0).getRelatedFirstRep().getType())
                 .isEqualTo(ObservationRelationshipType.DERIVEDFROM),
-            () -> assertRelated(observation)
+            () -> assertThat(observation.getRelatedFirstRep().getTarget().getReference())
+                .contains("BATTERY_DIRECT_CHILD_OBSERVATION_STATEMENT"),
+            () -> assertThat(observation.getRelated().get(1).getTarget().getReference())
+                .contains("OBSERVATION_STATEMENT_ID")
         );
     }
 
     @Test
     public void When_MappingObservation_Expect_ObservationCommentsDoNotContainBatteryDirectChildNarrativeStatement() {
-        final var ehrExtract = unmarshallEhrExtract("specimen_battery_compound_statement.xml");
+        final var ehrExtract = getSpecimenBatteryEhrExtract();
         final var batteryCompoundStatement = getBatteryCompoundStatements(ehrExtract);
         final var observationComments = getObservationComments();
         final var batteryParameters = getSpecimenBatteryParameters(
@@ -279,9 +291,10 @@ public class SpecimenBatteryMapperTest {
 
     @Test
     public void When_MappingObservationFromBatteryCompoundStatementWithSnomedCode_Expect_CorrectlyMapped() {
-        when(codeableConceptMapper.mapToCodeableConcept(any())).thenReturn(CODEABLE_CONCEPT);
+        final var codeableConcept = createCodeableConcept("1.2.3.4.5", "http://snomed.info/sct", "Test Display");
+        when(codeableConceptMapper.mapToCodeableConcept(any())).thenReturn(codeableConcept);
 
-        final RCMRMT030101UK04EhrExtract ehrExtract = unmarshallEhrExtract("specimen_battery_compound_statement.xml");
+        final RCMRMT030101UK04EhrExtract ehrExtract = getSpecimenBatteryEhrExtract();
         var batteryCompoundStatement = getBatteryCompoundStatements(ehrExtract);
 
         var batteryParameters = getSpecimenBatteryParameters(
@@ -292,16 +305,16 @@ public class SpecimenBatteryMapperTest {
 
         final Observation observation = specimenBatteryMapper.mapBatteryObservation(batteryParameters);
 
-        assertThat(observation.getCode()).isEqualTo(CODEABLE_CONCEPT);
+        assertThat(observation.getCode())
+            .isEqualTo(codeableConcept);
     }
 
     @Test
     public void When_MappingObservationFromBatteryCompoundStatementWithoutSnomedCode_Expect_DegradedCode() {
-
-        var codeableConcept = createCodeableConcept("1.2.3.4.5", null, CODING_DISPLAY_MOCK);
+        var codeableConcept = createCodeableConcept("1.2.3.4.5", null, "Test Display");
         when(codeableConceptMapper.mapToCodeableConcept(any())).thenReturn(codeableConcept);
 
-        final RCMRMT030101UK04EhrExtract ehrExtract = unmarshallEhrExtract("specimen_battery_compound_statement.xml");
+        final RCMRMT030101UK04EhrExtract ehrExtract = getSpecimenBatteryEhrExtract();
         var batteryCompoundStatement = getBatteryCompoundStatements(ehrExtract);
 
         final List<Observation> observations = getObservations();
@@ -311,7 +324,8 @@ public class SpecimenBatteryMapperTest {
 
         final Observation observation = specimenBatteryMapper.mapBatteryObservation(batteryParameters);
 
-        assertThat(observation.getCode().getCodingFirstRep()).isEqualTo(DegradedCodeableConcepts.DEGRADED_OTHER);
+        assertThat(observation.getCode().getCodingFirstRep())
+            .isEqualTo(DegradedCodeableConcepts.DEGRADED_OTHER);
     }
 
     private List<Observation> getObservationComments() {
@@ -353,19 +367,6 @@ public class SpecimenBatteryMapperTest {
         return observationComments;
     }
 
-    private void assertRelated(Observation observation) {
-        assertThat(observation.getRelated()).isNotEmpty();
-        assertThat(observation.getRelatedFirstRep().hasTarget()).isTrue();
-        assertThat(observation.getRelatedFirstRep().getTarget().getReference()).contains(OBSERVATION_STATEMENT_ID_1);
-        assertThat(observation.getRelated().get(1).getTarget().getReference()).contains(OBSERVATION_STATEMENT_ID_2);
-    }
-
-    private void assertSubject(Observation observation) {
-        assertThat(observation.getSubject()).isNotNull();
-        assertThat(observation.getSubject().getResource()).isNotNull();
-        assertThat(observation.getSubject().getResource().getIdElement().getValue()).isEqualTo(PATIENT_ID);
-    }
-
     private SpecimenBatteryParameters getSpecimenBatteryParameters(
         RCMRMT030101UK04EhrExtract ehrExtract,
         RCMRMT030101UKCompoundStatement batteryCompoundStatement,
@@ -378,9 +379,9 @@ public class SpecimenBatteryMapperTest {
             .specimenCompoundStatement(getSpecimenCompoundStatement(ehrExtract))
             .ehrComposition(getEhrComposition(ehrExtract))
             .diagnosticReport(getDiagnosticReport(ehrExtract))
-            .patient(PATIENT)
-            .encounters(encounters)
-            .practiseCode(PRACTISE_CODE)
+            .patient((Patient) new Patient().setId("TEST_PATIENT_ID"))
+            .encounters(List.of((Encounter) new Encounter().setId("ENCOUNTER_ID")))
+            .practiseCode("TEST_PRACTISE_CODE")
             .observations(observations)
             .observationComments(observationComments)
             .build();
@@ -411,27 +412,32 @@ public class SpecimenBatteryMapperTest {
 
     private List<Observation> getObservations() {
         return List.of(
-            (Observation) new Observation().setId(OBSERVATION_STATEMENT_ID_1),
-            (Observation) new Observation().setId(OBSERVATION_STATEMENT_ID_2)
+            (Observation) new Observation().setId("BATTERY_DIRECT_CHILD_OBSERVATION_STATEMENT"),
+            (Observation) new Observation().setId("OBSERVATION_STATEMENT_ID")
         );
     }
 
     private RCMRMT030101UKCompoundStatement getBatteryCompoundStatements(RCMRMT030101UK04EhrExtract ehrExtract) {
-
         return getEhrComposition(ehrExtract).getComponent()
             .stream()
             .flatMap(CompoundStatementResourceExtractors::extractAllCompoundStatements)
-            .filter(compoundStatement -> BATTERY_CLASSCODE.equals(compoundStatement.getClassCode().get(0)))
-            .findFirst().get();
-    }
-
-    private List<Encounter> generateEncounters() {
-        return List.of((Encounter) new Encounter().setId(ENCOUNTER_ID));
+            .filter(compoundStatement -> "BATTERY".equals(compoundStatement.getClassCode().get(0)))
+            .findFirst()
+            .orElseThrow();
     }
 
     @SneakyThrows
-    private RCMRMT030101UK04EhrExtract unmarshallEhrExtract(String filename) {
-        return unmarshallFile(getFile("classpath:" + RESOURCES_BASE + filename), RCMRMT030101UK04EhrExtract.class);
+    private RCMRMT030101UK04EhrExtract getSpecimenBatteryEhrExtract() {
+        return unmarshallFile(
+            getFile("classpath:xml/SpecimenBattery/specimen_battery_compound_statement.xml"),
+            RCMRMT030101UK04EhrExtract.class
+        );
+    }
+
+    @SneakyThrows
+    private RCMRMT030101UK04EhrExtract unmarshallEhrExtractFromEhrCompositionXml(String ehrCompositionXml) {
+        var ehrExtractXml = EHR_EXTRACT_WRAPPER.replace("{{ehrComposition}}", ehrCompositionXml);
+        return unmarshallString(ehrExtractXml, RCMRMT030101UK04EhrExtract.class);
     }
 }
 

--- a/gp2gp-translator/src/test/java/uk/nhs/adaptors/pss/translator/mapper/diagnosticreport/SpecimenBatteryMapperTest.java
+++ b/gp2gp-translator/src/test/java/uk/nhs/adaptors/pss/translator/mapper/diagnosticreport/SpecimenBatteryMapperTest.java
@@ -58,7 +58,7 @@ public class SpecimenBatteryMapperTest {
     @InjectMocks
     private SpecimenBatteryMapper specimenBatteryMapper;
 
-    @Test void When_MappingObservationWithEffectiveTimeInBatteryCompoundStatement_Expect_IssuedUsesThisValue() {
+    @Test void When_MappingObservationWithAvailabilityTimeInBatteryCompoundStatement_Expect_IssuedUsesThisValue() {
         final var ehrCompositionXml = """
             <ehrComposition>
                 <id root="ENCOUNTER_ID"/>
@@ -96,7 +96,7 @@ public class SpecimenBatteryMapperTest {
             .isEqualTo(parseToInstantType("20100225154300").asStringValue());
     }
 
-    @Test void When_MappingObservationWithEffectiveTimeInDiagnosticReport_Expect_IssuedUsesThisValue() {
+    @Test void When_MappingObservationWithAvailabilityTimeInDiagnosticReport_Expect_IssuedUsesThisValue() {
         final var ehrCompositionXml = """
             <ehrComposition>
                 <id root="ENCOUNTER_ID"/>
@@ -178,7 +178,7 @@ public class SpecimenBatteryMapperTest {
     }
 
     @Test
-    public void When_MappingObservation_Expect_ObservationCorrectlyMapped() {
+    public void When_MappingObservation_Expect_ObservationFieldsAreCorrectlyMapped() {
         final var ehrCompositionXml =
             """
             <ehrComposition classCode="COMPOSITION" moodCode="EVN">

--- a/gp2gp-translator/src/test/resources/xml/SpecimenBattery/specimen_battery_compound_statement.xml
+++ b/gp2gp-translator/src/test/resources/xml/SpecimenBattery/specimen_battery_compound_statement.xml
@@ -5,7 +5,7 @@
                 <ehrComposition classCode="COMPOSITION" moodCode="EVN">
                     <id root="ENCOUNTER_ID"/>
                     <author typeCode="AUT" contextControlCode="OP">
-                        <time value="202203021160700"/>
+                        <time value="20220302105070"/>
                         <agentRef classCode="AGNT">
                             <id root="749107A2-4975-441F-8EDF-ADFF451FD12D"/>
                         </agentRef>
@@ -41,7 +41,7 @@
                                     <effectiveTime>
                                         <center nullFlavor="NI"/>
                                     </effectiveTime>
-                                    <availabilityTime value="20100225154100"/>
+                                    <availabilityTime value="20100225154200"/>
                                     <specimen typeCode="SPC">
                                         <specimenRole classCode="SPEC">
                                             <id root="37252CF4-D7F6-4CBA-89B2-63477F0C8374"/>
@@ -67,7 +67,7 @@
                                             <effectiveTime>
                                                 <center value="20100223000000"/>
                                             </effectiveTime>
-                                            <availabilityTime value="20100225154100"/>
+                                            <availabilityTime value="20100225154300"/>
                                             <component typeCode="COMP" contextConductionInd="true">
                                                 <ObservationStatement classCode="OBS" moodCode="EVN">
                                                     <id root="BATTERY_DIRECT_CHILD_OBSERVATION_STATEMENT"/>
@@ -81,7 +81,7 @@
                                                     <effectiveTime>
                                                         <center value="20100223000000"/>
                                                     </effectiveTime>
-                                                    <availabilityTime value="20100225154100"/>
+                                                    <availabilityTime value="20100225154400"/>
                                                 </ObservationStatement>
                                             </component>
                                             <component typeCode="COMP" contextConductionInd="true">
@@ -109,7 +109,7 @@ Looks like Covid
                                                     <effectiveTime>
                                                         <center value="20100223000000"/>
                                                     </effectiveTime>
-                                                    <availabilityTime value="20100225154100"/>
+                                                    <availabilityTime value="20100225154600"/>
                                                     <component typeCode="COMP" contextConductionInd="true">
                                                         <ObservationStatement classCode="OBS" moodCode="EVN">
                                                             <id root="OBSERVATION_STATEMENT_ID"/>
@@ -123,7 +123,7 @@ Looks like Covid
                                                             <effectiveTime>
                                                                 <center value="20100223000000"/>
                                                             </effectiveTime>
-                                                            <availabilityTime value="20100225154100"/>
+                                                            <availabilityTime value="20100225154700"/>
                                                         </ObservationStatement>
                                                     </component>
                                                     <component typeCode="COMP" contextConductionInd="true">


### PR DESCRIPTION
## What

Update SpecimenBatteryMapper to set issued based on GP Connect requirements.  This should now use the effective time from the `SpecimenBattery`, or then the `DiagnosticReport`, failing that to fallback to `Author.time` from the `ehrComposition`

## Why

GP Connect specifies that the issued date on Test Group Header (specimen battery) should use the following to determine its value:

```
The date and time that the result was issued by the laboratory or other report provider.
If this is not provided for a test group header result then it should inherit the date from the DiagnosticReport.
```

It has been reported under NIAD-2911 that it has been identified that the date & time associated with Investigation Results is incorrect.


## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [x] I have performed a self-review of my code
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have updated the [Changelog](/CHANGELOG.md) with details of my change in the UNRELEASED section if this change will affect end users
- [x] A corresponding change has been made to the [Mapping Documentation repository][mapping-docs]

[mapping-docs]: https://github.com/NHSDigital/patient-switching-adaptors-mapping-documentation