### PR TITLE
Update ObservationMapper to ensure AvailabilityTime is used for Issued, when available

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 * Mapping of `issued` for `Test Group Headers` has been updated to use correct timestamps as per [GP Connect 
 Documentation](https://developer.nhs.uk/apis/gpconnect-1-5-1/accessrecord_structured_development_observation_testGroup.html#issued)
 and use author time if these values are not available.
+* Mapping of `issued` for uncategorized `ObservationStatements` and `RequestStatements` has been updated to use 
+availability timestamps as per [GP Connect Documentation](https://developer.nhs.uk/apis/gpconnect-1-5-0/accessrecord_structured_development_observation_uncategorisedData.html#issued)
+and use author time if these values are not available.
 
 ## [2.1.0] - 2024-04-17
 ### Added

--- a/gp2gp-translator/src/integrationTest/java/uk/nhs/adaptors/pss/translator/EhrExtractHandlingIT.java
+++ b/gp2gp-translator/src/integrationTest/java/uk/nhs/adaptors/pss/translator/EhrExtractHandlingIT.java
@@ -1,6 +1,5 @@
 package uk.nhs.adaptors.pss.translator;
 
-import static org.assertj.core.api.Assertions.fail;
 import static org.awaitility.Awaitility.waitAtMost;
 import static org.mockito.Mockito.when;
 import static org.springframework.boot.test.context.SpringBootTest.WebEnvironment.RANDOM_PORT;
@@ -8,29 +7,18 @@ import static org.springframework.boot.test.context.SpringBootTest.WebEnvironmen
 import static uk.nhs.adaptors.common.util.FileUtil.readResourceAsString;
 import static uk.nhs.adaptors.common.enums.MigrationStatus.EHR_EXTRACT_REQUEST_ACCEPTED;
 import static uk.nhs.adaptors.common.enums.MigrationStatus.MIGRATION_COMPLETED;
-import static uk.nhs.adaptors.pss.util.BaseEhrHandler.OVERWRITE_EXPECTED_JSON;
-import static uk.nhs.adaptors.pss.util.JsonPathIgnoreGeneratorUtil.generateJsonPathIgnores;
 
-import java.io.PrintWriter;
-import java.nio.charset.StandardCharsets;
 import java.time.Duration;
-import java.util.List;
-import java.util.Locale;
 import java.util.UUID;
-import java.util.stream.Stream;
 
 import org.apache.commons.lang3.RandomStringUtils;
-import org.hl7.fhir.dstu3.model.Bundle;
 import org.json.JSONException;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.invocation.InvocationOnMock;
 import org.mockito.stubbing.Answer;
-import org.skyscreamer.jsonassert.Customization;
 import org.skyscreamer.jsonassert.JSONAssert;
-import org.skyscreamer.jsonassert.JSONCompareMode;
-import org.skyscreamer.jsonassert.comparator.CustomComparator;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
@@ -43,7 +31,6 @@ import org.springframework.test.context.junit.jupiter.SpringExtension;
 import com.fasterxml.jackson.databind.ObjectMapper;
 
 import lombok.SneakyThrows;
-import uk.nhs.adaptors.common.util.fhir.FhirParser;
 import uk.nhs.adaptors.connector.dao.PatientMigrationRequestDao;
 import uk.nhs.adaptors.connector.service.MigrationStatusLogService;
 import uk.nhs.adaptors.pss.translator.mhs.model.InboundMessage;
@@ -55,39 +42,8 @@ import uk.nhs.adaptors.pss.translator.service.IdGeneratorService;
 @AutoConfigureMockMvc
 public class EhrExtractHandlingIT {
 
-    private static final int NHS_NUMBER_MIN_MAX_LENGTH = 10;
-    private static final String EBXML_PART_PATH = "/xml/RCMR_IN030000UK06/ebxml_part.xml";
+    private static final int TEN = 10;
     private static final String NHS_NUMBER_PLACEHOLDER = "{{nhsNumber}}";
-    private static final String CONVERSATION_ID_PLACEHOLDER = "{{conversationId}}";
-    private static final String LOSING_ODS_CODE = "D5445";
-    private static final String WINNING_ODS_CODE = "ABC";
-    //these are programming language special characters, not to be confused with line endings
-    private static final String SPECIAL_CHARS = "\\\\n|\\\\t|\\\\b|\\\\r";
-
-    private static final List<String> STATIC_IGNORED_JSON_PATHS = List.of(
-        "id",
-        "entry[0].resource.id",
-        "entry[0].resource.identifier[0].value",
-        "entry[1].resource.id",
-        "entry[*].resource.subject.reference",
-        "entry[*].resource.patient.reference",
-        "entry[21].resource.location[0].location.reference",
-        "entry[22].resource.location[0].location.reference",
-        "entry[23].resource.location[0].location.reference",
-        "entry[24].resource.location[0].location.reference",
-        "entry[25].resource.location[0].location.reference",
-        "entry[26].resource.location[0].location.reference",
-        "entry[29].resource.location[0].location.reference",
-        "entry[31].resource.location[0].location.reference",
-        "entry[59].resource.id",
-        "entry[59].resource.identifier[0].value",
-        "entry[60].resource.id",
-        "entry[60].resource.identifier[0].value",
-        "entry[502].resource.id",
-        "entry[502].resource.identifier[0].value",
-        "entry[504].resource.id",
-        "entry[504].resource.identifier[0].value"
-    );
 
     @MockBean
     private IdGeneratorService idGeneratorService;
@@ -105,14 +61,9 @@ public class EhrExtractHandlingIT {
     @Autowired
     private ObjectMapper objectMapper;
 
-    @Autowired
-    private FhirParser fhirParserService;
-
     private String patientNhsNumber;
     private String conversationId;
-    static final int WAITING_TIME = 10;
 
-    @BeforeEach
     public void setUpDeterministicRandomIds() {
         when(idGeneratorService.generateUuid()).thenAnswer(
                 new Answer<String>() {
@@ -127,58 +78,59 @@ public class EhrExtractHandlingIT {
 
     @BeforeEach
     public void setUp() {
-        patientNhsNumber = generatePatientNhsNumber();
-        conversationId = generateConversationId().toUpperCase(Locale.ROOT);
+        patientNhsNumber = RandomStringUtils.randomNumeric(TEN, TEN);
+        conversationId = UUID.randomUUID().toString().toUpperCase();
+        setUpDeterministicRandomIds();
         startPatientMigrationJourney();
     }
 
     @Test
     public void handleEhrExtractFromQueue() throws JSONException {
-        // process starts with consuming a message from MHS queue
-        sendInboundMessageToQueue("/xml/RCMR_IN030000UK06/payload_part.xml", EBXML_PART_PATH);
+        var expectedBundle = readResourceAsString("/json/expectedBundle.json")
+            .replace(NHS_NUMBER_PLACEHOLDER, patientNhsNumber);
 
-        // wait until EHR extract is translated to bundle resource and saved to the DB
-        waitAtMost(Duration.ofSeconds(WAITING_TIME)).until(this::isEhrMigrationCompleted);
+        var actualBundle = sendInboundMessageAndWaitForBundle(
+            "/xml/RCMR_IN030000UK06/ebxml_part.xml",
+            "/xml/RCMR_IN030000UK06/payload_part.xml"
+        );
 
-        // verify generated bundle resource
-        verifyBundle("/json/expectedBundle.json");
+        JSONAssert.assertEquals(expectedBundle, actualBundle, true);
     }
 
     @Test
     public void handleEhrExtractWithConfidentialityCodeFromQueue() throws JSONException {
-        final String ebxmlPartPath = "/xml/RCMR_IN030000UK07/ebxml_part.xml";
-        // process starts with consuming a message from MHS queue
-        sendInboundMessageToQueue("/xml/RCMR_IN030000UK07/payload_part_with_confidentiality_code.xml", ebxmlPartPath);
+        var expectedBundle = readResourceAsString("/json/expectedBundle.json")
+            .replace(NHS_NUMBER_PLACEHOLDER, patientNhsNumber);
 
-        // wait until EHR extract is translated to bundle resource and saved to the DB
-        waitAtMost(Duration.ofSeconds(WAITING_TIME)).until(this::isEhrMigrationCompleted);
+        var actualBundle = sendInboundMessageAndWaitForBundle(
+            "/xml/RCMR_IN030000UK07/ebxml_part.xml",
+            "/xml/RCMR_IN030000UK07/payload_part_with_confidentiality_code.xml"
+        );
 
-        // verify generated bundle resource
-        verifyBundle("/json/expectedBundle.json");
+        JSONAssert.assertEquals(expectedBundle, actualBundle, true);
+    }
+
+    private String sendInboundMessageAndWaitForBundle(String ebXmlPartPath, String payloadPartPath) {
+        var inboundMessage = createInboundMessage(ebXmlPartPath, payloadPartPath);
+        mhsJmsTemplate.send(session -> session.createTextMessage(parseMessageToString(inboundMessage)));
+        waitAtMost(Duration.ofSeconds(TEN)).until(this::isEhrMigrationCompleted);
+
+        var patientMigrationRequest = patientMigrationRequestDao.getMigrationRequest(conversationId);
+        return patientMigrationRequest.getBundleResource();
     }
 
     private void startPatientMigrationJourney() {
-        patientMigrationRequestDao.addNewRequest(patientNhsNumber, conversationId, LOSING_ODS_CODE, WINNING_ODS_CODE);
+        patientMigrationRequestDao.addNewRequest(patientNhsNumber, conversationId, "D5445", "ABC");
         migrationStatusLogService.addMigrationStatusLog(EHR_EXTRACT_REQUEST_ACCEPTED, conversationId, null, null);
     }
 
-    private String generatePatientNhsNumber() {
-        return RandomStringUtils.randomNumeric(NHS_NUMBER_MIN_MAX_LENGTH, NHS_NUMBER_MIN_MAX_LENGTH);
-    }
-
-    private String generateConversationId() {
-        return UUID.randomUUID().toString();
-    }
-
-    private void sendInboundMessageToQueue(String payloadPartPath, String ebxmlPartPath) {
-        var inboundMessage = createInboundMessage(payloadPartPath, ebxmlPartPath);
-        mhsJmsTemplate.send(session -> session.createTextMessage(parseMessageToString(inboundMessage)));
-    }
-
-    private InboundMessage createInboundMessage(String payloadPartPath, String ebxmlPartPath) {
+    private InboundMessage createInboundMessage(String ebXmlPartPath, String payloadPartPath) {
         var inboundMessage = new InboundMessage();
-        var payload = readResourceAsString(payloadPartPath).replace(NHS_NUMBER_PLACEHOLDER, patientNhsNumber);
-        var ebXml = readResourceAsString(ebxmlPartPath).replace(CONVERSATION_ID_PLACEHOLDER, conversationId);
+        var payload = readResourceAsString(payloadPartPath)
+            .replace(NHS_NUMBER_PLACEHOLDER, patientNhsNumber);
+        var ebXml = readResourceAsString(ebXmlPartPath)
+            .replace("{{conversationId}}", conversationId);
+
         inboundMessage.setPayload(payload);
         inboundMessage.setEbXML(ebXml);
         return inboundMessage;
@@ -187,44 +139,6 @@ public class EhrExtractHandlingIT {
     private boolean isEhrMigrationCompleted() {
         var migrationStatusLog = migrationStatusLogService.getLatestMigrationStatusLog(conversationId);
         return MIGRATION_COMPLETED.equals(migrationStatusLog.getMigrationStatus());
-    }
-
-    private void verifyBundle(String path) throws JSONException {
-        var patientMigrationRequest = patientMigrationRequestDao.getMigrationRequest(conversationId);
-        var expectedBundle = readResourceAsString(path).replace(NHS_NUMBER_PLACEHOLDER, patientNhsNumber);
-
-        if (OVERWRITE_EXPECTED_JSON) {
-            overwriteExpectJson(path, patientMigrationRequest.getBundleResource());
-        }
-
-        var bundle = fhirParserService.parseResource(patientMigrationRequest.getBundleResource(), Bundle.class);
-        var combinedList = Stream.of(generateJsonPathIgnores(bundle), STATIC_IGNORED_JSON_PATHS)
-            .flatMap(List::stream)
-            .toList();
-
-        assertBundleContent(
-            patientMigrationRequest.getBundleResource().replaceAll(SPECIAL_CHARS, ""),
-            expectedBundle.replaceAll(SPECIAL_CHARS, ""),
-            combinedList
-        );
-    }
-
-    private void assertBundleContent(String actual, String expected, List<String> ignoredPaths) throws JSONException {
-        // when comparing json objects, this will ignore various json paths that contain random values like ids or timestamps
-        var customizations = ignoredPaths.stream()
-            .map(jsonPath -> new Customization(jsonPath, (o1, o2) -> true))
-            .toArray(Customization[]::new);
-
-        JSONAssert.assertEquals(expected, actual,
-            new CustomComparator(JSONCompareMode.STRICT, customizations));
-    }
-
-    @SneakyThrows
-    private void overwriteExpectJson(String path, String newExpected) {
-        try (PrintWriter printWriter = new PrintWriter("src/integrationTest/resources/" + path, StandardCharsets.UTF_8)) {
-            printWriter.print(newExpected);
-        }
-        fail("Re-run the tests with OVERWRITE_EXPECTED_JSON=false");
     }
 
     @SneakyThrows

--- a/gp2gp-translator/src/integrationTest/java/uk/nhs/adaptors/pss/translator/LargeMessagingIT.java
+++ b/gp2gp-translator/src/integrationTest/java/uk/nhs/adaptors/pss/translator/LargeMessagingIT.java
@@ -1,6 +1,7 @@
 package uk.nhs.adaptors.pss.translator;
 
 import static org.awaitility.Awaitility.await;
+import static org.mockito.Mockito.when;
 import static org.springframework.boot.test.context.SpringBootTest.WebEnvironment.RANDOM_PORT;
 import static org.springframework.test.annotation.DirtiesContext.ClassMode.AFTER_EACH_TEST_METHOD;
 
@@ -14,16 +15,21 @@ import java.util.regex.Pattern;
 import java.util.stream.Stream;
 
 import org.json.JSONException;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
+import org.mockito.invocation.InvocationOnMock;
+import org.mockito.stubbing.Answer;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
 
+import uk.nhs.adaptors.pss.translator.service.IdGeneratorService;
 import uk.nhs.adaptors.pss.util.BaseEhrHandler;
 
 @SpringBootTest(webEnvironment = RANDOM_PORT)
@@ -45,6 +51,22 @@ public final class LargeMessagingIT extends BaseEhrHandler {
             "entry[*].resource.content[0].attachment.url",
             "entry[*].resource.description"
         ));
+    }
+
+    @MockBean
+    private IdGeneratorService idGeneratorService;
+
+    @BeforeEach
+    public void setUpDeterministicRandomIds() {
+        when(idGeneratorService.generateUuid()).thenAnswer(
+            new Answer<String>() {
+                private int invocationCount = 0;
+                @Override
+                public String answer(InvocationOnMock invocation) {
+                    return String.format("00000000-0000-0000-0000-%012d", invocationCount++);
+                }
+            }
+        );
     }
 
     @Test

--- a/gp2gp-translator/src/integrationTest/resources/e2e-mapping/output-json/PWTP10-output.json
+++ b/gp2gp-translator/src/integrationTest/resources/e2e-mapping/output-json/PWTP10-output.json
@@ -2449,7 +2449,7 @@
         "reference": "Encounter/E92099A9-F7E9-4684-91EB-D6427F022041"
       },
       "effectiveDateTime": "2010-01-14T13:08:00+00:00",
-      "issued": "2010-02-06T13:07:44.000+00:00",
+      "issued": "2010-01-14T13:08:00.000+00:00",
       "performer": [ {
         "reference": "Practitioner/C5DEFBF3-0174-BC6F-182C-B777B9C6FF43"
       } ]
@@ -2485,7 +2485,7 @@
         "reference": "Encounter/E92099A9-F7E9-4684-91EB-D6427F022041"
       },
       "effectiveDateTime": "2010-01-14T13:08:00+00:00",
-      "issued": "2010-02-06T13:07:44.000+00:00",
+      "issued": "2010-01-14T13:08:00.000+00:00",
       "performer": [ {
         "reference": "Practitioner/C5DEFBF3-0174-BC6F-182C-B777B9C6FF43"
       } ]
@@ -2531,7 +2531,7 @@
         "reference": "Encounter/81A3B881-FE23-4346-A7ED-48ED539E9054"
       },
       "effectiveDateTime": "2010-02-06T12:41:00+00:00",
-      "issued": "2010-02-06T12:44:53.000+00:00",
+      "issued": "2010-02-06T12:41:00.000+00:00",
       "performer": [ {
         "reference": "Practitioner/C5DEFBF3-0174-BC6F-182C-B777B9C6FF43"
       } ],
@@ -2578,7 +2578,7 @@
         "reference": "Encounter/81A3B881-FE23-4346-A7ED-48ED539E9054"
       },
       "effectiveDateTime": "2010-02-06T12:41:00+00:00",
-      "issued": "2010-02-06T12:44:53.000+00:00",
+      "issued": "2010-02-06T12:41:00.000+00:00",
       "performer": [ {
         "reference": "Practitioner/C5DEFBF3-0174-BC6F-182C-B777B9C6FF43"
       } ]
@@ -2624,7 +2624,7 @@
         "reference": "Encounter/81A3B881-FE23-4346-A7ED-48ED539E9054"
       },
       "effectiveDateTime": "2010-02-06T12:41:00+00:00",
-      "issued": "2010-02-06T12:44:53.000+00:00",
+      "issued": "2010-02-06T12:41:00.000+00:00",
       "performer": [ {
         "reference": "Practitioner/C5DEFBF3-0174-BC6F-182C-B777B9C6FF43"
       } ]
@@ -2670,7 +2670,7 @@
         "reference": "Encounter/81A3B881-FE23-4346-A7ED-48ED539E9054"
       },
       "effectiveDateTime": "2010-02-06T12:41:00+00:00",
-      "issued": "2010-02-06T12:44:53.000+00:00",
+      "issued": "2010-02-06T12:41:00.000+00:00",
       "performer": [ {
         "reference": "Practitioner/C5DEFBF3-0174-BC6F-182C-B777B9C6FF43"
       } ]
@@ -2716,7 +2716,7 @@
         "reference": "Encounter/81A3B881-FE23-4346-A7ED-48ED539E9054"
       },
       "effectiveDateTime": "2010-02-06T12:41:00+00:00",
-      "issued": "2010-02-06T12:44:53.000+00:00",
+      "issued": "2010-02-06T12:41:00.000+00:00",
       "performer": [ {
         "reference": "Practitioner/C5DEFBF3-0174-BC6F-182C-B777B9C6FF43"
       } ],
@@ -2772,7 +2772,7 @@
         "reference": "Encounter/81A3B881-FE23-4346-A7ED-48ED539E9054"
       },
       "effectiveDateTime": "2010-02-06T12:41:00+00:00",
-      "issued": "2010-02-06T12:44:53.000+00:00",
+      "issued": "2010-02-06T12:41:00.000+00:00",
       "performer": [ {
         "reference": "Practitioner/C5DEFBF3-0174-BC6F-182C-B777B9C6FF43"
       } ],
@@ -2828,7 +2828,7 @@
         "reference": "Encounter/81A3B881-FE23-4346-A7ED-48ED539E9054"
       },
       "effectiveDateTime": "2010-02-06T12:41:00+00:00",
-      "issued": "2010-02-06T12:44:53.000+00:00",
+      "issued": "2010-02-06T12:41:00.000+00:00",
       "performer": [ {
         "reference": "Practitioner/C5DEFBF3-0174-BC6F-182C-B777B9C6FF43"
       } ],
@@ -2879,7 +2879,7 @@
         "reference": "Encounter/81A3B881-FE23-4346-A7ED-48ED539E9054"
       },
       "effectiveDateTime": "2010-02-06T12:41:00+00:00",
-      "issued": "2010-02-06T12:44:53.000+00:00",
+      "issued": "2010-02-06T12:41:00.000+00:00",
       "performer": [ {
         "reference": "Practitioner/C5DEFBF3-0174-BC6F-182C-B777B9C6FF43"
       } ],
@@ -2930,7 +2930,7 @@
         "reference": "Encounter/81A3B881-FE23-4346-A7ED-48ED539E9054"
       },
       "effectiveDateTime": "2010-02-06T12:41:00+00:00",
-      "issued": "2010-02-06T12:44:53.000+00:00",
+      "issued": "2010-02-06T12:41:00.000+00:00",
       "performer": [ {
         "reference": "Practitioner/C5DEFBF3-0174-BC6F-182C-B777B9C6FF43"
       } ],
@@ -2977,7 +2977,7 @@
         "reference": "Encounter/81A3B881-FE23-4346-A7ED-48ED539E9054"
       },
       "effectiveDateTime": "2010-02-06T12:41:00+00:00",
-      "issued": "2010-02-06T12:44:53.000+00:00",
+      "issued": "2010-02-06T12:41:00.000+00:00",
       "performer": [ {
         "reference": "Practitioner/C5DEFBF3-0174-BC6F-182C-B777B9C6FF43"
       } ]
@@ -3023,7 +3023,7 @@
         "reference": "Encounter/81A3B881-FE23-4346-A7ED-48ED539E9054"
       },
       "effectiveDateTime": "2010-02-06T12:41:00+00:00",
-      "issued": "2010-02-06T12:44:53.000+00:00",
+      "issued": "2010-02-06T12:41:00.000+00:00",
       "performer": [ {
         "reference": "Practitioner/C5DEFBF3-0174-BC6F-182C-B777B9C6FF43"
       } ]
@@ -3066,7 +3066,7 @@
         "reference": "Encounter/81A3B881-FE23-4346-A7ED-48ED539E9054"
       },
       "effectiveDateTime": "2010-02-06T12:41:00+00:00",
-      "issued": "2010-02-06T12:44:53.000+00:00",
+      "issued": "2010-02-06T12:41:00.000+00:00",
       "performer": [ {
         "reference": "Practitioner/C5DEFBF3-0174-BC6F-182C-B777B9C6FF43"
       } ]
@@ -3112,7 +3112,7 @@
         "reference": "Encounter/81A3B881-FE23-4346-A7ED-48ED539E9054"
       },
       "effectiveDateTime": "2010-02-06T12:41:00+00:00",
-      "issued": "2010-02-06T12:44:53.000+00:00",
+      "issued": "2010-02-06T12:41:00.000+00:00",
       "performer": [ {
         "reference": "Practitioner/C5DEFBF3-0174-BC6F-182C-B777B9C6FF43"
       } ]
@@ -3158,7 +3158,7 @@
         "reference": "Encounter/81A3B881-FE23-4346-A7ED-48ED539E9054"
       },
       "effectiveDateTime": "2010-02-06T12:41:00+00:00",
-      "issued": "2010-02-06T12:44:53.000+00:00",
+      "issued": "2010-02-06T12:41:00.000+00:00",
       "performer": [ {
         "reference": "Practitioner/C5DEFBF3-0174-BC6F-182C-B777B9C6FF43"
       } ],
@@ -3205,7 +3205,7 @@
         "reference": "Encounter/81A3B881-FE23-4346-A7ED-48ED539E9054"
       },
       "effectiveDateTime": "2010-02-06T12:41:00+00:00",
-      "issued": "2010-02-06T12:44:53.000+00:00",
+      "issued": "2010-02-06T12:41:00.000+00:00",
       "performer": [ {
         "reference": "Practitioner/C5DEFBF3-0174-BC6F-182C-B777B9C6FF43"
       } ]
@@ -3251,7 +3251,7 @@
         "reference": "Encounter/81A3B881-FE23-4346-A7ED-48ED539E9054"
       },
       "effectiveDateTime": "2010-02-06T12:41:00+00:00",
-      "issued": "2010-02-06T12:44:53.000+00:00",
+      "issued": "2010-02-06T12:41:00.000+00:00",
       "performer": [ {
         "reference": "Practitioner/C5DEFBF3-0174-BC6F-182C-B777B9C6FF43"
       } ],
@@ -3298,7 +3298,7 @@
         "reference": "Encounter/81A3B881-FE23-4346-A7ED-48ED539E9054"
       },
       "effectiveDateTime": "2010-02-06T12:41:00+00:00",
-      "issued": "2010-02-06T12:44:53.000+00:00",
+      "issued": "2010-02-06T12:41:00.000+00:00",
       "performer": [ {
         "reference": "Practitioner/C5DEFBF3-0174-BC6F-182C-B777B9C6FF43"
       } ]
@@ -3344,7 +3344,7 @@
         "reference": "Encounter/81A3B881-FE23-4346-A7ED-48ED539E9054"
       },
       "effectiveDateTime": "2010-02-06T12:41:00+00:00",
-      "issued": "2010-02-06T12:44:53.000+00:00",
+      "issued": "2010-02-06T12:41:00.000+00:00",
       "performer": [ {
         "reference": "Practitioner/C5DEFBF3-0174-BC6F-182C-B777B9C6FF43"
       } ]
@@ -3390,7 +3390,7 @@
         "reference": "Encounter/81A3B881-FE23-4346-A7ED-48ED539E9054"
       },
       "effectiveDateTime": "2010-02-06T12:41:00+00:00",
-      "issued": "2010-02-06T12:44:53.000+00:00",
+      "issued": "2010-02-06T12:41:00.000+00:00",
       "performer": [ {
         "reference": "Practitioner/C5DEFBF3-0174-BC6F-182C-B777B9C6FF43"
       } ],

--- a/gp2gp-translator/src/integrationTest/resources/e2e-mapping/output-json/PWTP11-output.json
+++ b/gp2gp-translator/src/integrationTest/resources/e2e-mapping/output-json/PWTP11-output.json
@@ -2471,7 +2471,7 @@
         "reference": "Encounter/3F785B5D-7964-444A-8E3F-6D0AF25E86AD"
       },
       "effectiveDateTime": "2010-02-10T08:30:00+00:00",
-      "issued": "2010-02-10T08:31:53.000+00:00",
+      "issued": "2010-02-10T08:30:00.000+00:00",
       "performer": [ {
         "reference": "Practitioner/1E473786-E7FA-785E-C911-A8D38FB56F20"
       } ],
@@ -2518,7 +2518,7 @@
         "reference": "Encounter/3F785B5D-7964-444A-8E3F-6D0AF25E86AD"
       },
       "effectiveDateTime": "2010-02-10T08:30:00+00:00",
-      "issued": "2010-02-10T08:31:53.000+00:00",
+      "issued": "2010-02-10T08:30:00.000+00:00",
       "performer": [ {
         "reference": "Practitioner/1E473786-E7FA-785E-C911-A8D38FB56F20"
       } ]
@@ -2564,7 +2564,7 @@
         "reference": "Encounter/3F785B5D-7964-444A-8E3F-6D0AF25E86AD"
       },
       "effectiveDateTime": "2010-02-10T08:30:00+00:00",
-      "issued": "2010-02-10T08:31:53.000+00:00",
+      "issued": "2010-02-10T08:30:00.000+00:00",
       "performer": [ {
         "reference": "Practitioner/1E473786-E7FA-785E-C911-A8D38FB56F20"
       } ]
@@ -2610,7 +2610,7 @@
         "reference": "Encounter/3F785B5D-7964-444A-8E3F-6D0AF25E86AD"
       },
       "effectiveDateTime": "2010-02-10T08:30:00+00:00",
-      "issued": "2010-02-10T08:31:53.000+00:00",
+      "issued": "2010-02-10T08:30:00.000+00:00",
       "performer": [ {
         "reference": "Practitioner/1E473786-E7FA-785E-C911-A8D38FB56F20"
       } ]
@@ -2656,7 +2656,7 @@
         "reference": "Encounter/3F785B5D-7964-444A-8E3F-6D0AF25E86AD"
       },
       "effectiveDateTime": "2010-02-10T08:30:00+00:00",
-      "issued": "2010-02-10T08:31:53.000+00:00",
+      "issued": "2010-02-10T08:30:00.000+00:00",
       "performer": [ {
         "reference": "Practitioner/1E473786-E7FA-785E-C911-A8D38FB56F20"
       } ],
@@ -2703,7 +2703,7 @@
         "reference": "Encounter/3F785B5D-7964-444A-8E3F-6D0AF25E86AD"
       },
       "effectiveDateTime": "2010-02-10T08:30:00+00:00",
-      "issued": "2010-02-10T08:31:53.000+00:00",
+      "issued": "2010-02-10T08:30:00.000+00:00",
       "performer": [ {
         "reference": "Practitioner/1E473786-E7FA-785E-C911-A8D38FB56F20"
       } ]
@@ -2749,7 +2749,7 @@
         "reference": "Encounter/76102D2A-8898-4EE3-B0C5-72FC95F93BB0"
       },
       "effectiveDateTime": "2010-03-23T07:59:00+00:00",
-      "issued": "2010-03-24T09:00:00.000+00:00",
+      "issued": "2010-03-23T07:59:00.000+00:00",
       "performer": [ {
         "reference": "Practitioner/1E473786-E7FA-785E-C911-A8D38FB56F20"
       } ],
@@ -2796,7 +2796,7 @@
         "reference": "Encounter/76102D2A-8898-4EE3-B0C5-72FC95F93BB0"
       },
       "effectiveDateTime": "2010-03-23T07:59:00+00:00",
-      "issued": "2010-03-24T09:00:00.000+00:00",
+      "issued": "2010-03-23T07:59:00.000+00:00",
       "performer": [ {
         "reference": "Practitioner/1E473786-E7FA-785E-C911-A8D38FB56F20"
       } ],
@@ -2843,7 +2843,7 @@
         "reference": "Encounter/76102D2A-8898-4EE3-B0C5-72FC95F93BB0"
       },
       "effectiveDateTime": "2010-03-23T07:59:00+00:00",
-      "issued": "2010-03-24T09:00:00.000+00:00",
+      "issued": "2010-03-23T07:59:00.000+00:00",
       "performer": [ {
         "reference": "Practitioner/1E473786-E7FA-785E-C911-A8D38FB56F20"
       } ],
@@ -2895,7 +2895,7 @@
         "reference": "Encounter/76102D2A-8898-4EE3-B0C5-72FC95F93BB0"
       },
       "effectiveDateTime": "2010-03-23T07:59:00+00:00",
-      "issued": "2010-03-24T09:00:00.000+00:00",
+      "issued": "2010-03-23T07:59:00.000+00:00",
       "performer": [ {
         "reference": "Practitioner/1E473786-E7FA-785E-C911-A8D38FB56F20"
       } ],
@@ -2939,7 +2939,7 @@
         "reference": "Encounter/76102D2A-8898-4EE3-B0C5-72FC95F93BB0"
       },
       "effectiveDateTime": "2010-03-23T07:59:00+00:00",
-      "issued": "2010-03-24T09:00:00.000+00:00",
+      "issued": "2010-03-23T07:59:00.000+00:00",
       "performer": [ {
         "reference": "Practitioner/1E473786-E7FA-785E-C911-A8D38FB56F20"
       } ]
@@ -2985,7 +2985,7 @@
         "reference": "Encounter/76102D2A-8898-4EE3-B0C5-72FC95F93BB0"
       },
       "effectiveDateTime": "2010-03-23T07:59:00+00:00",
-      "issued": "2010-03-24T09:00:00.000+00:00",
+      "issued": "2010-03-23T07:59:00.000+00:00",
       "performer": [ {
         "reference": "Practitioner/1E473786-E7FA-785E-C911-A8D38FB56F20"
       } ],
@@ -3032,7 +3032,7 @@
         "reference": "Encounter/76102D2A-8898-4EE3-B0C5-72FC95F93BB0"
       },
       "effectiveDateTime": "2010-03-23T07:59:00+00:00",
-      "issued": "2010-03-24T09:00:00.000+00:00",
+      "issued": "2010-03-23T07:59:00.000+00:00",
       "performer": [ {
         "reference": "Practitioner/1E473786-E7FA-785E-C911-A8D38FB56F20"
       } ],
@@ -3083,7 +3083,7 @@
         "reference": "Encounter/76102D2A-8898-4EE3-B0C5-72FC95F93BB0"
       },
       "effectiveDateTime": "2010-03-23T07:59:00+00:00",
-      "issued": "2010-03-24T09:00:00.000+00:00",
+      "issued": "2010-03-23T07:59:00.000+00:00",
       "performer": [ {
         "reference": "Practitioner/1E473786-E7FA-785E-C911-A8D38FB56F20"
       } ],
@@ -3130,7 +3130,7 @@
         "reference": "Encounter/22A00924-FCA4-4B32-9588-5BBC1145AAB0"
       },
       "effectiveDateTime": "2010-03-23T13:46:00+00:00",
-      "issued": "2010-03-23T15:02:28.000+00:00",
+      "issued": "2010-03-23T13:46:00.000+00:00",
       "performer": [ {
         "reference": "Practitioner/1E473786-E7FA-785E-C911-A8D38FB56F20"
       } ],
@@ -3177,7 +3177,7 @@
         "reference": "Encounter/6B023A7D-ABD9-494B-A133-D77E6A4B0D2C"
       },
       "effectiveDateTime": "2010-03-24",
-      "issued": "2010-03-24T09:04:07.000+00:00",
+      "issued": "2010-03-24T00:00:00.000+00:00",
       "performer": [ {
         "reference": "Practitioner/1E473786-E7FA-785E-C911-A8D38FB56F20"
       } ],
@@ -3224,7 +3224,7 @@
         "reference": "Encounter/6B023A7D-ABD9-494B-A133-D77E6A4B0D2C"
       },
       "effectiveDateTime": "2010-03-24",
-      "issued": "2010-03-24T09:04:07.000+00:00",
+      "issued": "2010-03-24T00:00:00.000+00:00",
       "performer": [ {
         "reference": "Practitioner/1E473786-E7FA-785E-C911-A8D38FB56F20"
       } ],
@@ -3271,7 +3271,7 @@
         "reference": "Encounter/18CE5476-4631-4E23-9BF9-6DF67556EEB4"
       },
       "effectiveDateTime": "2010-03-24",
-      "issued": "2010-03-24T09:04:17.000+00:00",
+      "issued": "2010-03-24T00:00:00.000+00:00",
       "performer": [ {
         "reference": "Practitioner/1E473786-E7FA-785E-C911-A8D38FB56F20"
       } ],
@@ -3315,7 +3315,7 @@
         "reference": "Encounter/18CE5476-4631-4E23-9BF9-6DF67556EEB4"
       },
       "effectiveDateTime": "2010-03-24",
-      "issued": "2010-03-24T09:04:17.000+00:00",
+      "issued": "2010-03-24T00:00:00.000+00:00",
       "performer": [ {
         "reference": "Practitioner/1E473786-E7FA-785E-C911-A8D38FB56F20"
       } ]
@@ -3361,7 +3361,7 @@
         "reference": "Encounter/12F40565-E231-449D-ABE1-803ECEB7FAEA"
       },
       "effectiveDateTime": "2010-03-24",
-      "issued": "2010-03-24T09:04:28.000+00:00",
+      "issued": "2010-03-24T00:00:00.000+00:00",
       "performer": [ {
         "reference": "Practitioner/1E473786-E7FA-785E-C911-A8D38FB56F20"
       } ],
@@ -3408,7 +3408,7 @@
         "reference": "Encounter/12F40565-E231-449D-ABE1-803ECEB7FAEA"
       },
       "effectiveDateTime": "2010-03-24",
-      "issued": "2010-03-24T09:04:28.000+00:00",
+      "issued": "2010-03-24T00:00:00.000+00:00",
       "performer": [ {
         "reference": "Practitioner/1E473786-E7FA-785E-C911-A8D38FB56F20"
       } ],
@@ -3455,7 +3455,7 @@
         "reference": "Encounter/67D1789F-D717-4A94-B026-4BA3513C4433"
       },
       "effectiveDateTime": "2010-03-24",
-      "issued": "2010-03-24T09:07:42.000+00:00",
+      "issued": "2010-03-24T00:00:00.000+00:00",
       "performer": [ {
         "reference": "Practitioner/1E473786-E7FA-785E-C911-A8D38FB56F20"
       } ],
@@ -3499,7 +3499,7 @@
         "reference": "Patient/00000000-0000-0000-0000-000000000008"
       },
       "effectiveDateTime": "2001-03-01",
-      "issued": "2010-02-10T08:11:29.000+00:00",
+      "issued": "2001-03-01T00:00:00.000+00:00",
       "performer": [ {
         "reference": "Practitioner/1E473786-E7FA-785E-C911-A8D38FB56F20"
       } ],
@@ -3543,7 +3543,7 @@
         "reference": "Patient/00000000-0000-0000-0000-000000000008"
       },
       "effectiveDateTime": "2008-06-01",
-      "issued": "2010-02-10T08:43:34.000+00:00",
+      "issued": "2008-06-01T00:00:00.000+00:00",
       "performer": [ {
         "reference": "Practitioner/1E473786-E7FA-785E-C911-A8D38FB56F20"
       } ],
@@ -3587,7 +3587,7 @@
         "reference": "Patient/00000000-0000-0000-0000-000000000008"
       },
       "effectiveDateTime": "2009-03-18",
-      "issued": "2010-02-10T08:11:10.000+00:00",
+      "issued": "2009-03-18T00:00:00.000+00:00",
       "performer": [ {
         "reference": "Practitioner/1E473786-E7FA-785E-C911-A8D38FB56F20"
       } ],
@@ -3631,7 +3631,7 @@
         "reference": "Patient/00000000-0000-0000-0000-000000000008"
       },
       "effectiveDateTime": "2010-02-10",
-      "issued": "2010-02-10T08:11:29.000+00:00",
+      "issued": "2010-02-10T00:00:00.000+00:00",
       "performer": [ {
         "reference": "Practitioner/1E473786-E7FA-785E-C911-A8D38FB56F20"
       } ],
@@ -3672,7 +3672,7 @@
         "reference": "Patient/00000000-0000-0000-0000-000000000008"
       },
       "effectiveDateTime": "2010-02-10",
-      "issued": "2010-02-10T08:15:25.000+00:00",
+      "issued": "2010-02-10T00:00:00.000+00:00",
       "performer": [ {
         "reference": "Practitioner/1E473786-E7FA-785E-C911-A8D38FB56F20"
       } ],
@@ -3716,7 +3716,7 @@
         "reference": "Patient/00000000-0000-0000-0000-000000000008"
       },
       "effectiveDateTime": "2010-02-10",
-      "issued": "2010-02-10T08:19:04.000+00:00",
+      "issued": "2010-02-10T00:00:00.000+00:00",
       "performer": [ {
         "reference": "Practitioner/1E473786-E7FA-785E-C911-A8D38FB56F20"
       } ],
@@ -3760,7 +3760,7 @@
         "reference": "Patient/00000000-0000-0000-0000-000000000008"
       },
       "effectiveDateTime": "2010-02-10",
-      "issued": "2010-02-10T08:20:00.000+00:00",
+      "issued": "2010-02-10T00:00:00.000+00:00",
       "performer": [ {
         "reference": "Practitioner/1E473786-E7FA-785E-C911-A8D38FB56F20"
       } ],
@@ -3804,7 +3804,7 @@
         "reference": "Patient/00000000-0000-0000-0000-000000000008"
       },
       "effectiveDateTime": "2010-02-10",
-      "issued": "2010-02-10T08:23:25.000+00:00",
+      "issued": "2010-02-10T00:00:00.000+00:00",
       "performer": [ {
         "reference": "Practitioner/1E473786-E7FA-785E-C911-A8D38FB56F20"
       } ],
@@ -3845,7 +3845,7 @@
         "reference": "Patient/00000000-0000-0000-0000-000000000008"
       },
       "effectiveDateTime": "2010-02-10",
-      "issued": "2010-02-10T08:35:37.000+00:00",
+      "issued": "2010-02-10T00:00:00.000+00:00",
       "performer": [ {
         "reference": "Practitioner/1E473786-E7FA-785E-C911-A8D38FB56F20"
       } ],
@@ -3889,7 +3889,7 @@
         "reference": "Patient/00000000-0000-0000-0000-000000000008"
       },
       "effectiveDateTime": "2010-02-10",
-      "issued": "2010-02-10T08:35:57.000+00:00",
+      "issued": "2010-02-10T00:00:00.000+00:00",
       "performer": [ {
         "reference": "Practitioner/1E473786-E7FA-785E-C911-A8D38FB56F20"
       } ],
@@ -3933,7 +3933,7 @@
         "reference": "Patient/00000000-0000-0000-0000-000000000008"
       },
       "effectiveDateTime": "2010-02-10",
-      "issued": "2010-02-10T08:43:34.000+00:00",
+      "issued": "2010-02-10T00:00:00.000+00:00",
       "performer": [ {
         "reference": "Practitioner/1E473786-E7FA-785E-C911-A8D38FB56F20"
       } ],
@@ -3977,7 +3977,7 @@
         "reference": "Patient/00000000-0000-0000-0000-000000000008"
       },
       "effectiveDateTime": "2010-03-23",
-      "issued": "2010-03-23T15:06:09.000+00:00",
+      "issued": "2010-03-23T00:00:00.000+00:00",
       "performer": [ {
         "reference": "Practitioner/1E473786-E7FA-785E-C911-A8D38FB56F20"
       } ],

--- a/gp2gp-translator/src/integrationTest/resources/e2e-mapping/output-json/PWTP2-output.json
+++ b/gp2gp-translator/src/integrationTest/resources/e2e-mapping/output-json/PWTP2-output.json
@@ -6654,7 +6654,7 @@
         "reference": "Encounter/9B69EBA5-F541-4119-9142-0AA0F87E3758"
       },
       "effectiveDateTime": "2009-11-02",
-      "issued": "2010-01-13T15:13:32.000+00:00",
+      "issued": "2009-11-02T00:00:00.000+00:00",
       "performer": [ {
         "reference": "Practitioner/C5DEFBF3-0174-BC6F-182C-B777B9C6FF43"
       } ],
@@ -6701,7 +6701,7 @@
         "reference": "Encounter/9B69EBA5-F541-4119-9142-0AA0F87E3758"
       },
       "effectiveDateTime": "2009-11-02",
-      "issued": "2010-01-13T15:13:32.000+00:00",
+      "issued": "2009-11-02T00:00:00.000+00:00",
       "performer": [ {
         "reference": "Practitioner/C5DEFBF3-0174-BC6F-182C-B777B9C6FF43"
       } ],
@@ -6757,7 +6757,7 @@
         "reference": "Encounter/9B69EBA5-F541-4119-9142-0AA0F87E3758"
       },
       "effectiveDateTime": "2009-11-02",
-      "issued": "2010-01-13T15:13:32.000+00:00",
+      "issued": "2009-11-02T00:00:00.000+00:00",
       "performer": [ {
         "reference": "Practitioner/C5DEFBF3-0174-BC6F-182C-B777B9C6FF43"
       } ],
@@ -6813,7 +6813,7 @@
         "reference": "Encounter/9B69EBA5-F541-4119-9142-0AA0F87E3758"
       },
       "effectiveDateTime": "2009-11-02",
-      "issued": "2010-01-13T15:13:32.000+00:00",
+      "issued": "2009-11-02T00:00:00.000+00:00",
       "performer": [ {
         "reference": "Practitioner/C5DEFBF3-0174-BC6F-182C-B777B9C6FF43"
       } ],
@@ -6864,7 +6864,7 @@
         "reference": "Encounter/9B69EBA5-F541-4119-9142-0AA0F87E3758"
       },
       "effectiveDateTime": "2009-11-02",
-      "issued": "2010-01-13T15:13:32.000+00:00",
+      "issued": "2009-11-02T00:00:00.000+00:00",
       "performer": [ {
         "reference": "Practitioner/C5DEFBF3-0174-BC6F-182C-B777B9C6FF43"
       } ],
@@ -6915,7 +6915,7 @@
         "reference": "Encounter/9B69EBA5-F541-4119-9142-0AA0F87E3758"
       },
       "effectiveDateTime": "2009-11-02",
-      "issued": "2010-01-13T15:13:32.000+00:00",
+      "issued": "2009-11-02T00:00:00.000+00:00",
       "performer": [ {
         "reference": "Practitioner/C5DEFBF3-0174-BC6F-182C-B777B9C6FF43"
       } ],
@@ -6967,7 +6967,7 @@
         "reference": "Encounter/9B69EBA5-F541-4119-9142-0AA0F87E3758"
       },
       "effectiveDateTime": "2009-11-02",
-      "issued": "2010-01-13T15:13:32.000+00:00",
+      "issued": "2009-11-02T00:00:00.000+00:00",
       "performer": [ {
         "reference": "Practitioner/C5DEFBF3-0174-BC6F-182C-B777B9C6FF43"
       } ],
@@ -7014,7 +7014,7 @@
         "reference": "Encounter/B618332C-F6FC-4A79-B193-580FD098B95C"
       },
       "effectiveDateTime": "2010-01-13",
-      "issued": "2010-01-13T11:37:33.000+00:00",
+      "issued": "2010-01-13T00:00:00.000+00:00",
       "performer": [ {
         "reference": "Practitioner/1E473786-E7FA-785E-C911-A8D38FB56F20"
       } ]
@@ -7057,7 +7057,7 @@
         "reference": "Encounter/F9ADFA5F-A4D0-469D-B22F-2F1787DD7F05"
       },
       "effectiveDateTime": "2010-01-13T11:48:00+00:00",
-      "issued": "2010-01-13T11:42:01.000+00:00",
+      "issued": "2010-01-13T11:48:00.000+00:00",
       "performer": [ {
         "reference": "Practitioner/1E473786-E7FA-785E-C911-A8D38FB56F20"
       } ],
@@ -7108,7 +7108,7 @@
         "reference": "Encounter/F9ADFA5F-A4D0-469D-B22F-2F1787DD7F05"
       },
       "effectiveDateTime": "2010-01-13T11:48:00+00:00",
-      "issued": "2010-01-13T11:42:01.000+00:00",
+      "issued": "2010-01-13T11:48:00.000+00:00",
       "performer": [ {
         "reference": "Practitioner/1E473786-E7FA-785E-C911-A8D38FB56F20"
       } ],
@@ -7156,7 +7156,7 @@
         "reference": "Encounter/F9ADFA5F-A4D0-469D-B22F-2F1787DD7F05"
       },
       "effectiveDateTime": "2010-01-13T11:48:00+00:00",
-      "issued": "2010-01-13T11:42:01.000+00:00",
+      "issued": "2010-01-13T11:48:00.000+00:00",
       "performer": [ {
         "reference": "Practitioner/1E473786-E7FA-785E-C911-A8D38FB56F20"
       } ],
@@ -7207,7 +7207,7 @@
         "reference": "Encounter/F9ADFA5F-A4D0-469D-B22F-2F1787DD7F05"
       },
       "effectiveDateTime": "2010-01-13T11:48:00+00:00",
-      "issued": "2010-01-13T11:42:01.000+00:00",
+      "issued": "2010-01-13T11:48:00.000+00:00",
       "performer": [ {
         "reference": "Practitioner/1E473786-E7FA-785E-C911-A8D38FB56F20"
       } ]
@@ -7253,7 +7253,7 @@
         "reference": "Encounter/F9ADFA5F-A4D0-469D-B22F-2F1787DD7F05"
       },
       "effectiveDateTime": "2010-01-13T11:48:00+00:00",
-      "issued": "2010-01-13T11:42:01.000+00:00",
+      "issued": "2010-01-13T11:48:00.000+00:00",
       "performer": [ {
         "reference": "Practitioner/1E473786-E7FA-785E-C911-A8D38FB56F20"
       } ]
@@ -7299,7 +7299,7 @@
         "reference": "Encounter/F9ADFA5F-A4D0-469D-B22F-2F1787DD7F05"
       },
       "effectiveDateTime": "2010-01-13T11:48:00+00:00",
-      "issued": "2010-01-13T11:42:01.000+00:00",
+      "issued": "2010-01-13T11:48:00.000+00:00",
       "performer": [ {
         "reference": "Practitioner/1E473786-E7FA-785E-C911-A8D38FB56F20"
       } ]
@@ -7345,7 +7345,7 @@
         "reference": "Encounter/F9ADFA5F-A4D0-469D-B22F-2F1787DD7F05"
       },
       "effectiveDateTime": "2010-01-13T11:48:00+00:00",
-      "issued": "2010-01-13T11:42:01.000+00:00",
+      "issued": "2010-01-13T11:48:00.000+00:00",
       "performer": [ {
         "reference": "Practitioner/1E473786-E7FA-785E-C911-A8D38FB56F20"
       } ]
@@ -7391,7 +7391,7 @@
         "reference": "Encounter/9B69F6AE-F991-49EE-9FFD-028E39B38BFE"
       },
       "effectiveDateTime": "2010-01-23T13:48:00+00:00",
-      "issued": "2010-01-23T14:03:54.000+00:00",
+      "issued": "2010-01-23T13:48:00.000+00:00",
       "performer": [ {
         "reference": "Practitioner/1E473786-E7FA-785E-C911-A8D38FB56F20"
       } ],
@@ -7438,7 +7438,7 @@
         "reference": "Encounter/9B69F6AE-F991-49EE-9FFD-028E39B38BFE"
       },
       "effectiveDateTime": "2010-01-23T13:48:00+00:00",
-      "issued": "2010-01-23T14:03:54.000+00:00",
+      "issued": "2010-01-23T13:48:00.000+00:00",
       "performer": [ {
         "reference": "Practitioner/1E473786-E7FA-785E-C911-A8D38FB56F20"
       } ]
@@ -7484,7 +7484,7 @@
         "reference": "Encounter/9B69F6AE-F991-49EE-9FFD-028E39B38BFE"
       },
       "effectiveDateTime": "2010-01-23T13:48:00+00:00",
-      "issued": "2010-01-23T14:03:54.000+00:00",
+      "issued": "2010-01-23T13:48:00.000+00:00",
       "performer": [ {
         "reference": "Practitioner/1E473786-E7FA-785E-C911-A8D38FB56F20"
       } ],
@@ -7531,7 +7531,7 @@
         "reference": "Encounter/9B69F6AE-F991-49EE-9FFD-028E39B38BFE"
       },
       "effectiveDateTime": "2010-01-23T13:48:00+00:00",
-      "issued": "2010-01-23T14:03:54.000+00:00",
+      "issued": "2010-01-23T13:48:00.000+00:00",
       "performer": [ {
         "reference": "Practitioner/1E473786-E7FA-785E-C911-A8D38FB56F20"
       } ]
@@ -7577,7 +7577,7 @@
         "reference": "Encounter/9B69F6AE-F991-49EE-9FFD-028E39B38BFE"
       },
       "effectiveDateTime": "2010-01-23T13:48:00+00:00",
-      "issued": "2010-01-23T14:03:54.000+00:00",
+      "issued": "2010-01-23T13:48:00.000+00:00",
       "performer": [ {
         "reference": "Practitioner/1E473786-E7FA-785E-C911-A8D38FB56F20"
       } ],
@@ -7624,7 +7624,7 @@
         "reference": "Encounter/9B69F6AE-F991-49EE-9FFD-028E39B38BFE"
       },
       "effectiveDateTime": "2010-01-23T13:48:00+00:00",
-      "issued": "2010-01-23T14:03:54.000+00:00",
+      "issued": "2010-01-23T13:48:00.000+00:00",
       "performer": [ {
         "reference": "Practitioner/1E473786-E7FA-785E-C911-A8D38FB56F20"
       } ],
@@ -7671,7 +7671,7 @@
         "reference": "Encounter/4088F3A1-CE58-4374-AABA-763C31738281"
       },
       "effectiveDateTime": "2010-07-14T16:55:00+00:00",
-      "issued": "2010-07-14T15:28:13.000+00:00",
+      "issued": "2010-07-14T16:55:00.000+00:00",
       "performer": [ {
         "reference": "Practitioner/1E473786-E7FA-785E-C911-A8D38FB56F20"
       } ],
@@ -7727,7 +7727,7 @@
         "reference": "Encounter/4088F3A1-CE58-4374-AABA-763C31738281"
       },
       "effectiveDateTime": "2010-07-14T16:55:00+00:00",
-      "issued": "2010-07-14T15:28:13.000+00:00",
+      "issued": "2010-07-14T16:55:00.000+00:00",
       "performer": [ {
         "reference": "Practitioner/1E473786-E7FA-785E-C911-A8D38FB56F20"
       } ],
@@ -7780,7 +7780,7 @@
         "reference": "Encounter/DBF5776F-8A86-477C-AB98-57182A9B40FD"
       },
       "effectiveDateTime": "2010-07-14T17:07:00+00:00",
-      "issued": "2010-07-14T15:32:32.000+00:00",
+      "issued": "2010-07-14T17:07:00.000+00:00",
       "performer": [ {
         "reference": "Practitioner/1E473786-E7FA-785E-C911-A8D38FB56F20"
       } ],
@@ -7824,7 +7824,7 @@
         "reference": "Patient/00000000-0000-0000-0000-000000000010"
       },
       "effectiveDateTime": "1988-01-01",
-      "issued": "2010-01-13T15:41:41.000+00:00",
+      "issued": "1988-01-01T00:00:00.000+00:00",
       "performer": [ {
         "reference": "Practitioner/1E473786-E7FA-785E-C911-A8D38FB56F20"
       } ],
@@ -7868,7 +7868,7 @@
         "reference": "Patient/00000000-0000-0000-0000-000000000010"
       },
       "effectiveDateTime": "2010-01-13",
-      "issued": "2010-01-13T11:41:11.000+00:00",
+      "issued": "2010-01-13T00:00:00.000+00:00",
       "performer": [ {
         "reference": "Practitioner/1E473786-E7FA-785E-C911-A8D38FB56F20"
       } ],
@@ -7912,7 +7912,7 @@
         "reference": "Patient/00000000-0000-0000-0000-000000000010"
       },
       "effectiveDateTime": "2010-01-13",
-      "issued": "2010-01-13T14:57:25.000+00:00",
+      "issued": "2010-01-13T00:00:00.000+00:00",
       "performer": [ {
         "reference": "Practitioner/1E473786-E7FA-785E-C911-A8D38FB56F20"
       } ],
@@ -7956,7 +7956,7 @@
         "reference": "Patient/00000000-0000-0000-0000-000000000010"
       },
       "effectiveDateTime": "2010-01-13",
-      "issued": "2010-01-13T14:57:39.000+00:00",
+      "issued": "2010-01-13T00:00:00.000+00:00",
       "performer": [ {
         "reference": "Practitioner/1E473786-E7FA-785E-C911-A8D38FB56F20"
       } ],
@@ -8000,7 +8000,7 @@
         "reference": "Patient/00000000-0000-0000-0000-000000000010"
       },
       "effectiveDateTime": "2010-06-09T15:08:00+00:00",
-      "issued": "2010-06-09T15:04:09.000+00:00",
+      "issued": "2010-06-09T15:08:00.000+00:00",
       "performer": [ {
         "reference": "Practitioner/C5DEFBF3-0174-BC6F-182C-B777B9C6FF43"
       } ]
@@ -8043,7 +8043,7 @@
         "reference": "Patient/00000000-0000-0000-0000-000000000010"
       },
       "effectiveDateTime": "2010-07-14",
-      "issued": "2010-07-14T15:27:49.000+00:00",
+      "issued": "2010-07-14T00:00:00.000+00:00",
       "performer": [ {
         "reference": "Practitioner/1E473786-E7FA-785E-C911-A8D38FB56F20"
       } ],
@@ -8096,7 +8096,7 @@
         "reference": "Patient/00000000-0000-0000-0000-000000000010"
       },
       "effectiveDateTime": "2010-07-14",
-      "issued": "2010-07-14T15:27:49.000+00:00",
+      "issued": "2010-07-14T00:00:00.000+00:00",
       "performer": [ {
         "reference": "Practitioner/1E473786-E7FA-785E-C911-A8D38FB56F20"
       } ],
@@ -8149,7 +8149,7 @@
         "reference": "Patient/00000000-0000-0000-0000-000000000010"
       },
       "effectiveDateTime": "2010-07-14",
-      "issued": "2010-07-14T15:31:24.000+00:00",
+      "issued": "2010-07-14T00:00:00.000+00:00",
       "performer": [ {
         "reference": "Practitioner/1E473786-E7FA-785E-C911-A8D38FB56F20"
       } ],
@@ -8193,7 +8193,7 @@
         "reference": "Patient/00000000-0000-0000-0000-000000000010"
       },
       "effectiveDateTime": "2010-07-14",
-      "issued": "2010-07-14T15:32:51.000+00:00",
+      "issued": "2010-07-14T00:00:00.000+00:00",
       "performer": [ {
         "reference": "Practitioner/1E473786-E7FA-785E-C911-A8D38FB56F20"
       } ],

--- a/gp2gp-translator/src/integrationTest/resources/e2e-mapping/output-json/PWTP3-output.json
+++ b/gp2gp-translator/src/integrationTest/resources/e2e-mapping/output-json/PWTP3-output.json
@@ -638,7 +638,7 @@
         "reference": "Encounter/5649F991-91C0-4A01-A9CA-7C12F4032DD6"
       },
       "effectiveDateTime": "2010-01-23T13:27:00+00:00",
-      "issued": "2010-01-23T13:27:34.000+00:00",
+      "issued": "2010-01-23T13:27:00.000+00:00",
       "performer": [ {
         "reference": "Practitioner/1E473786-E7FA-785E-C911-A8D38FB56F20"
       } ]
@@ -674,7 +674,7 @@
         "reference": "Encounter/5649F991-91C0-4A01-A9CA-7C12F4032DD6"
       },
       "effectiveDateTime": "2010-01-23T13:27:00+00:00",
-      "issued": "2010-01-23T13:27:34.000+00:00",
+      "issued": "2010-01-23T13:27:00.000+00:00",
       "performer": [ {
         "reference": "Practitioner/1E473786-E7FA-785E-C911-A8D38FB56F20"
       } ],
@@ -711,7 +711,7 @@
         "reference": "Encounter/5649F991-91C0-4A01-A9CA-7C12F4032DD6"
       },
       "effectiveDateTime": "2010-01-23T13:27:00+00:00",
-      "issued": "2010-01-23T13:27:34.000+00:00",
+      "issued": "2010-01-23T13:27:00.000+00:00",
       "performer": [ {
         "reference": "Practitioner/1E473786-E7FA-785E-C911-A8D38FB56F20"
       } ]
@@ -747,7 +747,7 @@
         "reference": "Encounter/5649F991-91C0-4A01-A9CA-7C12F4032DD6"
       },
       "effectiveDateTime": "2010-01-23T13:27:00+00:00",
-      "issued": "2010-01-23T13:27:34.000+00:00",
+      "issued": "2010-01-23T13:27:00.000+00:00",
       "performer": [ {
         "reference": "Practitioner/1E473786-E7FA-785E-C911-A8D38FB56F20"
       } ],
@@ -784,7 +784,7 @@
         "reference": "Encounter/5649F991-91C0-4A01-A9CA-7C12F4032DD6"
       },
       "effectiveDateTime": "2010-01-23T13:27:00+00:00",
-      "issued": "2010-01-23T13:27:34.000+00:00",
+      "issued": "2010-01-23T13:27:00.000+00:00",
       "performer": [ {
         "reference": "Practitioner/1E473786-E7FA-785E-C911-A8D38FB56F20"
       } ],
@@ -828,7 +828,7 @@
         "reference": "Patient/00000000-0000-0000-0000-000000000002"
       },
       "effectiveDateTime": "2010-01-14",
-      "issued": "2010-01-14T09:42:02.000+00:00",
+      "issued": "2010-01-14T00:00:00.000+00:00",
       "performer": [ {
         "reference": "Practitioner/1E473786-E7FA-785E-C911-A8D38FB56F20"
       } ]
@@ -871,7 +871,7 @@
         "reference": "Patient/00000000-0000-0000-0000-000000000002"
       },
       "effectiveDateTime": "2010-01-14T09:42:00+00:00",
-      "issued": "2010-01-14T09:42:02.000+00:00",
+      "issued": "2010-01-14T09:42:00.000+00:00",
       "performer": [ {
         "reference": "Practitioner/1E473786-E7FA-785E-C911-A8D38FB56F20"
       } ]
@@ -914,7 +914,7 @@
         "reference": "Patient/00000000-0000-0000-0000-000000000002"
       },
       "effectiveDateTime": "2010-01-14T09:42:00+00:00",
-      "issued": "2010-01-14T09:42:02.000+00:00",
+      "issued": "2010-01-14T09:42:00.000+00:00",
       "performer": [ {
         "reference": "Practitioner/1E473786-E7FA-785E-C911-A8D38FB56F20"
       } ]
@@ -957,7 +957,7 @@
         "reference": "Patient/00000000-0000-0000-0000-000000000002"
       },
       "effectiveDateTime": "2010-01-14T09:42:00+00:00",
-      "issued": "2010-01-14T09:42:02.000+00:00",
+      "issued": "2010-01-14T09:42:00.000+00:00",
       "performer": [ {
         "reference": "Practitioner/1E473786-E7FA-785E-C911-A8D38FB56F20"
       } ]
@@ -1000,7 +1000,7 @@
         "reference": "Patient/00000000-0000-0000-0000-000000000002"
       },
       "effectiveDateTime": "2010-02-22",
-      "issued": "2010-02-22T13:41:20.000+00:00",
+      "issued": "2010-02-22T00:00:00.000+00:00",
       "performer": [ {
         "reference": "Practitioner/1E473786-E7FA-785E-C911-A8D38FB56F20"
       } ],
@@ -1034,7 +1034,7 @@
         "reference": "Patient/00000000-0000-0000-0000-000000000002"
       },
       "effectiveDateTime": "2010-10-01",
-      "issued": "2010-10-01T10:00:06.000+00:00",
+      "issued": "2010-10-01T00:00:00.000+00:00",
       "performer": [ {
         "reference": "Practitioner/1E473786-E7FA-785E-C911-A8D38FB56F20"
       } ],
@@ -1078,7 +1078,7 @@
         "reference": "Patient/00000000-0000-0000-0000-000000000002"
       },
       "effectiveDateTime": "2010-10-12",
-      "issued": "2010-10-12T13:50:55.000+00:00",
+      "issued": "2010-10-12T00:00:00.000+00:00",
       "performer": [ {
         "reference": "Practitioner/1E473786-E7FA-785E-C911-A8D38FB56F20"
       } ],

--- a/gp2gp-translator/src/integrationTest/resources/e2e-mapping/output-json/PWTP4-output.json
+++ b/gp2gp-translator/src/integrationTest/resources/e2e-mapping/output-json/PWTP4-output.json
@@ -18284,7 +18284,7 @@
         "reference": "Encounter/0CF70E30-DD21-433E-87AE-F32DA5FBE4DA"
       },
       "effectiveDateTime": "2010-01-14",
-      "issued": "2010-01-14T10:34:30.000+00:00",
+      "issued": "2010-01-14T00:00:00.000+00:00",
       "performer": [ {
         "reference": "Practitioner/1E473786-E7FA-785E-C911-A8D38FB56F20"
       } ]
@@ -18330,7 +18330,7 @@
         "reference": "Encounter/A6CE9003-C784-4E11-A5C1-E406BCF35D55"
       },
       "effectiveDateTime": "2010-01-15",
-      "issued": "2010-01-15T10:06:46.000+00:00",
+      "issued": "2010-01-15T00:00:00.000+00:00",
       "performer": [ {
         "reference": "Practitioner/1E473786-E7FA-785E-C911-A8D38FB56F20"
       } ]
@@ -18376,7 +18376,7 @@
         "reference": "Encounter/07FFDE3B-B0BC-4B02-BA20-624FE2E8AB8A"
       },
       "effectiveDateTime": "2010-03-23T15:36:00+00:00",
-      "issued": "2010-03-23T15:51:27.000+00:00",
+      "issued": "2010-03-23T15:36:00.000+00:00",
       "performer": [ {
         "reference": "Practitioner/1E473786-E7FA-785E-C911-A8D38FB56F20"
       } ],
@@ -18423,7 +18423,7 @@
         "reference": "Encounter/8F1F0FF5-2F2C-482B-BD9A-98101786B46D"
       },
       "effectiveDateTime": "2010-03-23T15:39:00+00:00",
-      "issued": "2010-03-23T15:59:35.000+00:00",
+      "issued": "2010-03-23T15:39:00.000+00:00",
       "performer": [ {
         "reference": "Practitioner/1E473786-E7FA-785E-C911-A8D38FB56F20"
       } ],
@@ -18470,7 +18470,7 @@
         "reference": "Encounter/0B6398B9-E22B-4195-BBBA-301BA6732708"
       },
       "effectiveDateTime": "2011-11-15T14:54:00+00:00",
-      "issued": "2011-11-15T14:59:10.000+00:00",
+      "issued": "2011-11-15T14:54:00.000+00:00",
       "performer": [ {
         "reference": "Practitioner/44B5F72D-0848-76A1-4554-F980EB27FB7B"
       } ],
@@ -18514,7 +18514,7 @@
         "reference": "Patient/00000000-0000-0000-0000-000000000007"
       },
       "effectiveDateTime": "2010-01-14T10:10:00+00:00",
-      "issued": "2010-01-14T10:10:35.000+00:00",
+      "issued": "2010-01-14T10:10:00.000+00:00",
       "performer": [ {
         "reference": "Practitioner/1E473786-E7FA-785E-C911-A8D38FB56F20"
       } ]

--- a/gp2gp-translator/src/integrationTest/resources/e2e-mapping/output-json/PWTP5-output.json
+++ b/gp2gp-translator/src/integrationTest/resources/e2e-mapping/output-json/PWTP5-output.json
@@ -1999,7 +1999,7 @@
         "reference": "Encounter/6CE8318F-2230-47CE-86CC-5210130A00F5"
       },
       "effectiveDateTime": "2010-06-30T04:59:00+00:00",
-      "issued": "2010-06-30T04:48:04.000+00:00",
+      "issued": "2010-06-30T04:59:00.000+00:00",
       "performer": [ {
         "reference": "Practitioner/1E473786-E7FA-785E-C911-A8D38FB56F20"
       } ],
@@ -2046,7 +2046,7 @@
         "reference": "Encounter/6CE8318F-2230-47CE-86CC-5210130A00F5"
       },
       "effectiveDateTime": "2010-06-30T04:59:00+00:00",
-      "issued": "2010-06-30T04:48:04.000+00:00",
+      "issued": "2010-06-30T04:59:00.000+00:00",
       "performer": [ {
         "reference": "Practitioner/1E473786-E7FA-785E-C911-A8D38FB56F20"
       } ],
@@ -2102,7 +2102,7 @@
         "reference": "Encounter/6CE8318F-2230-47CE-86CC-5210130A00F5"
       },
       "effectiveDateTime": "2010-06-30T04:59:00+00:00",
-      "issued": "2010-06-30T04:48:04.000+00:00",
+      "issued": "2010-06-30T04:59:00.000+00:00",
       "performer": [ {
         "reference": "Practitioner/1E473786-E7FA-785E-C911-A8D38FB56F20"
       } ],
@@ -2158,7 +2158,7 @@
         "reference": "Encounter/6CE8318F-2230-47CE-86CC-5210130A00F5"
       },
       "effectiveDateTime": "2010-06-30T04:59:00+00:00",
-      "issued": "2010-06-30T04:48:04.000+00:00",
+      "issued": "2010-06-30T04:59:00.000+00:00",
       "performer": [ {
         "reference": "Practitioner/1E473786-E7FA-785E-C911-A8D38FB56F20"
       } ],
@@ -2205,7 +2205,7 @@
         "reference": "Encounter/6CE8318F-2230-47CE-86CC-5210130A00F5"
       },
       "effectiveDateTime": "2010-06-30T04:59:00+00:00",
-      "issued": "2010-06-30T04:48:04.000+00:00",
+      "issued": "2010-06-30T04:59:00.000+00:00",
       "performer": [ {
         "reference": "Practitioner/1E473786-E7FA-785E-C911-A8D38FB56F20"
       } ],
@@ -2252,7 +2252,7 @@
         "reference": "Encounter/CF355E94-C4BB-44A8-A346-785A993F37F0"
       },
       "effectiveDateTime": "2011-02-11T13:46:00+00:00",
-      "issued": "2011-02-11T13:51:36.000+00:00",
+      "issued": "2011-02-11T13:46:00.000+00:00",
       "performer": [ {
         "reference": "Practitioner/1E473786-E7FA-785E-C911-A8D38FB56F20"
       } ],
@@ -2305,7 +2305,7 @@
         "reference": "Encounter/55315F2E-55D0-4737-B2BC-4E816F04770E"
       },
       "effectiveDateTime": "2011-02-11T13:53:00+00:00",
-      "issued": "2011-02-11T14:02:43.000+00:00",
+      "issued": "2011-02-11T13:53:00.000+00:00",
       "performer": [ {
         "reference": "Practitioner/1E473786-E7FA-785E-C911-A8D38FB56F20"
       } ],
@@ -2355,7 +2355,7 @@
         "reference": "Encounter/55315F2E-55D0-4737-B2BC-4E816F04770E"
       },
       "effectiveDateTime": "2011-02-11T13:53:00+00:00",
-      "issued": "2011-02-11T14:02:43.000+00:00",
+      "issued": "2011-02-11T13:53:00.000+00:00",
       "performer": [ {
         "reference": "Practitioner/1E473786-E7FA-785E-C911-A8D38FB56F20"
       } ],
@@ -2408,7 +2408,7 @@
         "reference": "Encounter/55315F2E-55D0-4737-B2BC-4E816F04770E"
       },
       "effectiveDateTime": "2011-02-11T13:53:00+00:00",
-      "issued": "2011-02-11T14:02:43.000+00:00",
+      "issued": "2011-02-11T13:53:00.000+00:00",
       "performer": [ {
         "reference": "Practitioner/1E473786-E7FA-785E-C911-A8D38FB56F20"
       } ],
@@ -2461,7 +2461,7 @@
         "reference": "Encounter/55315F2E-55D0-4737-B2BC-4E816F04770E"
       },
       "effectiveDateTime": "2011-02-11T13:53:00+00:00",
-      "issued": "2011-02-11T14:02:43.000+00:00",
+      "issued": "2011-02-11T13:53:00.000+00:00",
       "performer": [ {
         "reference": "Practitioner/1E473786-E7FA-785E-C911-A8D38FB56F20"
       } ],
@@ -2511,7 +2511,7 @@
         "reference": "Encounter/55315F2E-55D0-4737-B2BC-4E816F04770E"
       },
       "effectiveDateTime": "2011-02-11T13:53:00+00:00",
-      "issued": "2011-02-11T14:02:43.000+00:00",
+      "issued": "2011-02-11T13:53:00.000+00:00",
       "performer": [ {
         "reference": "Practitioner/1E473786-E7FA-785E-C911-A8D38FB56F20"
       } ],
@@ -2563,7 +2563,7 @@
         "reference": "Encounter/55315F2E-55D0-4737-B2BC-4E816F04770E"
       },
       "effectiveDateTime": "2011-02-11T13:53:00+00:00",
-      "issued": "2011-02-11T14:02:43.000+00:00",
+      "issued": "2011-02-11T13:53:00.000+00:00",
       "performer": [ {
         "reference": "Practitioner/1E473786-E7FA-785E-C911-A8D38FB56F20"
       } ],
@@ -2615,7 +2615,7 @@
         "reference": "Encounter/55315F2E-55D0-4737-B2BC-4E816F04770E"
       },
       "effectiveDateTime": "2011-02-11T13:53:00+00:00",
-      "issued": "2011-02-11T14:02:43.000+00:00",
+      "issued": "2011-02-11T13:53:00.000+00:00",
       "performer": [ {
         "reference": "Practitioner/1E473786-E7FA-785E-C911-A8D38FB56F20"
       } ],
@@ -2671,7 +2671,7 @@
         "reference": "Encounter/55315F2E-55D0-4737-B2BC-4E816F04770E"
       },
       "effectiveDateTime": "2011-02-11T13:53:00+00:00",
-      "issued": "2011-02-11T14:02:43.000+00:00",
+      "issued": "2011-02-11T13:53:00.000+00:00",
       "performer": [ {
         "reference": "Practitioner/1E473786-E7FA-785E-C911-A8D38FB56F20"
       } ],
@@ -2714,7 +2714,7 @@
         "reference": "Patient/00000000-0000-0000-0000-000000000011"
       },
       "effectiveDateTime": "2010-01-18T09:29:00+00:00",
-      "issued": "2010-01-18T09:29:11.000+00:00",
+      "issued": "2010-01-18T09:29:00.000+00:00",
       "performer": [ {
         "reference": "Practitioner/1E473786-E7FA-785E-C911-A8D38FB56F20"
       } ]
@@ -2757,7 +2757,7 @@
         "reference": "Patient/00000000-0000-0000-0000-000000000011"
       },
       "effectiveDateTime": "2010-01-18T09:29:00+00:00",
-      "issued": "2010-01-18T09:29:11.000+00:00",
+      "issued": "2010-01-18T09:29:00.000+00:00",
       "performer": [ {
         "reference": "Practitioner/1E473786-E7FA-785E-C911-A8D38FB56F20"
       } ]
@@ -2800,7 +2800,7 @@
         "reference": "Patient/00000000-0000-0000-0000-000000000011"
       },
       "effectiveDateTime": "2010-01-18T11:16:00+00:00",
-      "issued": "2010-01-18T11:10:38.000+00:00",
+      "issued": "2010-01-18T11:16:00.000+00:00",
       "performer": [ {
         "reference": "Practitioner/1E473786-E7FA-785E-C911-A8D38FB56F20"
       } ]
@@ -2843,7 +2843,7 @@
         "reference": "Patient/00000000-0000-0000-0000-000000000011"
       },
       "effectiveDateTime": "2010-06-30",
-      "issued": "2010-06-30T04:48:26.000+00:00",
+      "issued": "2010-06-30T00:00:00.000+00:00",
       "performer": [ {
         "reference": "Practitioner/1E473786-E7FA-785E-C911-A8D38FB56F20"
       } ],
@@ -2884,7 +2884,7 @@
         "reference": "Patient/00000000-0000-0000-0000-000000000011"
       },
       "effectiveDateTime": "2010-06-30",
-      "issued": "2010-06-30T04:51:44.000+00:00",
+      "issued": "2010-06-30T00:00:00.000+00:00",
       "performer": [ {
         "reference": "Practitioner/1E473786-E7FA-785E-C911-A8D38FB56F20"
       } ],
@@ -2925,7 +2925,7 @@
         "reference": "Patient/00000000-0000-0000-0000-000000000011"
       },
       "effectiveDateTime": "2010-06-30",
-      "issued": "2010-06-30T04:51:55.000+00:00",
+      "issued": "2010-06-30T00:00:00.000+00:00",
       "performer": [ {
         "reference": "Practitioner/1E473786-E7FA-785E-C911-A8D38FB56F20"
       } ],

--- a/gp2gp-translator/src/integrationTest/resources/e2e-mapping/output-json/PWTP6-output.json
+++ b/gp2gp-translator/src/integrationTest/resources/e2e-mapping/output-json/PWTP6-output.json
@@ -1954,7 +1954,7 @@
         "reference": "Encounter/698C8458-569F-4451-863B-DBA96EDA776E"
       },
       "effectiveDateTime": "2009",
-      "issued": "2010-01-23T12:39:26.000+00:00",
+      "issued": "2009-01-01T00:00:00.000+00:00",
       "performer": [ {
         "reference": "Practitioner/C5DEFBF3-0174-BC6F-182C-B777B9C6FF43"
       } ]
@@ -2000,7 +2000,7 @@
         "reference": "Encounter/698C8458-569F-4451-863B-DBA96EDA776E"
       },
       "effectiveDateTime": "2009",
-      "issued": "2010-01-23T12:39:26.000+00:00",
+      "issued": "2009-01-01T00:00:00.000+00:00",
       "performer": [ {
         "reference": "Practitioner/C5DEFBF3-0174-BC6F-182C-B777B9C6FF43"
       } ],
@@ -2050,7 +2050,7 @@
         "reference": "Encounter/698C8458-569F-4451-863B-DBA96EDA776E"
       },
       "effectiveDateTime": "2009",
-      "issued": "2010-01-23T12:39:26.000+00:00",
+      "issued": "2009-01-01T00:00:00.000+00:00",
       "performer": [ {
         "reference": "Practitioner/C5DEFBF3-0174-BC6F-182C-B777B9C6FF43"
       } ],
@@ -2098,7 +2098,7 @@
         "reference": "Encounter/698C8458-569F-4451-863B-DBA96EDA776E"
       },
       "effectiveDateTime": "2009",
-      "issued": "2010-01-23T12:39:26.000+00:00",
+      "issued": "2009-01-01T00:00:00.000+00:00",
       "performer": [ {
         "reference": "Practitioner/C5DEFBF3-0174-BC6F-182C-B777B9C6FF43"
       } ]
@@ -2144,7 +2144,7 @@
         "reference": "Encounter/698C8458-569F-4451-863B-DBA96EDA776E"
       },
       "effectiveDateTime": "2009",
-      "issued": "2010-01-23T12:39:26.000+00:00",
+      "issued": "2009-01-01T00:00:00.000+00:00",
       "performer": [ {
         "reference": "Practitioner/C5DEFBF3-0174-BC6F-182C-B777B9C6FF43"
       } ]
@@ -2190,7 +2190,7 @@
         "reference": "Encounter/698C8458-569F-4451-863B-DBA96EDA776E"
       },
       "effectiveDateTime": "2009",
-      "issued": "2010-01-23T12:39:26.000+00:00",
+      "issued": "2009-01-01T00:00:00.000+00:00",
       "performer": [ {
         "reference": "Practitioner/C5DEFBF3-0174-BC6F-182C-B777B9C6FF43"
       } ]
@@ -2236,7 +2236,7 @@
         "reference": "Encounter/698C8458-569F-4451-863B-DBA96EDA776E"
       },
       "effectiveDateTime": "2009",
-      "issued": "2010-01-23T12:39:26.000+00:00",
+      "issued": "2009-01-01T00:00:00.000+00:00",
       "performer": [ {
         "reference": "Practitioner/C5DEFBF3-0174-BC6F-182C-B777B9C6FF43"
       } ]
@@ -2279,7 +2279,7 @@
         "reference": "Encounter/698C8458-569F-4451-863B-DBA96EDA776E"
       },
       "effectiveDateTime": "2009",
-      "issued": "2010-01-23T12:39:26.000+00:00",
+      "issued": "2009-01-01T00:00:00.000+00:00",
       "performer": [ {
         "reference": "Practitioner/C5DEFBF3-0174-BC6F-182C-B777B9C6FF43"
       } ],
@@ -2329,7 +2329,7 @@
         "reference": "Encounter/698C8458-569F-4451-863B-DBA96EDA776E"
       },
       "effectiveDateTime": "2009",
-      "issued": "2010-01-23T12:39:26.000+00:00",
+      "issued": "2009-01-01T00:00:00.000+00:00",
       "performer": [ {
         "reference": "Practitioner/C5DEFBF3-0174-BC6F-182C-B777B9C6FF43"
       } ]
@@ -2375,7 +2375,7 @@
         "reference": "Encounter/698C8458-569F-4451-863B-DBA96EDA776E"
       },
       "effectiveDateTime": "2009",
-      "issued": "2010-01-23T12:39:26.000+00:00",
+      "issued": "2009-01-01T00:00:00.000+00:00",
       "performer": [ {
         "reference": "Practitioner/C5DEFBF3-0174-BC6F-182C-B777B9C6FF43"
       } ],
@@ -2412,7 +2412,7 @@
         "reference": "Encounter/698C8458-569F-4451-863B-DBA96EDA776E"
       },
       "effectiveDateTime": "2009",
-      "issued": "2010-01-23T12:39:26.000+00:00",
+      "issued": "2009-01-01T00:00:00.000+00:00",
       "performer": [ {
         "reference": "Practitioner/C5DEFBF3-0174-BC6F-182C-B777B9C6FF43"
       } ]
@@ -2455,7 +2455,7 @@
         "reference": "Encounter/B7E5AE3B-260D-4BEB-962A-BC489C30041F"
       },
       "effectiveDateTime": "2010-01-18T11:38:00+00:00",
-      "issued": "2010-01-18T11:34:50.000+00:00",
+      "issued": "2010-01-18T11:38:00.000+00:00",
       "performer": [ {
         "reference": "Practitioner/1E473786-E7FA-785E-C911-A8D38FB56F20"
       } ],
@@ -2506,7 +2506,7 @@
         "reference": "Encounter/B7E5AE3B-260D-4BEB-962A-BC489C30041F"
       },
       "effectiveDateTime": "2010-01-18T11:38:00+00:00",
-      "issued": "2010-01-18T11:34:50.000+00:00",
+      "issued": "2010-01-18T11:38:00.000+00:00",
       "performer": [ {
         "reference": "Practitioner/1E473786-E7FA-785E-C911-A8D38FB56F20"
       } ],
@@ -2554,7 +2554,7 @@
         "reference": "Encounter/B7E5AE3B-260D-4BEB-962A-BC489C30041F"
       },
       "effectiveDateTime": "2010-01-18T11:38:00+00:00",
-      "issued": "2010-01-18T11:34:50.000+00:00",
+      "issued": "2010-01-18T11:38:00.000+00:00",
       "performer": [ {
         "reference": "Practitioner/1E473786-E7FA-785E-C911-A8D38FB56F20"
       } ],
@@ -2605,7 +2605,7 @@
         "reference": "Encounter/B7E5AE3B-260D-4BEB-962A-BC489C30041F"
       },
       "effectiveDateTime": "2010-01-18T11:38:00+00:00",
-      "issued": "2010-01-18T11:34:50.000+00:00",
+      "issued": "2010-01-18T11:38:00.000+00:00",
       "performer": [ {
         "reference": "Practitioner/1E473786-E7FA-785E-C911-A8D38FB56F20"
       } ]
@@ -2651,7 +2651,7 @@
         "reference": "Encounter/B7E5AE3B-260D-4BEB-962A-BC489C30041F"
       },
       "effectiveDateTime": "2010-01-18T11:38:00+00:00",
-      "issued": "2010-01-18T11:34:50.000+00:00",
+      "issued": "2010-01-18T11:38:00.000+00:00",
       "performer": [ {
         "reference": "Practitioner/1E473786-E7FA-785E-C911-A8D38FB56F20"
       } ]
@@ -2697,7 +2697,7 @@
         "reference": "Encounter/B7E5AE3B-260D-4BEB-962A-BC489C30041F"
       },
       "effectiveDateTime": "2010-01-18T11:38:00+00:00",
-      "issued": "2010-01-18T11:34:50.000+00:00",
+      "issued": "2010-01-18T11:38:00.000+00:00",
       "performer": [ {
         "reference": "Practitioner/1E473786-E7FA-785E-C911-A8D38FB56F20"
       } ]
@@ -2743,7 +2743,7 @@
         "reference": "Encounter/B7E5AE3B-260D-4BEB-962A-BC489C30041F"
       },
       "effectiveDateTime": "2010-01-18T11:38:00+00:00",
-      "issued": "2010-01-18T11:34:50.000+00:00",
+      "issued": "2010-01-18T11:38:00.000+00:00",
       "performer": [ {
         "reference": "Practitioner/1E473786-E7FA-785E-C911-A8D38FB56F20"
       } ]
@@ -2789,7 +2789,7 @@
         "reference": "Encounter/62B17FF3-AC74-4118-A567-B34D09798DCA"
       },
       "effectiveDateTime": "2010-01-18T11:47:00+00:00",
-      "issued": "2010-01-18T11:47:10.000+00:00",
+      "issued": "2010-01-18T11:47:00.000+00:00",
       "performer": [ {
         "reference": "Practitioner/1E473786-E7FA-785E-C911-A8D38FB56F20"
       } ]
@@ -2835,7 +2835,7 @@
         "reference": "Encounter/62B17FF3-AC74-4118-A567-B34D09798DCA"
       },
       "effectiveDateTime": "2010-01-18T11:47:00+00:00",
-      "issued": "2010-01-18T11:47:10.000+00:00",
+      "issued": "2010-01-18T11:47:00.000+00:00",
       "performer": [ {
         "reference": "Practitioner/1E473786-E7FA-785E-C911-A8D38FB56F20"
       } ]
@@ -2881,7 +2881,7 @@
         "reference": "Encounter/62B17FF3-AC74-4118-A567-B34D09798DCA"
       },
       "effectiveDateTime": "2010-01-18T11:47:00+00:00",
-      "issued": "2010-01-18T11:47:10.000+00:00",
+      "issued": "2010-01-18T11:47:00.000+00:00",
       "performer": [ {
         "reference": "Practitioner/1E473786-E7FA-785E-C911-A8D38FB56F20"
       } ]
@@ -2927,7 +2927,7 @@
         "reference": "Encounter/62B17FF3-AC74-4118-A567-B34D09798DCA"
       },
       "effectiveDateTime": "2010-01-18T11:47:00+00:00",
-      "issued": "2010-01-18T11:47:10.000+00:00",
+      "issued": "2010-01-18T11:47:00.000+00:00",
       "performer": [ {
         "reference": "Practitioner/1E473786-E7FA-785E-C911-A8D38FB56F20"
       } ]
@@ -2973,7 +2973,7 @@
         "reference": "Encounter/62B17FF3-AC74-4118-A567-B34D09798DCA"
       },
       "effectiveDateTime": "2010-01-18T11:47:00+00:00",
-      "issued": "2010-01-18T11:47:10.000+00:00",
+      "issued": "2010-01-18T11:47:00.000+00:00",
       "performer": [ {
         "reference": "Practitioner/1E473786-E7FA-785E-C911-A8D38FB56F20"
       } ],
@@ -3020,7 +3020,7 @@
         "reference": "Encounter/62B17FF3-AC74-4118-A567-B34D09798DCA"
       },
       "effectiveDateTime": "2010-01-18T11:47:00+00:00",
-      "issued": "2010-01-18T11:47:10.000+00:00",
+      "issued": "2010-01-18T11:47:00.000+00:00",
       "performer": [ {
         "reference": "Practitioner/1E473786-E7FA-785E-C911-A8D38FB56F20"
       } ],
@@ -3067,7 +3067,7 @@
         "reference": "Encounter/62B17FF3-AC74-4118-A567-B34D09798DCA"
       },
       "effectiveDateTime": "2010-01-18T11:47:00+00:00",
-      "issued": "2010-01-18T11:47:10.000+00:00",
+      "issued": "2010-01-18T11:47:00.000+00:00",
       "performer": [ {
         "reference": "Practitioner/1E473786-E7FA-785E-C911-A8D38FB56F20"
       } ],
@@ -3114,7 +3114,7 @@
         "reference": "Encounter/62B17FF3-AC74-4118-A567-B34D09798DCA"
       },
       "effectiveDateTime": "2010-01-18T11:47:00+00:00",
-      "issued": "2010-01-18T11:47:10.000+00:00",
+      "issued": "2010-01-18T11:47:00.000+00:00",
       "performer": [ {
         "reference": "Practitioner/1E473786-E7FA-785E-C911-A8D38FB56F20"
       } ],
@@ -3151,7 +3151,7 @@
         "reference": "Encounter/62B17FF3-AC74-4118-A567-B34D09798DCA"
       },
       "effectiveDateTime": "2010-01-18T11:47:00+00:00",
-      "issued": "2010-01-18T11:47:10.000+00:00",
+      "issued": "2010-01-18T11:47:00.000+00:00",
       "performer": [ {
         "reference": "Practitioner/1E473786-E7FA-785E-C911-A8D38FB56F20"
       } ]
@@ -3187,7 +3187,7 @@
         "reference": "Encounter/62B17FF3-AC74-4118-A567-B34D09798DCA"
       },
       "effectiveDateTime": "2010-01-18T11:47:00+00:00",
-      "issued": "2010-01-18T11:47:10.000+00:00",
+      "issued": "2010-01-18T11:47:00.000+00:00",
       "performer": [ {
         "reference": "Practitioner/1E473786-E7FA-785E-C911-A8D38FB56F20"
       } ]
@@ -3233,7 +3233,7 @@
         "reference": "Encounter/62B17FF3-AC74-4118-A567-B34D09798DCA"
       },
       "effectiveDateTime": "2010-01-18T11:47:00+00:00",
-      "issued": "2010-01-18T11:47:10.000+00:00",
+      "issued": "2010-01-18T11:47:00.000+00:00",
       "performer": [ {
         "reference": "Practitioner/1E473786-E7FA-785E-C911-A8D38FB56F20"
       } ],
@@ -3285,7 +3285,7 @@
         "reference": "Encounter/62B17FF3-AC74-4118-A567-B34D09798DCA"
       },
       "effectiveDateTime": "2010-01-18T11:47:00+00:00",
-      "issued": "2010-01-18T11:47:10.000+00:00",
+      "issued": "2010-01-18T11:47:00.000+00:00",
       "performer": [ {
         "reference": "Practitioner/1E473786-E7FA-785E-C911-A8D38FB56F20"
       } ],
@@ -3336,7 +3336,7 @@
         "reference": "Encounter/62B17FF3-AC74-4118-A567-B34D09798DCA"
       },
       "effectiveDateTime": "2010-01-18T11:47:00+00:00",
-      "issued": "2010-01-18T11:47:10.000+00:00",
+      "issued": "2010-01-18T11:47:00.000+00:00",
       "performer": [ {
         "reference": "Practitioner/1E473786-E7FA-785E-C911-A8D38FB56F20"
       } ],
@@ -3388,7 +3388,7 @@
         "reference": "Encounter/62B17FF3-AC74-4118-A567-B34D09798DCA"
       },
       "effectiveDateTime": "2010-01-18T11:47:00+00:00",
-      "issued": "2010-01-18T11:47:10.000+00:00",
+      "issued": "2010-01-18T11:47:00.000+00:00",
       "performer": [ {
         "reference": "Practitioner/1E473786-E7FA-785E-C911-A8D38FB56F20"
       } ],
@@ -3440,7 +3440,7 @@
         "reference": "Encounter/62B17FF3-AC74-4118-A567-B34D09798DCA"
       },
       "effectiveDateTime": "2010-01-18T11:47:00+00:00",
-      "issued": "2010-01-18T11:47:10.000+00:00",
+      "issued": "2010-01-18T11:47:00.000+00:00",
       "performer": [ {
         "reference": "Practitioner/1E473786-E7FA-785E-C911-A8D38FB56F20"
       } ],
@@ -3487,7 +3487,7 @@
         "reference": "Encounter/62B17FF3-AC74-4118-A567-B34D09798DCA"
       },
       "effectiveDateTime": "2010-01-18T11:47:00+00:00",
-      "issued": "2010-01-18T11:47:10.000+00:00",
+      "issued": "2010-01-18T11:47:00.000+00:00",
       "performer": [ {
         "reference": "Practitioner/1E473786-E7FA-785E-C911-A8D38FB56F20"
       } ],
@@ -3534,7 +3534,7 @@
         "reference": "Encounter/62B17FF3-AC74-4118-A567-B34D09798DCA"
       },
       "effectiveDateTime": "2010-01-18T11:47:00+00:00",
-      "issued": "2010-01-18T11:47:10.000+00:00",
+      "issued": "2010-01-18T11:47:00.000+00:00",
       "performer": [ {
         "reference": "Practitioner/1E473786-E7FA-785E-C911-A8D38FB56F20"
       } ],
@@ -3581,7 +3581,7 @@
         "reference": "Encounter/62B17FF3-AC74-4118-A567-B34D09798DCA"
       },
       "effectiveDateTime": "2010-01-18T11:47:00+00:00",
-      "issued": "2010-01-18T11:47:10.000+00:00",
+      "issued": "2010-01-18T11:47:00.000+00:00",
       "performer": [ {
         "reference": "Practitioner/1E473786-E7FA-785E-C911-A8D38FB56F20"
       } ],
@@ -3618,7 +3618,7 @@
         "reference": "Encounter/62B17FF3-AC74-4118-A567-B34D09798DCA"
       },
       "effectiveDateTime": "2010-01-18T11:47:00+00:00",
-      "issued": "2010-01-18T11:47:10.000+00:00",
+      "issued": "2010-01-18T11:47:00.000+00:00",
       "performer": [ {
         "reference": "Practitioner/1E473786-E7FA-785E-C911-A8D38FB56F20"
       } ],
@@ -3655,7 +3655,7 @@
         "reference": "Encounter/62B17FF3-AC74-4118-A567-B34D09798DCA"
       },
       "effectiveDateTime": "2010-01-18T11:47:00+00:00",
-      "issued": "2010-01-18T11:47:10.000+00:00",
+      "issued": "2010-01-18T11:47:00.000+00:00",
       "performer": [ {
         "reference": "Practitioner/1E473786-E7FA-785E-C911-A8D38FB56F20"
       } ],
@@ -3702,7 +3702,7 @@
         "reference": "Encounter/62B17FF3-AC74-4118-A567-B34D09798DCA"
       },
       "effectiveDateTime": "2010-01-18T11:47:00+00:00",
-      "issued": "2010-01-18T11:47:10.000+00:00",
+      "issued": "2010-01-18T11:47:00.000+00:00",
       "performer": [ {
         "reference": "Practitioner/1E473786-E7FA-785E-C911-A8D38FB56F20"
       } ]
@@ -3748,7 +3748,7 @@
         "reference": "Encounter/62B17FF3-AC74-4118-A567-B34D09798DCA"
       },
       "effectiveDateTime": "2010-01-18T11:47:00+00:00",
-      "issued": "2010-01-18T11:47:10.000+00:00",
+      "issued": "2010-01-18T11:47:00.000+00:00",
       "performer": [ {
         "reference": "Practitioner/1E473786-E7FA-785E-C911-A8D38FB56F20"
       } ]
@@ -3794,7 +3794,7 @@
         "reference": "Encounter/62B17FF3-AC74-4118-A567-B34D09798DCA"
       },
       "effectiveDateTime": "2010-01-18T11:47:00+00:00",
-      "issued": "2010-01-18T11:47:10.000+00:00",
+      "issued": "2010-01-18T11:47:00.000+00:00",
       "performer": [ {
         "reference": "Practitioner/1E473786-E7FA-785E-C911-A8D38FB56F20"
       } ],
@@ -3841,7 +3841,7 @@
         "reference": "Encounter/62B17FF3-AC74-4118-A567-B34D09798DCA"
       },
       "effectiveDateTime": "2010-01-18T11:47:00+00:00",
-      "issued": "2010-01-18T11:47:10.000+00:00",
+      "issued": "2010-01-18T11:47:00.000+00:00",
       "performer": [ {
         "reference": "Practitioner/1E473786-E7FA-785E-C911-A8D38FB56F20"
       } ],
@@ -3888,7 +3888,7 @@
         "reference": "Encounter/62B17FF3-AC74-4118-A567-B34D09798DCA"
       },
       "effectiveDateTime": "2010-01-18T11:47:00+00:00",
-      "issued": "2010-01-18T11:47:10.000+00:00",
+      "issued": "2010-01-18T11:47:00.000+00:00",
       "performer": [ {
         "reference": "Practitioner/1E473786-E7FA-785E-C911-A8D38FB56F20"
       } ]
@@ -3934,7 +3934,7 @@
         "reference": "Encounter/62B17FF3-AC74-4118-A567-B34D09798DCA"
       },
       "effectiveDateTime": "2010-01-18T11:47:00+00:00",
-      "issued": "2010-01-18T11:47:10.000+00:00",
+      "issued": "2010-01-18T11:47:00.000+00:00",
       "performer": [ {
         "reference": "Practitioner/1E473786-E7FA-785E-C911-A8D38FB56F20"
       } ]
@@ -3980,7 +3980,7 @@
         "reference": "Encounter/62B17FF3-AC74-4118-A567-B34D09798DCA"
       },
       "effectiveDateTime": "2010-01-18T11:47:00+00:00",
-      "issued": "2010-01-18T11:47:10.000+00:00",
+      "issued": "2010-01-18T11:47:00.000+00:00",
       "performer": [ {
         "reference": "Practitioner/1E473786-E7FA-785E-C911-A8D38FB56F20"
       } ],
@@ -4027,7 +4027,7 @@
         "reference": "Encounter/62B17FF3-AC74-4118-A567-B34D09798DCA"
       },
       "effectiveDateTime": "2010-01-18T11:47:00+00:00",
-      "issued": "2010-01-18T11:47:10.000+00:00",
+      "issued": "2010-01-18T11:47:00.000+00:00",
       "performer": [ {
         "reference": "Practitioner/1E473786-E7FA-785E-C911-A8D38FB56F20"
       } ],
@@ -4074,7 +4074,7 @@
         "reference": "Encounter/62B17FF3-AC74-4118-A567-B34D09798DCA"
       },
       "effectiveDateTime": "2010-01-18T11:47:00+00:00",
-      "issued": "2010-01-18T11:47:10.000+00:00",
+      "issued": "2010-01-18T11:47:00.000+00:00",
       "performer": [ {
         "reference": "Practitioner/1E473786-E7FA-785E-C911-A8D38FB56F20"
       } ],
@@ -4121,7 +4121,7 @@
         "reference": "Encounter/62B17FF3-AC74-4118-A567-B34D09798DCA"
       },
       "effectiveDateTime": "2010-01-18T11:47:00+00:00",
-      "issued": "2010-01-18T11:47:10.000+00:00",
+      "issued": "2010-01-18T11:47:00.000+00:00",
       "performer": [ {
         "reference": "Practitioner/1E473786-E7FA-785E-C911-A8D38FB56F20"
       } ],
@@ -4168,7 +4168,7 @@
         "reference": "Encounter/62B17FF3-AC74-4118-A567-B34D09798DCA"
       },
       "effectiveDateTime": "2010-01-18T11:47:00+00:00",
-      "issued": "2010-01-18T11:47:10.000+00:00",
+      "issued": "2010-01-18T11:47:00.000+00:00",
       "performer": [ {
         "reference": "Practitioner/1E473786-E7FA-785E-C911-A8D38FB56F20"
       } ],
@@ -4215,7 +4215,7 @@
         "reference": "Encounter/62B17FF3-AC74-4118-A567-B34D09798DCA"
       },
       "effectiveDateTime": "2010-01-18T11:47:00+00:00",
-      "issued": "2010-01-18T11:47:10.000+00:00",
+      "issued": "2010-01-18T11:47:00.000+00:00",
       "performer": [ {
         "reference": "Practitioner/1E473786-E7FA-785E-C911-A8D38FB56F20"
       } ],
@@ -4262,7 +4262,7 @@
         "reference": "Encounter/62B17FF3-AC74-4118-A567-B34D09798DCA"
       },
       "effectiveDateTime": "2010-01-18T11:47:00+00:00",
-      "issued": "2010-01-18T11:47:10.000+00:00",
+      "issued": "2010-01-18T11:47:00.000+00:00",
       "performer": [ {
         "reference": "Practitioner/1E473786-E7FA-785E-C911-A8D38FB56F20"
       } ],
@@ -4309,7 +4309,7 @@
         "reference": "Encounter/62B17FF3-AC74-4118-A567-B34D09798DCA"
       },
       "effectiveDateTime": "2010-01-18T11:47:00+00:00",
-      "issued": "2010-01-18T11:47:10.000+00:00",
+      "issued": "2010-01-18T11:47:00.000+00:00",
       "performer": [ {
         "reference": "Practitioner/1E473786-E7FA-785E-C911-A8D38FB56F20"
       } ],
@@ -4353,7 +4353,7 @@
         "reference": "Encounter/62B17FF3-AC74-4118-A567-B34D09798DCA"
       },
       "effectiveDateTime": "2010-01-18T11:47:00+00:00",
-      "issued": "2010-01-18T11:47:10.000+00:00",
+      "issued": "2010-01-18T11:47:00.000+00:00",
       "performer": [ {
         "reference": "Practitioner/1E473786-E7FA-785E-C911-A8D38FB56F20"
       } ],
@@ -4400,7 +4400,7 @@
         "reference": "Encounter/62B17FF3-AC74-4118-A567-B34D09798DCA"
       },
       "effectiveDateTime": "2010-01-18T11:47:00+00:00",
-      "issued": "2010-01-18T11:47:10.000+00:00",
+      "issued": "2010-01-18T11:47:00.000+00:00",
       "performer": [ {
         "reference": "Practitioner/1E473786-E7FA-785E-C911-A8D38FB56F20"
       } ]
@@ -4446,7 +4446,7 @@
         "reference": "Encounter/62B17FF3-AC74-4118-A567-B34D09798DCA"
       },
       "effectiveDateTime": "2010-01-18T11:47:00+00:00",
-      "issued": "2010-01-18T11:47:10.000+00:00",
+      "issued": "2010-01-18T11:47:00.000+00:00",
       "performer": [ {
         "reference": "Practitioner/1E473786-E7FA-785E-C911-A8D38FB56F20"
       } ]
@@ -4492,7 +4492,7 @@
         "reference": "Encounter/62B17FF3-AC74-4118-A567-B34D09798DCA"
       },
       "effectiveDateTime": "2010-01-18T11:47:00+00:00",
-      "issued": "2010-01-18T11:47:10.000+00:00",
+      "issued": "2010-01-18T11:47:00.000+00:00",
       "performer": [ {
         "reference": "Practitioner/1E473786-E7FA-785E-C911-A8D38FB56F20"
       } ]
@@ -4538,7 +4538,7 @@
         "reference": "Encounter/62B17FF3-AC74-4118-A567-B34D09798DCA"
       },
       "effectiveDateTime": "2010-01-18T11:47:00+00:00",
-      "issued": "2010-01-18T11:47:10.000+00:00",
+      "issued": "2010-01-18T11:47:00.000+00:00",
       "performer": [ {
         "reference": "Practitioner/1E473786-E7FA-785E-C911-A8D38FB56F20"
       } ]
@@ -4584,7 +4584,7 @@
         "reference": "Encounter/62B17FF3-AC74-4118-A567-B34D09798DCA"
       },
       "effectiveDateTime": "2010-01-18T11:47:00+00:00",
-      "issued": "2010-01-18T11:47:10.000+00:00",
+      "issued": "2010-01-18T11:47:00.000+00:00",
       "performer": [ {
         "reference": "Practitioner/1E473786-E7FA-785E-C911-A8D38FB56F20"
       } ]
@@ -4630,7 +4630,7 @@
         "reference": "Encounter/62B17FF3-AC74-4118-A567-B34D09798DCA"
       },
       "effectiveDateTime": "2010-01-18T11:47:00+00:00",
-      "issued": "2010-01-18T11:47:10.000+00:00",
+      "issued": "2010-01-18T11:47:00.000+00:00",
       "performer": [ {
         "reference": "Practitioner/1E473786-E7FA-785E-C911-A8D38FB56F20"
       } ]
@@ -4676,7 +4676,7 @@
         "reference": "Encounter/62B17FF3-AC74-4118-A567-B34D09798DCA"
       },
       "effectiveDateTime": "2010-01-18T11:47:00+00:00",
-      "issued": "2010-01-18T11:47:10.000+00:00",
+      "issued": "2010-01-18T11:47:00.000+00:00",
       "performer": [ {
         "reference": "Practitioner/1E473786-E7FA-785E-C911-A8D38FB56F20"
       } ],
@@ -4720,7 +4720,7 @@
         "reference": "Encounter/62B17FF3-AC74-4118-A567-B34D09798DCA"
       },
       "effectiveDateTime": "2010-01-18T11:47:00+00:00",
-      "issued": "2010-01-18T11:47:10.000+00:00",
+      "issued": "2010-01-18T11:47:00.000+00:00",
       "performer": [ {
         "reference": "Practitioner/1E473786-E7FA-785E-C911-A8D38FB56F20"
       } ],
@@ -4767,7 +4767,7 @@
         "reference": "Encounter/62B17FF3-AC74-4118-A567-B34D09798DCA"
       },
       "effectiveDateTime": "2010-01-18T11:47:00+00:00",
-      "issued": "2010-01-18T11:47:10.000+00:00",
+      "issued": "2010-01-18T11:47:00.000+00:00",
       "performer": [ {
         "reference": "Practitioner/1E473786-E7FA-785E-C911-A8D38FB56F20"
       } ],
@@ -4814,7 +4814,7 @@
         "reference": "Encounter/FE642D6E-A729-47E9-9512-B0DEA7AC36A1"
       },
       "effectiveDateTime": "2010-01-23T12:27:00+00:00",
-      "issued": "2010-01-23T12:31:44.000+00:00",
+      "issued": "2010-01-23T12:27:00.000+00:00",
       "performer": [ {
         "reference": "Practitioner/1E473786-E7FA-785E-C911-A8D38FB56F20"
       } ],
@@ -4861,7 +4861,7 @@
         "reference": "Encounter/FE642D6E-A729-47E9-9512-B0DEA7AC36A1"
       },
       "effectiveDateTime": "2010-01-23T12:27:00+00:00",
-      "issued": "2010-01-23T12:31:44.000+00:00",
+      "issued": "2010-01-23T12:27:00.000+00:00",
       "performer": [ {
         "reference": "Practitioner/1E473786-E7FA-785E-C911-A8D38FB56F20"
       } ]
@@ -4907,7 +4907,7 @@
         "reference": "Encounter/FE642D6E-A729-47E9-9512-B0DEA7AC36A1"
       },
       "effectiveDateTime": "2010-01-23T12:27:00+00:00",
-      "issued": "2010-01-23T12:31:44.000+00:00",
+      "issued": "2010-01-23T12:27:00.000+00:00",
       "performer": [ {
         "reference": "Practitioner/1E473786-E7FA-785E-C911-A8D38FB56F20"
       } ]
@@ -4953,7 +4953,7 @@
         "reference": "Encounter/FE642D6E-A729-47E9-9512-B0DEA7AC36A1"
       },
       "effectiveDateTime": "2010-01-23T12:27:00+00:00",
-      "issued": "2010-01-23T12:31:44.000+00:00",
+      "issued": "2010-01-23T12:27:00.000+00:00",
       "performer": [ {
         "reference": "Practitioner/1E473786-E7FA-785E-C911-A8D38FB56F20"
       } ]
@@ -4996,7 +4996,7 @@
         "reference": "Encounter/FE642D6E-A729-47E9-9512-B0DEA7AC36A1"
       },
       "effectiveDateTime": "2010-01-23T12:27:00+00:00",
-      "issued": "2010-01-23T12:31:44.000+00:00",
+      "issued": "2010-01-23T12:27:00.000+00:00",
       "performer": [ {
         "reference": "Practitioner/1E473786-E7FA-785E-C911-A8D38FB56F20"
       } ]
@@ -5042,7 +5042,7 @@
         "reference": "Encounter/FE642D6E-A729-47E9-9512-B0DEA7AC36A1"
       },
       "effectiveDateTime": "2010-01-23T12:27:00+00:00",
-      "issued": "2010-01-23T12:31:44.000+00:00",
+      "issued": "2010-01-23T12:27:00.000+00:00",
       "performer": [ {
         "reference": "Practitioner/1E473786-E7FA-785E-C911-A8D38FB56F20"
       } ]
@@ -5088,7 +5088,7 @@
         "reference": "Encounter/FE642D6E-A729-47E9-9512-B0DEA7AC36A1"
       },
       "effectiveDateTime": "2010-01-23T12:27:00+00:00",
-      "issued": "2010-01-23T12:31:44.000+00:00",
+      "issued": "2010-01-23T12:27:00.000+00:00",
       "performer": [ {
         "reference": "Practitioner/1E473786-E7FA-785E-C911-A8D38FB56F20"
       } ],
@@ -5135,7 +5135,7 @@
         "reference": "Encounter/FE642D6E-A729-47E9-9512-B0DEA7AC36A1"
       },
       "effectiveDateTime": "2010-01-23T12:27:00+00:00",
-      "issued": "2010-01-23T12:31:44.000+00:00",
+      "issued": "2010-01-23T12:27:00.000+00:00",
       "performer": [ {
         "reference": "Practitioner/1E473786-E7FA-785E-C911-A8D38FB56F20"
       } ]
@@ -5181,7 +5181,7 @@
         "reference": "Encounter/FE642D6E-A729-47E9-9512-B0DEA7AC36A1"
       },
       "effectiveDateTime": "2010-01-23T12:27:00+00:00",
-      "issued": "2010-01-23T12:31:44.000+00:00",
+      "issued": "2010-01-23T12:27:00.000+00:00",
       "performer": [ {
         "reference": "Practitioner/1E473786-E7FA-785E-C911-A8D38FB56F20"
       } ]
@@ -5227,7 +5227,7 @@
         "reference": "Encounter/FE642D6E-A729-47E9-9512-B0DEA7AC36A1"
       },
       "effectiveDateTime": "2010-01-23T12:27:00+00:00",
-      "issued": "2010-01-23T12:31:44.000+00:00",
+      "issued": "2010-01-23T12:27:00.000+00:00",
       "performer": [ {
         "reference": "Practitioner/1E473786-E7FA-785E-C911-A8D38FB56F20"
       } ],
@@ -5277,7 +5277,7 @@
         "reference": "Encounter/FE642D6E-A729-47E9-9512-B0DEA7AC36A1"
       },
       "effectiveDateTime": "2010-01-23T12:27:00+00:00",
-      "issued": "2010-01-23T12:31:44.000+00:00",
+      "issued": "2010-01-23T12:27:00.000+00:00",
       "performer": [ {
         "reference": "Practitioner/1E473786-E7FA-785E-C911-A8D38FB56F20"
       } ],
@@ -5327,7 +5327,7 @@
         "reference": "Encounter/FE642D6E-A729-47E9-9512-B0DEA7AC36A1"
       },
       "effectiveDateTime": "2010-01-23T12:27:00+00:00",
-      "issued": "2010-01-23T12:31:44.000+00:00",
+      "issued": "2010-01-23T12:27:00.000+00:00",
       "performer": [ {
         "reference": "Practitioner/1E473786-E7FA-785E-C911-A8D38FB56F20"
       } ],
@@ -5377,7 +5377,7 @@
         "reference": "Encounter/B7A64FCC-6F01-489E-8A2E-6D5080EFB36C"
       },
       "effectiveDateTime": "2011-01-11T15:33:00+00:00",
-      "issued": "2011-01-11T15:39:27.000+00:00",
+      "issued": "2011-01-11T15:33:00.000+00:00",
       "performer": [ {
         "reference": "Practitioner/1E473786-E7FA-785E-C911-A8D38FB56F20"
       } ],
@@ -5430,7 +5430,7 @@
         "reference": "Encounter/B7A64FCC-6F01-489E-8A2E-6D5080EFB36C"
       },
       "effectiveDateTime": "2011-01-11T15:33:00+00:00",
-      "issued": "2011-01-11T15:39:27.000+00:00",
+      "issued": "2011-01-11T15:33:00.000+00:00",
       "performer": [ {
         "reference": "Practitioner/1E473786-E7FA-785E-C911-A8D38FB56F20"
       } ],
@@ -5483,7 +5483,7 @@
         "reference": "Encounter/B7A64FCC-6F01-489E-8A2E-6D5080EFB36C"
       },
       "effectiveDateTime": "2011-01-04",
-      "issued": "2011-01-11T15:39:27.000+00:00",
+      "issued": "2011-01-04T00:00:00.000+00:00",
       "performer": [ {
         "reference": "Practitioner/1E473786-E7FA-785E-C911-A8D38FB56F20"
       } ],
@@ -5532,7 +5532,7 @@
         "reference": "Encounter/B7A64FCC-6F01-489E-8A2E-6D5080EFB36C"
       },
       "effectiveDateTime": "2011-01-11T15:33:00+00:00",
-      "issued": "2011-01-11T15:39:27.000+00:00",
+      "issued": "2011-01-11T15:33:00.000+00:00",
       "performer": [ {
         "reference": "Practitioner/1E473786-E7FA-785E-C911-A8D38FB56F20"
       } ],
@@ -5584,7 +5584,7 @@
         "reference": "Encounter/B7A64FCC-6F01-489E-8A2E-6D5080EFB36C"
       },
       "effectiveDateTime": "2011-01-11T15:33:00+00:00",
-      "issued": "2011-01-11T15:39:27.000+00:00",
+      "issued": "2011-01-11T15:33:00.000+00:00",
       "performer": [ {
         "reference": "Practitioner/1E473786-E7FA-785E-C911-A8D38FB56F20"
       } ],
@@ -5636,7 +5636,7 @@
         "reference": "Encounter/B7A64FCC-6F01-489E-8A2E-6D5080EFB36C"
       },
       "effectiveDateTime": "2011-01-11T15:33:00+00:00",
-      "issued": "2011-01-11T15:39:27.000+00:00",
+      "issued": "2011-01-11T15:33:00.000+00:00",
       "performer": [ {
         "reference": "Practitioner/1E473786-E7FA-785E-C911-A8D38FB56F20"
       } ],
@@ -5692,7 +5692,7 @@
         "reference": "Encounter/B7A64FCC-6F01-489E-8A2E-6D5080EFB36C"
       },
       "effectiveDateTime": "2011-01-11T15:33:00+00:00",
-      "issued": "2011-01-11T15:39:27.000+00:00",
+      "issued": "2011-01-11T15:33:00.000+00:00",
       "performer": [ {
         "reference": "Practitioner/1E473786-E7FA-785E-C911-A8D38FB56F20"
       } ],

--- a/gp2gp-translator/src/integrationTest/resources/e2e-mapping/output-json/PWTP7_vis-output.json
+++ b/gp2gp-translator/src/integrationTest/resources/e2e-mapping/output-json/PWTP7_vis-output.json
@@ -2391,7 +2391,7 @@
         "reference": "Encounter/B88EECC1-8DA9-48F9-981F-8D31C517A693"
       },
       "effectiveDateTime": "2010-01-19",
-      "issued": "2010-01-19T11:39:57.000+00:00",
+      "issued": "2010-01-19T00:00:00.000+00:00",
       "performer": [ {
         "reference": "Practitioner/C5DEFBF3-0174-BC6F-182C-B777B9C6FF43"
       } ],
@@ -2443,7 +2443,7 @@
         "reference": "Patient/00000000-0000-0000-0000-000000000012"
       },
       "effectiveDateTime": "2010-01-19",
-      "issued": "2010-01-19T11:31:52.000+00:00",
+      "issued": "2010-01-19T00:00:00.000+00:00",
       "performer": [ {
         "reference": "Practitioner/1E473786-E7FA-785E-C911-A8D38FB56F20"
       } ],
@@ -2487,7 +2487,7 @@
         "reference": "Patient/00000000-0000-0000-0000-000000000012"
       },
       "effectiveDateTime": "2010-01-19",
-      "issued": "2010-01-19T11:32:01.000+00:00",
+      "issued": "2010-01-19T00:00:00.000+00:00",
       "performer": [ {
         "reference": "Practitioner/1E473786-E7FA-785E-C911-A8D38FB56F20"
       } ],
@@ -2531,7 +2531,7 @@
         "reference": "Patient/00000000-0000-0000-0000-000000000012"
       },
       "effectiveDateTime": "2010-01-19",
-      "issued": "2010-01-19T11:36:16.000+00:00",
+      "issued": "2010-01-19T00:00:00.000+00:00",
       "performer": [ {
         "reference": "Practitioner/1E473786-E7FA-785E-C911-A8D38FB56F20"
       } ]
@@ -2574,7 +2574,7 @@
         "reference": "Patient/00000000-0000-0000-0000-000000000012"
       },
       "effectiveDateTime": "2010-01-19",
-      "issued": "2010-01-19T11:36:21.000+00:00",
+      "issued": "2010-01-19T00:00:00.000+00:00",
       "performer": [ {
         "reference": "Practitioner/1E473786-E7FA-785E-C911-A8D38FB56F20"
       } ]
@@ -2617,7 +2617,7 @@
         "reference": "Patient/00000000-0000-0000-0000-000000000012"
       },
       "effectiveDateTime": "2010-01-19",
-      "issued": "2010-01-19T11:36:34.000+00:00",
+      "issued": "2010-01-19T00:00:00.000+00:00",
       "performer": [ {
         "reference": "Practitioner/1E473786-E7FA-785E-C911-A8D38FB56F20"
       } ],

--- a/gp2gp-translator/src/integrationTest/resources/e2e-mapping/output-json/PWTP9-output.json
+++ b/gp2gp-translator/src/integrationTest/resources/e2e-mapping/output-json/PWTP9-output.json
@@ -3762,7 +3762,7 @@
         "reference": "Encounter/97AD4F69-49C5-4B0F-B8E4-AFEF4B9D39B2"
       },
       "effectiveDateTime": "2001-03-30",
-      "issued": "2010-02-09T12:31:51.000+00:00",
+      "issued": "2001-03-30T00:00:00.000+00:00",
       "performer": [ {
         "reference": "Practitioner/C5DEFBF3-0174-BC6F-182C-B777B9C6FF43"
       } ],
@@ -3816,7 +3816,7 @@
         "reference": "Encounter/7040CC1C-A6A6-4B38-A73A-77D5C474F539"
       },
       "effectiveDateTime": "2010-06-24T10:34:01+00:00",
-      "issued": "2010-06-24T11:34:31.000+00:00",
+      "issued": "2010-06-24T10:34:01.000+00:00",
       "performer": [ {
         "reference": "Practitioner/1E473786-E7FA-785E-C911-A8D38FB56F20"
       } ],
@@ -3883,7 +3883,7 @@
         "reference": "Encounter/71CE665D-D113-4359-B640-73CE6ACBE6AB"
       },
       "effectiveDateTime": "2010-06-24T10:34:01+00:00",
-      "issued": "2010-06-24T11:41:27.000+00:00",
+      "issued": "2010-06-24T10:34:01.000+00:00",
       "performer": [ {
         "reference": "Practitioner/1E473786-E7FA-785E-C911-A8D38FB56F20"
       } ],
@@ -3942,7 +3942,7 @@
         "reference": "Encounter/C5323AB7-2CA9-4E85-85E4-8FA896E45628"
       },
       "effectiveDateTime": "2010-06-24T10:34:01+00:00",
-      "issued": "2010-06-24T11:38:00.000+00:00",
+      "issued": "2010-06-24T10:34:01.000+00:00",
       "performer": [ {
         "reference": "Practitioner/1E473786-E7FA-785E-C911-A8D38FB56F20"
       } ],
@@ -4023,7 +4023,7 @@
         "reference": "Encounter/C5323AB7-2CA9-4E85-85E4-8FA896E45628"
       },
       "effectiveDateTime": "2010-06-24T10:34:01+00:00",
-      "issued": "2010-06-24T11:38:00.000+00:00",
+      "issued": "2010-06-24T10:34:01.000+00:00",
       "performer": [ {
         "reference": "Practitioner/1E473786-E7FA-785E-C911-A8D38FB56F20"
       } ],
@@ -4092,7 +4092,7 @@
         "reference": "Encounter/6F7401EE-5139-4F98-8982-70BDD33D4189"
       },
       "effectiveDateTime": "2010-06-24T10:34:01+00:00",
-      "issued": "2010-06-24T11:44:16.000+00:00",
+      "issued": "2010-06-24T10:34:01.000+00:00",
       "performer": [ {
         "reference": "Practitioner/1E473786-E7FA-785E-C911-A8D38FB56F20"
       } ],
@@ -4151,7 +4151,7 @@
         "reference": "Encounter/9A47C85C-7A97-4656-8CAF-572B29B3A591"
       },
       "effectiveDateTime": "2010-01-20T16:27:19+00:00",
-      "issued": "2010-03-26T13:52:58.000+00:00",
+      "issued": "2010-01-20T16:27:19.000+00:00",
       "performer": [ {
         "reference": "Practitioner/C5DEFBF3-0174-BC6F-182C-B777B9C6FF43"
       } ],
@@ -4212,7 +4212,7 @@
         "reference": "Encounter/9A47C85C-7A97-4656-8CAF-572B29B3A591"
       },
       "effectiveDateTime": "2010-01-20T16:27:19+00:00",
-      "issued": "2010-03-26T13:52:58.000+00:00",
+      "issued": "2010-01-20T16:27:19.000+00:00",
       "performer": [ {
         "reference": "Practitioner/C5DEFBF3-0174-BC6F-182C-B777B9C6FF43"
       } ],
@@ -4273,7 +4273,7 @@
         "reference": "Encounter/9A47C85C-7A97-4656-8CAF-572B29B3A591"
       },
       "effectiveDateTime": "2010-01-20T16:27:19+00:00",
-      "issued": "2010-03-26T13:52:58.000+00:00",
+      "issued": "2010-01-20T16:27:19.000+00:00",
       "performer": [ {
         "reference": "Practitioner/C5DEFBF3-0174-BC6F-182C-B777B9C6FF43"
       } ],
@@ -4334,7 +4334,7 @@
         "reference": "Encounter/9A47C85C-7A97-4656-8CAF-572B29B3A591"
       },
       "effectiveDateTime": "2010-01-20T16:27:19+00:00",
-      "issued": "2010-03-26T13:52:58.000+00:00",
+      "issued": "2010-01-20T16:27:19.000+00:00",
       "performer": [ {
         "reference": "Practitioner/C5DEFBF3-0174-BC6F-182C-B777B9C6FF43"
       } ],
@@ -4395,7 +4395,7 @@
         "reference": "Encounter/B2410617-E36D-4B94-8DAF-24449E3A0297"
       },
       "effectiveDateTime": "2010-01-20T16:27:20+00:00",
-      "issued": "2010-03-26T13:53:28.000+00:00",
+      "issued": "2010-01-20T16:27:20.000+00:00",
       "performer": [ {
         "reference": "Practitioner/C5DEFBF3-0174-BC6F-182C-B777B9C6FF43"
       } ],
@@ -4456,7 +4456,7 @@
         "reference": "Encounter/B2410617-E36D-4B94-8DAF-24449E3A0297"
       },
       "effectiveDateTime": "2010-01-20T16:27:20+00:00",
-      "issued": "2010-03-26T13:53:28.000+00:00",
+      "issued": "2010-01-20T16:27:20.000+00:00",
       "performer": [ {
         "reference": "Practitioner/C5DEFBF3-0174-BC6F-182C-B777B9C6FF43"
       } ],
@@ -4517,7 +4517,7 @@
         "reference": "Encounter/B2410617-E36D-4B94-8DAF-24449E3A0297"
       },
       "effectiveDateTime": "2010-01-20T16:27:20+00:00",
-      "issued": "2010-03-26T13:53:28.000+00:00",
+      "issued": "2010-01-20T16:27:20.000+00:00",
       "performer": [ {
         "reference": "Practitioner/C5DEFBF3-0174-BC6F-182C-B777B9C6FF43"
       } ],
@@ -4578,7 +4578,7 @@
         "reference": "Encounter/B2410617-E36D-4B94-8DAF-24449E3A0297"
       },
       "effectiveDateTime": "2010-01-20T16:27:20+00:00",
-      "issued": "2010-03-26T13:53:28.000+00:00",
+      "issued": "2010-01-20T16:27:20.000+00:00",
       "performer": [ {
         "reference": "Practitioner/C5DEFBF3-0174-BC6F-182C-B777B9C6FF43"
       } ],
@@ -4639,7 +4639,7 @@
         "reference": "Encounter/DD64A383-7DC5-4E15-A0FF-20F2C4D195A5"
       },
       "effectiveDateTime": "2010-01-20T16:27:23+00:00",
-      "issued": "2010-03-26T14:04:43.000+00:00",
+      "issued": "2010-01-20T16:27:23.000+00:00",
       "performer": [ {
         "reference": "Practitioner/C5DEFBF3-0174-BC6F-182C-B777B9C6FF43"
       } ],
@@ -4700,7 +4700,7 @@
         "reference": "Encounter/DD64A383-7DC5-4E15-A0FF-20F2C4D195A5"
       },
       "effectiveDateTime": "2010-01-20T16:27:23+00:00",
-      "issued": "2010-03-26T14:04:43.000+00:00",
+      "issued": "2010-01-20T16:27:23.000+00:00",
       "performer": [ {
         "reference": "Practitioner/C5DEFBF3-0174-BC6F-182C-B777B9C6FF43"
       } ],
@@ -4761,7 +4761,7 @@
         "reference": "Encounter/DD64A383-7DC5-4E15-A0FF-20F2C4D195A5"
       },
       "effectiveDateTime": "2010-01-20T16:27:23+00:00",
-      "issued": "2010-03-26T14:04:43.000+00:00",
+      "issued": "2010-01-20T16:27:23.000+00:00",
       "performer": [ {
         "reference": "Practitioner/C5DEFBF3-0174-BC6F-182C-B777B9C6FF43"
       } ],
@@ -4822,7 +4822,7 @@
         "reference": "Encounter/DD64A383-7DC5-4E15-A0FF-20F2C4D195A5"
       },
       "effectiveDateTime": "2010-01-20T16:27:23+00:00",
-      "issued": "2010-03-26T14:04:43.000+00:00",
+      "issued": "2010-01-20T16:27:23.000+00:00",
       "performer": [ {
         "reference": "Practitioner/C5DEFBF3-0174-BC6F-182C-B777B9C6FF43"
       } ],
@@ -4891,7 +4891,7 @@
         "reference": "Encounter/6ACDA770-F676-4ECB-AE41-3BECCE24D02C"
       },
       "effectiveDateTime": "2010-01-20T10:46:22+00:00",
-      "issued": "2010-03-26T13:49:25.000+00:00",
+      "issued": "2010-01-20T10:46:22.000+00:00",
       "performer": [ {
         "reference": "Practitioner/1E473786-E7FA-785E-C911-A8D38FB56F20"
       } ],
@@ -4952,7 +4952,7 @@
         "reference": "Encounter/6ACDA770-F676-4ECB-AE41-3BECCE24D02C"
       },
       "effectiveDateTime": "2010-01-20T10:46:22+00:00",
-      "issued": "2010-03-26T13:49:25.000+00:00",
+      "issued": "2010-01-20T10:46:22.000+00:00",
       "performer": [ {
         "reference": "Practitioner/1E473786-E7FA-785E-C911-A8D38FB56F20"
       } ],
@@ -5027,7 +5027,7 @@
         "reference": "Encounter/6ACDA770-F676-4ECB-AE41-3BECCE24D02C"
       },
       "effectiveDateTime": "2010-01-20T10:46:22+00:00",
-      "issued": "2010-03-26T13:49:25.000+00:00",
+      "issued": "2010-01-20T10:46:22.000+00:00",
       "performer": [ {
         "reference": "Practitioner/1E473786-E7FA-785E-C911-A8D38FB56F20"
       } ],
@@ -5099,7 +5099,7 @@
         "reference": "Encounter/6ACDA770-F676-4ECB-AE41-3BECCE24D02C"
       },
       "effectiveDateTime": "2010-01-20T10:46:22+00:00",
-      "issued": "2010-03-26T13:49:25.000+00:00",
+      "issued": "2010-01-20T10:46:22.000+00:00",
       "performer": [ {
         "reference": "Practitioner/1E473786-E7FA-785E-C911-A8D38FB56F20"
       } ],
@@ -5168,7 +5168,7 @@
         "reference": "Encounter/6ACDA770-F676-4ECB-AE41-3BECCE24D02C"
       },
       "effectiveDateTime": "2010-01-20T10:46:22+00:00",
-      "issued": "2010-03-26T13:49:25.000+00:00",
+      "issued": "2010-01-20T10:46:22.000+00:00",
       "performer": [ {
         "reference": "Practitioner/1E473786-E7FA-785E-C911-A8D38FB56F20"
       } ],
@@ -5243,7 +5243,7 @@
         "reference": "Encounter/6ACDA770-F676-4ECB-AE41-3BECCE24D02C"
       },
       "effectiveDateTime": "2010-01-20T10:46:22+00:00",
-      "issued": "2010-03-26T13:49:25.000+00:00",
+      "issued": "2010-01-20T10:46:22.000+00:00",
       "performer": [ {
         "reference": "Practitioner/1E473786-E7FA-785E-C911-A8D38FB56F20"
       } ],
@@ -5324,7 +5324,7 @@
         "reference": "Encounter/6ACDA770-F676-4ECB-AE41-3BECCE24D02C"
       },
       "effectiveDateTime": "2010-01-20T10:46:22+00:00",
-      "issued": "2010-03-26T13:49:25.000+00:00",
+      "issued": "2010-01-20T10:46:22.000+00:00",
       "performer": [ {
         "reference": "Practitioner/1E473786-E7FA-785E-C911-A8D38FB56F20"
       } ],
@@ -5408,7 +5408,7 @@
         "reference": "Encounter/6ACDA770-F676-4ECB-AE41-3BECCE24D02C"
       },
       "effectiveDateTime": "2010-01-20T10:46:22+00:00",
-      "issued": "2010-03-26T13:49:25.000+00:00",
+      "issued": "2010-01-20T10:46:22.000+00:00",
       "performer": [ {
         "reference": "Practitioner/1E473786-E7FA-785E-C911-A8D38FB56F20"
       } ],
@@ -5474,7 +5474,7 @@
         "reference": "Encounter/6ACDA770-F676-4ECB-AE41-3BECCE24D02C"
       },
       "effectiveDateTime": "2010-01-20T10:46:22+00:00",
-      "issued": "2010-03-26T13:49:25.000+00:00",
+      "issued": "2010-01-20T10:46:22.000+00:00",
       "performer": [ {
         "reference": "Practitioner/1E473786-E7FA-785E-C911-A8D38FB56F20"
       } ],
@@ -5546,7 +5546,7 @@
         "reference": "Encounter/6ACDA770-F676-4ECB-AE41-3BECCE24D02C"
       },
       "effectiveDateTime": "2010-01-20T10:46:22+00:00",
-      "issued": "2010-03-26T13:49:25.000+00:00",
+      "issued": "2010-01-20T10:46:22.000+00:00",
       "performer": [ {
         "reference": "Practitioner/1E473786-E7FA-785E-C911-A8D38FB56F20"
       } ],
@@ -5621,7 +5621,7 @@
         "reference": "Encounter/6ACDA770-F676-4ECB-AE41-3BECCE24D02C"
       },
       "effectiveDateTime": "2010-01-20T10:46:22+00:00",
-      "issued": "2010-03-26T13:49:25.000+00:00",
+      "issued": "2010-01-20T10:46:22.000+00:00",
       "performer": [ {
         "reference": "Practitioner/1E473786-E7FA-785E-C911-A8D38FB56F20"
       } ],
@@ -5701,7 +5701,7 @@
         "reference": "Encounter/6ACDA770-F676-4ECB-AE41-3BECCE24D02C"
       },
       "effectiveDateTime": "2010-01-20T10:46:22+00:00",
-      "issued": "2010-03-26T13:49:25.000+00:00",
+      "issued": "2010-01-20T10:46:22.000+00:00",
       "performer": [ {
         "reference": "Practitioner/1E473786-E7FA-785E-C911-A8D38FB56F20"
       } ],
@@ -5773,7 +5773,7 @@
         "reference": "Encounter/6ACDA770-F676-4ECB-AE41-3BECCE24D02C"
       },
       "effectiveDateTime": "2010-01-20T10:46:22+00:00",
-      "issued": "2010-03-26T13:49:25.000+00:00",
+      "issued": "2010-01-20T10:46:22.000+00:00",
       "performer": [ {
         "reference": "Practitioner/1E473786-E7FA-785E-C911-A8D38FB56F20"
       } ],
@@ -5848,7 +5848,7 @@
         "reference": "Encounter/6ACDA770-F676-4ECB-AE41-3BECCE24D02C"
       },
       "effectiveDateTime": "2010-01-20T10:46:22+00:00",
-      "issued": "2010-03-26T13:49:25.000+00:00",
+      "issued": "2010-01-20T10:46:22.000+00:00",
       "performer": [ {
         "reference": "Practitioner/1E473786-E7FA-785E-C911-A8D38FB56F20"
       } ],
@@ -5920,7 +5920,7 @@
         "reference": "Encounter/6ACDA770-F676-4ECB-AE41-3BECCE24D02C"
       },
       "effectiveDateTime": "2010-01-20T10:46:22+00:00",
-      "issued": "2010-03-26T13:49:25.000+00:00",
+      "issued": "2010-01-20T10:46:22.000+00:00",
       "performer": [ {
         "reference": "Practitioner/1E473786-E7FA-785E-C911-A8D38FB56F20"
       } ],
@@ -5981,7 +5981,7 @@
         "reference": "Encounter/6ACDA770-F676-4ECB-AE41-3BECCE24D02C"
       },
       "effectiveDateTime": "2010-01-20T10:46:22+00:00",
-      "issued": "2010-03-26T13:49:25.000+00:00",
+      "issued": "2010-01-20T10:46:22.000+00:00",
       "performer": [ {
         "reference": "Practitioner/1E473786-E7FA-785E-C911-A8D38FB56F20"
       } ],
@@ -6056,7 +6056,7 @@
         "reference": "Encounter/6ACDA770-F676-4ECB-AE41-3BECCE24D02C"
       },
       "effectiveDateTime": "2010-01-20T10:46:22+00:00",
-      "issued": "2010-03-26T13:49:25.000+00:00",
+      "issued": "2010-01-20T10:46:22.000+00:00",
       "performer": [ {
         "reference": "Practitioner/1E473786-E7FA-785E-C911-A8D38FB56F20"
       } ],
@@ -6117,7 +6117,7 @@
         "reference": "Encounter/6ACDA770-F676-4ECB-AE41-3BECCE24D02C"
       },
       "effectiveDateTime": "2010-01-20T10:46:22+00:00",
-      "issued": "2010-03-26T13:49:25.000+00:00",
+      "issued": "2010-01-20T10:46:22.000+00:00",
       "performer": [ {
         "reference": "Practitioner/1E473786-E7FA-785E-C911-A8D38FB56F20"
       } ],
@@ -6192,7 +6192,7 @@
         "reference": "Encounter/6ACDA770-F676-4ECB-AE41-3BECCE24D02C"
       },
       "effectiveDateTime": "2010-01-20T10:46:22+00:00",
-      "issued": "2010-03-26T13:49:25.000+00:00",
+      "issued": "2010-01-20T10:46:22.000+00:00",
       "performer": [ {
         "reference": "Practitioner/1E473786-E7FA-785E-C911-A8D38FB56F20"
       } ],
@@ -6267,7 +6267,7 @@
         "reference": "Encounter/6ACDA770-F676-4ECB-AE41-3BECCE24D02C"
       },
       "effectiveDateTime": "2010-01-20T10:46:22+00:00",
-      "issued": "2010-03-26T13:49:25.000+00:00",
+      "issued": "2010-01-20T10:46:22.000+00:00",
       "performer": [ {
         "reference": "Practitioner/1E473786-E7FA-785E-C911-A8D38FB56F20"
       } ],
@@ -6339,7 +6339,7 @@
         "reference": "Encounter/9096889B-4D56-4668-86F7-1E1C63011A46"
       },
       "effectiveDateTime": "2010-01-20T10:46:22+00:00",
-      "issued": "2010-03-26T13:45:44.000+00:00",
+      "issued": "2010-01-20T10:46:22.000+00:00",
       "performer": [ {
         "reference": "Practitioner/1E473786-E7FA-785E-C911-A8D38FB56F20"
       } ],
@@ -6414,7 +6414,7 @@
         "reference": "Encounter/9096889B-4D56-4668-86F7-1E1C63011A46"
       },
       "effectiveDateTime": "2010-01-20T10:46:22+00:00",
-      "issued": "2010-03-26T13:45:44.000+00:00",
+      "issued": "2010-01-20T10:46:22.000+00:00",
       "performer": [ {
         "reference": "Practitioner/1E473786-E7FA-785E-C911-A8D38FB56F20"
       } ],
@@ -6486,7 +6486,7 @@
         "reference": "Encounter/9096889B-4D56-4668-86F7-1E1C63011A46"
       },
       "effectiveDateTime": "2010-01-20T10:46:22+00:00",
-      "issued": "2010-03-26T13:45:44.000+00:00",
+      "issued": "2010-01-20T10:46:22.000+00:00",
       "performer": [ {
         "reference": "Practitioner/1E473786-E7FA-785E-C911-A8D38FB56F20"
       } ],
@@ -6561,7 +6561,7 @@
         "reference": "Encounter/9096889B-4D56-4668-86F7-1E1C63011A46"
       },
       "effectiveDateTime": "2010-01-20T10:46:22+00:00",
-      "issued": "2010-03-26T13:45:44.000+00:00",
+      "issued": "2010-01-20T10:46:22.000+00:00",
       "performer": [ {
         "reference": "Practitioner/1E473786-E7FA-785E-C911-A8D38FB56F20"
       } ],
@@ -6639,7 +6639,7 @@
         "reference": "Encounter/9096889B-4D56-4668-86F7-1E1C63011A46"
       },
       "effectiveDateTime": "2010-01-20T10:46:22+00:00",
-      "issued": "2010-03-26T13:45:44.000+00:00",
+      "issued": "2010-01-20T10:46:22.000+00:00",
       "performer": [ {
         "reference": "Practitioner/1E473786-E7FA-785E-C911-A8D38FB56F20"
       } ],
@@ -6707,7 +6707,7 @@
         "reference": "Encounter/9096889B-4D56-4668-86F7-1E1C63011A46"
       },
       "effectiveDateTime": "2010-01-20T10:46:22+00:00",
-      "issued": "2010-03-26T13:45:44.000+00:00",
+      "issued": "2010-01-20T10:46:22.000+00:00",
       "performer": [ {
         "reference": "Practitioner/1E473786-E7FA-785E-C911-A8D38FB56F20"
       } ],
@@ -6781,7 +6781,7 @@
         "reference": "Encounter/9096889B-4D56-4668-86F7-1E1C63011A46"
       },
       "effectiveDateTime": "2010-01-20T10:46:22+00:00",
-      "issued": "2010-03-26T13:45:44.000+00:00",
+      "issued": "2010-01-20T10:46:22.000+00:00",
       "performer": [ {
         "reference": "Practitioner/1E473786-E7FA-785E-C911-A8D38FB56F20"
       } ],
@@ -6856,7 +6856,7 @@
         "reference": "Encounter/9096889B-4D56-4668-86F7-1E1C63011A46"
       },
       "effectiveDateTime": "2010-01-20T10:46:22+00:00",
-      "issued": "2010-03-26T13:45:44.000+00:00",
+      "issued": "2010-01-20T10:46:22.000+00:00",
       "performer": [ {
         "reference": "Practitioner/1E473786-E7FA-785E-C911-A8D38FB56F20"
       } ],
@@ -6934,7 +6934,7 @@
         "reference": "Encounter/9096889B-4D56-4668-86F7-1E1C63011A46"
       },
       "effectiveDateTime": "2010-01-20T10:46:22+00:00",
-      "issued": "2010-03-26T13:45:44.000+00:00",
+      "issued": "2010-01-20T10:46:22.000+00:00",
       "performer": [ {
         "reference": "Practitioner/1E473786-E7FA-785E-C911-A8D38FB56F20"
       } ],
@@ -6997,7 +6997,7 @@
         "reference": "Encounter/9096889B-4D56-4668-86F7-1E1C63011A46"
       },
       "effectiveDateTime": "2010-01-20T10:46:22+00:00",
-      "issued": "2010-03-26T13:45:44.000+00:00",
+      "issued": "2010-01-20T10:46:22.000+00:00",
       "performer": [ {
         "reference": "Practitioner/1E473786-E7FA-785E-C911-A8D38FB56F20"
       } ],
@@ -7072,7 +7072,7 @@
         "reference": "Encounter/9096889B-4D56-4668-86F7-1E1C63011A46"
       },
       "effectiveDateTime": "2010-01-20T10:46:22+00:00",
-      "issued": "2010-03-26T13:45:44.000+00:00",
+      "issued": "2010-01-20T10:46:22.000+00:00",
       "performer": [ {
         "reference": "Practitioner/1E473786-E7FA-785E-C911-A8D38FB56F20"
       } ],
@@ -7149,7 +7149,7 @@
         "reference": "Encounter/9096889B-4D56-4668-86F7-1E1C63011A46"
       },
       "effectiveDateTime": "2010-01-20T10:46:22+00:00",
-      "issued": "2010-03-26T13:45:44.000+00:00",
+      "issued": "2010-01-20T10:46:22.000+00:00",
       "performer": [ {
         "reference": "Practitioner/1E473786-E7FA-785E-C911-A8D38FB56F20"
       } ],
@@ -7226,7 +7226,7 @@
         "reference": "Encounter/9096889B-4D56-4668-86F7-1E1C63011A46"
       },
       "effectiveDateTime": "2010-01-20T10:46:22+00:00",
-      "issued": "2010-03-26T13:45:44.000+00:00",
+      "issued": "2010-01-20T10:46:22.000+00:00",
       "performer": [ {
         "reference": "Practitioner/1E473786-E7FA-785E-C911-A8D38FB56F20"
       } ],
@@ -7303,7 +7303,7 @@
         "reference": "Encounter/730C507B-32CE-4270-80BA-42F4B62BA064"
       },
       "effectiveDateTime": "2010-01-20T10:46:22+00:00",
-      "issued": "2010-02-09T12:21:06.000+00:00",
+      "issued": "2010-01-20T10:46:22.000+00:00",
       "performer": [ {
         "reference": "Practitioner/1E473786-E7FA-785E-C911-A8D38FB56F20"
       } ],
@@ -7377,7 +7377,7 @@
         "reference": "Encounter/730C507B-32CE-4270-80BA-42F4B62BA064"
       },
       "effectiveDateTime": "2010-01-20T10:46:22+00:00",
-      "issued": "2010-02-09T12:21:06.000+00:00",
+      "issued": "2010-01-20T10:46:22.000+00:00",
       "performer": [ {
         "reference": "Practitioner/1E473786-E7FA-785E-C911-A8D38FB56F20"
       } ],
@@ -7449,7 +7449,7 @@
         "reference": "Encounter/730C507B-32CE-4270-80BA-42F4B62BA064"
       },
       "effectiveDateTime": "2010-01-20T10:46:22+00:00",
-      "issued": "2010-02-09T12:21:06.000+00:00",
+      "issued": "2010-01-20T10:46:22.000+00:00",
       "performer": [ {
         "reference": "Practitioner/1E473786-E7FA-785E-C911-A8D38FB56F20"
       } ],
@@ -7524,7 +7524,7 @@
         "reference": "Encounter/730C507B-32CE-4270-80BA-42F4B62BA064"
       },
       "effectiveDateTime": "2010-01-20T10:46:22+00:00",
-      "issued": "2010-02-09T12:21:06.000+00:00",
+      "issued": "2010-01-20T10:46:22.000+00:00",
       "performer": [ {
         "reference": "Practitioner/1E473786-E7FA-785E-C911-A8D38FB56F20"
       } ],
@@ -7606,7 +7606,7 @@
         "reference": "Encounter/730C507B-32CE-4270-80BA-42F4B62BA064"
       },
       "effectiveDateTime": "2010-01-20T10:46:22+00:00",
-      "issued": "2010-02-09T12:21:06.000+00:00",
+      "issued": "2010-01-20T10:46:22.000+00:00",
       "performer": [ {
         "reference": "Practitioner/1E473786-E7FA-785E-C911-A8D38FB56F20"
       } ],
@@ -7681,7 +7681,7 @@
         "reference": "Encounter/730C507B-32CE-4270-80BA-42F4B62BA064"
       },
       "effectiveDateTime": "2010-01-20T10:46:22+00:00",
-      "issued": "2010-02-09T12:21:06.000+00:00",
+      "issued": "2010-01-20T10:46:22.000+00:00",
       "performer": [ {
         "reference": "Practitioner/1E473786-E7FA-785E-C911-A8D38FB56F20"
       } ],
@@ -7754,7 +7754,7 @@
         "reference": "Encounter/730C507B-32CE-4270-80BA-42F4B62BA064"
       },
       "effectiveDateTime": "2010-01-20T10:46:22+00:00",
-      "issued": "2010-02-09T12:21:06.000+00:00",
+      "issued": "2010-01-20T10:46:22.000+00:00",
       "performer": [ {
         "reference": "Practitioner/1E473786-E7FA-785E-C911-A8D38FB56F20"
       } ],
@@ -7809,7 +7809,7 @@
         "reference": "Encounter/730C507B-32CE-4270-80BA-42F4B62BA064"
       },
       "effectiveDateTime": "2010-01-20T10:46:22+00:00",
-      "issued": "2010-02-09T12:21:06.000+00:00",
+      "issued": "2010-01-20T10:46:22.000+00:00",
       "performer": [ {
         "reference": "Practitioner/1E473786-E7FA-785E-C911-A8D38FB56F20"
       } ],
@@ -7866,7 +7866,7 @@
         "reference": "Encounter/A076B5DA-4B2F-42C4-8807-4A71A26ECD25"
       },
       "effectiveDateTime": "2010-01-20T10:46:22+00:00",
-      "issued": "2010-03-26T13:49:40.000+00:00",
+      "issued": "2010-01-20T10:46:22.000+00:00",
       "performer": [ {
         "reference": "Practitioner/1E473786-E7FA-785E-C911-A8D38FB56F20"
       } ],
@@ -7935,7 +7935,7 @@
         "reference": "Encounter/A076B5DA-4B2F-42C4-8807-4A71A26ECD25"
       },
       "effectiveDateTime": "2010-01-20T10:46:22+00:00",
-      "issued": "2010-03-26T13:49:40.000+00:00",
+      "issued": "2010-01-20T10:46:22.000+00:00",
       "performer": [ {
         "reference": "Practitioner/1E473786-E7FA-785E-C911-A8D38FB56F20"
       } ],
@@ -8001,7 +8001,7 @@
         "reference": "Encounter/B0696913-F11D-4EAA-8BB7-41350B296F3F"
       },
       "effectiveDateTime": "2010-01-20T16:27:23+00:00",
-      "issued": "2010-02-01T09:33:13.000+00:00",
+      "issued": "2010-01-20T16:27:23.000+00:00",
       "performer": [ {
         "reference": "Practitioner/1E473786-E7FA-785E-C911-A8D38FB56F20"
       } ],
@@ -8073,7 +8073,7 @@
         "reference": "Encounter/B0696913-F11D-4EAA-8BB7-41350B296F3F"
       },
       "effectiveDateTime": "2010-01-20T16:27:23+00:00",
-      "issued": "2010-02-01T09:33:13.000+00:00",
+      "issued": "2010-01-20T16:27:23.000+00:00",
       "performer": [ {
         "reference": "Practitioner/1E473786-E7FA-785E-C911-A8D38FB56F20"
       } ],
@@ -8148,7 +8148,7 @@
         "reference": "Encounter/B0696913-F11D-4EAA-8BB7-41350B296F3F"
       },
       "effectiveDateTime": "2010-01-20T16:27:23+00:00",
-      "issued": "2010-02-01T09:33:13.000+00:00",
+      "issued": "2010-01-20T16:27:23.000+00:00",
       "performer": [ {
         "reference": "Practitioner/1E473786-E7FA-785E-C911-A8D38FB56F20"
       } ],
@@ -8220,7 +8220,7 @@
         "reference": "Encounter/B0696913-F11D-4EAA-8BB7-41350B296F3F"
       },
       "effectiveDateTime": "2010-01-20T16:27:23+00:00",
-      "issued": "2010-02-01T09:33:13.000+00:00",
+      "issued": "2010-01-20T16:27:23.000+00:00",
       "performer": [ {
         "reference": "Practitioner/1E473786-E7FA-785E-C911-A8D38FB56F20"
       } ],
@@ -8281,7 +8281,7 @@
         "reference": "Encounter/B0696913-F11D-4EAA-8BB7-41350B296F3F"
       },
       "effectiveDateTime": "2010-01-20T16:27:23+00:00",
-      "issued": "2010-02-01T09:33:13.000+00:00",
+      "issued": "2010-01-20T16:27:23.000+00:00",
       "performer": [ {
         "reference": "Practitioner/1E473786-E7FA-785E-C911-A8D38FB56F20"
       } ],
@@ -8354,7 +8354,7 @@
         "reference": "Encounter/B0696913-F11D-4EAA-8BB7-41350B296F3F"
       },
       "effectiveDateTime": "2010-01-20T16:27:23+00:00",
-      "issued": "2010-02-01T09:33:13.000+00:00",
+      "issued": "2010-01-20T16:27:23.000+00:00",
       "performer": [ {
         "reference": "Practitioner/1E473786-E7FA-785E-C911-A8D38FB56F20"
       } ],
@@ -8426,7 +8426,7 @@
         "reference": "Encounter/B0696913-F11D-4EAA-8BB7-41350B296F3F"
       },
       "effectiveDateTime": "2010-01-20T16:27:23+00:00",
-      "issued": "2010-02-01T09:33:13.000+00:00",
+      "issued": "2010-01-20T16:27:23.000+00:00",
       "performer": [ {
         "reference": "Practitioner/1E473786-E7FA-785E-C911-A8D38FB56F20"
       } ],
@@ -8498,7 +8498,7 @@
         "reference": "Encounter/B0696913-F11D-4EAA-8BB7-41350B296F3F"
       },
       "effectiveDateTime": "2010-01-20T16:27:23+00:00",
-      "issued": "2010-02-01T09:33:13.000+00:00",
+      "issued": "2010-01-20T16:27:23.000+00:00",
       "performer": [ {
         "reference": "Practitioner/1E473786-E7FA-785E-C911-A8D38FB56F20"
       } ],
@@ -8573,7 +8573,7 @@
         "reference": "Encounter/B0696913-F11D-4EAA-8BB7-41350B296F3F"
       },
       "effectiveDateTime": "2010-01-20T16:27:23+00:00",
-      "issued": "2010-02-01T09:33:13.000+00:00",
+      "issued": "2010-01-20T16:27:23.000+00:00",
       "performer": [ {
         "reference": "Practitioner/1E473786-E7FA-785E-C911-A8D38FB56F20"
       } ],
@@ -8635,7 +8635,7 @@
         "reference": "Encounter/B0696913-F11D-4EAA-8BB7-41350B296F3F"
       },
       "effectiveDateTime": "2010-01-20T16:27:23+00:00",
-      "issued": "2010-02-01T09:33:13.000+00:00",
+      "issued": "2010-01-20T16:27:23.000+00:00",
       "performer": [ {
         "reference": "Practitioner/1E473786-E7FA-785E-C911-A8D38FB56F20"
       } ],
@@ -8710,7 +8710,7 @@
         "reference": "Encounter/B0696913-F11D-4EAA-8BB7-41350B296F3F"
       },
       "effectiveDateTime": "2010-01-20T16:27:23+00:00",
-      "issued": "2010-02-01T09:33:13.000+00:00",
+      "issued": "2010-01-20T16:27:23.000+00:00",
       "performer": [ {
         "reference": "Practitioner/1E473786-E7FA-785E-C911-A8D38FB56F20"
       } ],
@@ -8785,7 +8785,7 @@
         "reference": "Encounter/B0696913-F11D-4EAA-8BB7-41350B296F3F"
       },
       "effectiveDateTime": "2010-01-20T16:27:23+00:00",
-      "issued": "2010-02-01T09:33:13.000+00:00",
+      "issued": "2010-01-20T16:27:23.000+00:00",
       "performer": [ {
         "reference": "Practitioner/1E473786-E7FA-785E-C911-A8D38FB56F20"
       } ],
@@ -8860,7 +8860,7 @@
         "reference": "Encounter/B0696913-F11D-4EAA-8BB7-41350B296F3F"
       },
       "effectiveDateTime": "2010-01-20T16:27:23+00:00",
-      "issued": "2010-02-01T09:33:13.000+00:00",
+      "issued": "2010-01-20T16:27:23.000+00:00",
       "performer": [ {
         "reference": "Practitioner/1E473786-E7FA-785E-C911-A8D38FB56F20"
       } ],
@@ -8921,7 +8921,7 @@
         "reference": "Encounter/B0696913-F11D-4EAA-8BB7-41350B296F3F"
       },
       "effectiveDateTime": "2010-01-20T16:27:23+00:00",
-      "issued": "2010-02-01T09:33:13.000+00:00",
+      "issued": "2010-01-20T16:27:23.000+00:00",
       "performer": [ {
         "reference": "Practitioner/1E473786-E7FA-785E-C911-A8D38FB56F20"
       } ],
@@ -8993,7 +8993,7 @@
         "reference": "Encounter/B0696913-F11D-4EAA-8BB7-41350B296F3F"
       },
       "effectiveDateTime": "2010-01-20T16:27:23+00:00",
-      "issued": "2010-02-01T09:33:13.000+00:00",
+      "issued": "2010-01-20T16:27:23.000+00:00",
       "performer": [ {
         "reference": "Practitioner/1E473786-E7FA-785E-C911-A8D38FB56F20"
       } ],
@@ -9060,7 +9060,7 @@
         "reference": "Encounter/B0696913-F11D-4EAA-8BB7-41350B296F3F"
       },
       "effectiveDateTime": "2010-01-20T16:27:23+00:00",
-      "issued": "2010-02-01T09:33:13.000+00:00",
+      "issued": "2010-01-20T16:27:23.000+00:00",
       "performer": [ {
         "reference": "Practitioner/1E473786-E7FA-785E-C911-A8D38FB56F20"
       } ],
@@ -9120,7 +9120,7 @@
         "reference": "Encounter/B0696913-F11D-4EAA-8BB7-41350B296F3F"
       },
       "effectiveDateTime": "2010-01-20T16:27:23+00:00",
-      "issued": "2010-02-01T09:33:13.000+00:00",
+      "issued": "2010-01-20T16:27:23.000+00:00",
       "performer": [ {
         "reference": "Practitioner/1E473786-E7FA-785E-C911-A8D38FB56F20"
       } ],
@@ -9180,7 +9180,7 @@
         "reference": "Encounter/6AF1549E-55BC-481D-A498-19B213312DB7"
       },
       "effectiveDateTime": "2010-01-20T10:46:22+00:00",
-      "issued": "2010-02-09T12:08:18.000+00:00",
+      "issued": "2010-01-20T10:46:22.000+00:00",
       "performer": [ {
         "reference": "Practitioner/C5DEFBF3-0174-BC6F-182C-B777B9C6FF43"
       } ],
@@ -9246,7 +9246,7 @@
         "reference": "Encounter/6AF1549E-55BC-481D-A498-19B213312DB7"
       },
       "effectiveDateTime": "2010-01-20T10:46:22+00:00",
-      "issued": "2010-02-09T12:08:18.000+00:00",
+      "issued": "2010-01-20T10:46:22.000+00:00",
       "performer": [ {
         "reference": "Practitioner/C5DEFBF3-0174-BC6F-182C-B777B9C6FF43"
       } ],
@@ -9309,7 +9309,7 @@
         "reference": "Encounter/6AF1549E-55BC-481D-A498-19B213312DB7"
       },
       "effectiveDateTime": "2010-01-20T10:46:22+00:00",
-      "issued": "2010-02-09T12:08:18.000+00:00",
+      "issued": "2010-01-20T10:46:22.000+00:00",
       "performer": [ {
         "reference": "Practitioner/C5DEFBF3-0174-BC6F-182C-B777B9C6FF43"
       } ],
@@ -9366,7 +9366,7 @@
         "reference": "Encounter/6AF1549E-55BC-481D-A498-19B213312DB7"
       },
       "effectiveDateTime": "2010-01-20T10:46:22+00:00",
-      "issued": "2010-02-09T12:08:18.000+00:00",
+      "issued": "2010-01-20T10:46:22.000+00:00",
       "performer": [ {
         "reference": "Practitioner/C5DEFBF3-0174-BC6F-182C-B777B9C6FF43"
       } ],
@@ -9423,7 +9423,7 @@
         "reference": "Encounter/6AF1549E-55BC-481D-A498-19B213312DB7"
       },
       "effectiveDateTime": "2010-01-20T10:46:22+00:00",
-      "issued": "2010-02-09T12:08:18.000+00:00",
+      "issued": "2010-01-20T10:46:22.000+00:00",
       "performer": [ {
         "reference": "Practitioner/C5DEFBF3-0174-BC6F-182C-B777B9C6FF43"
       } ],
@@ -9477,7 +9477,7 @@
         "reference": "Encounter/6AF1549E-55BC-481D-A498-19B213312DB7"
       },
       "effectiveDateTime": "2010-01-20T10:46:22+00:00",
-      "issued": "2010-02-09T12:08:18.000+00:00",
+      "issued": "2010-01-20T10:46:22.000+00:00",
       "performer": [ {
         "reference": "Practitioner/C5DEFBF3-0174-BC6F-182C-B777B9C6FF43"
       } ],
@@ -9534,7 +9534,7 @@
         "reference": "Encounter/6AF1549E-55BC-481D-A498-19B213312DB7"
       },
       "effectiveDateTime": "2010-01-20T10:46:22+00:00",
-      "issued": "2010-02-09T12:08:18.000+00:00",
+      "issued": "2010-01-20T10:46:22.000+00:00",
       "performer": [ {
         "reference": "Practitioner/C5DEFBF3-0174-BC6F-182C-B777B9C6FF43"
       } ],
@@ -9577,7 +9577,7 @@
         "reference": "Encounter/6AF1549E-55BC-481D-A498-19B213312DB7"
       },
       "effectiveDateTime": "2010-01-20T10:46:22+00:00",
-      "issued": "2010-02-09T12:08:18.000+00:00",
+      "issued": "2010-01-20T10:46:22.000+00:00",
       "performer": [ {
         "reference": "Practitioner/C5DEFBF3-0174-BC6F-182C-B777B9C6FF43"
       } ],
@@ -9620,7 +9620,7 @@
         "reference": "Encounter/6AF1549E-55BC-481D-A498-19B213312DB7"
       },
       "effectiveDateTime": "2010-01-20T10:46:22+00:00",
-      "issued": "2010-02-09T12:08:18.000+00:00",
+      "issued": "2010-01-20T10:46:22.000+00:00",
       "performer": [ {
         "reference": "Practitioner/C5DEFBF3-0174-BC6F-182C-B777B9C6FF43"
       } ],
@@ -9677,7 +9677,7 @@
         "reference": "Encounter/6AF1549E-55BC-481D-A498-19B213312DB7"
       },
       "effectiveDateTime": "2010-01-20T10:46:22+00:00",
-      "issued": "2010-02-09T12:08:18.000+00:00",
+      "issued": "2010-01-20T10:46:22.000+00:00",
       "performer": [ {
         "reference": "Practitioner/C5DEFBF3-0174-BC6F-182C-B777B9C6FF43"
       } ],
@@ -9720,7 +9720,7 @@
         "reference": "Encounter/6AF1549E-55BC-481D-A498-19B213312DB7"
       },
       "effectiveDateTime": "2010-01-20T10:46:22+00:00",
-      "issued": "2010-02-09T12:08:18.000+00:00",
+      "issued": "2010-01-20T10:46:22.000+00:00",
       "performer": [ {
         "reference": "Practitioner/C5DEFBF3-0174-BC6F-182C-B777B9C6FF43"
       } ],
@@ -9763,7 +9763,7 @@
         "reference": "Encounter/6AF1549E-55BC-481D-A498-19B213312DB7"
       },
       "effectiveDateTime": "2010-01-20T10:46:22+00:00",
-      "issued": "2010-02-09T12:08:18.000+00:00",
+      "issued": "2010-01-20T10:46:22.000+00:00",
       "performer": [ {
         "reference": "Practitioner/C5DEFBF3-0174-BC6F-182C-B777B9C6FF43"
       } ],
@@ -9820,7 +9820,7 @@
         "reference": "Encounter/1449860E-3953-4D71-A867-3E1E79D2E11B"
       },
       "effectiveDateTime": "2010-01-20T10:46:22+00:00",
-      "issued": "2010-03-26T13:49:48.000+00:00",
+      "issued": "2010-01-20T10:46:22.000+00:00",
       "performer": [ {
         "reference": "Practitioner/1E473786-E7FA-785E-C911-A8D38FB56F20"
       } ],
@@ -9892,7 +9892,7 @@
         "reference": "Encounter/1449860E-3953-4D71-A867-3E1E79D2E11B"
       },
       "effectiveDateTime": "2010-01-20T10:46:22+00:00",
-      "issued": "2010-03-26T13:49:48.000+00:00",
+      "issued": "2010-01-20T10:46:22.000+00:00",
       "performer": [ {
         "reference": "Practitioner/1E473786-E7FA-785E-C911-A8D38FB56F20"
       } ],
@@ -9967,7 +9967,7 @@
         "reference": "Encounter/1449860E-3953-4D71-A867-3E1E79D2E11B"
       },
       "effectiveDateTime": "2010-01-20T10:46:22+00:00",
-      "issued": "2010-03-26T13:49:48.000+00:00",
+      "issued": "2010-01-20T10:46:22.000+00:00",
       "performer": [ {
         "reference": "Practitioner/1E473786-E7FA-785E-C911-A8D38FB56F20"
       } ],
@@ -10042,7 +10042,7 @@
         "reference": "Encounter/1449860E-3953-4D71-A867-3E1E79D2E11B"
       },
       "effectiveDateTime": "2010-01-20T10:46:22+00:00",
-      "issued": "2010-03-26T13:49:48.000+00:00",
+      "issued": "2010-01-20T10:46:22.000+00:00",
       "performer": [ {
         "reference": "Practitioner/1E473786-E7FA-785E-C911-A8D38FB56F20"
       } ],
@@ -10114,7 +10114,7 @@
         "reference": "Encounter/1449860E-3953-4D71-A867-3E1E79D2E11B"
       },
       "effectiveDateTime": "2010-01-20T10:46:22+00:00",
-      "issued": "2010-03-26T13:49:48.000+00:00",
+      "issued": "2010-01-20T10:46:22.000+00:00",
       "performer": [ {
         "reference": "Practitioner/1E473786-E7FA-785E-C911-A8D38FB56F20"
       } ],
@@ -10181,7 +10181,7 @@
         "reference": "Encounter/1449860E-3953-4D71-A867-3E1E79D2E11B"
       },
       "effectiveDateTime": "2010-01-20T10:46:22+00:00",
-      "issued": "2010-03-26T13:49:48.000+00:00",
+      "issued": "2010-01-20T10:46:22.000+00:00",
       "performer": [ {
         "reference": "Practitioner/1E473786-E7FA-785E-C911-A8D38FB56F20"
       } ],
@@ -10253,7 +10253,7 @@
         "reference": "Encounter/1449860E-3953-4D71-A867-3E1E79D2E11B"
       },
       "effectiveDateTime": "2010-01-20T10:46:22+00:00",
-      "issued": "2010-03-26T13:49:48.000+00:00",
+      "issued": "2010-01-20T10:46:22.000+00:00",
       "performer": [ {
         "reference": "Practitioner/1E473786-E7FA-785E-C911-A8D38FB56F20"
       } ],
@@ -10321,7 +10321,7 @@
         "reference": "Encounter/1449860E-3953-4D71-A867-3E1E79D2E11B"
       },
       "effectiveDateTime": "2010-01-20T10:46:22+00:00",
-      "issued": "2010-03-26T13:49:48.000+00:00",
+      "issued": "2010-01-20T10:46:22.000+00:00",
       "performer": [ {
         "reference": "Practitioner/1E473786-E7FA-785E-C911-A8D38FB56F20"
       } ],
@@ -10384,7 +10384,7 @@
         "reference": "Encounter/6ED5590B-146D-4B42-939E-2C35646ED7C1"
       },
       "effectiveDateTime": "2010-02-10T08:56:00+00:00",
-      "issued": "2010-02-10T09:00:02.000+00:00",
+      "issued": "2010-02-10T08:56:00.000+00:00",
       "performer": [ {
         "reference": "Practitioner/1E473786-E7FA-785E-C911-A8D38FB56F20"
       } ],
@@ -10428,7 +10428,7 @@
         "reference": "Encounter/6ED5590B-146D-4B42-939E-2C35646ED7C1"
       },
       "effectiveDateTime": "2010-02-10T08:56:00+00:00",
-      "issued": "2010-02-10T09:00:02.000+00:00",
+      "issued": "2010-02-10T08:56:00.000+00:00",
       "performer": [ {
         "reference": "Practitioner/1E473786-E7FA-785E-C911-A8D38FB56F20"
       } ],
@@ -10479,7 +10479,7 @@
         "reference": "Encounter/6ED5590B-146D-4B42-939E-2C35646ED7C1"
       },
       "effectiveDateTime": "2010-02-10T08:56:00+00:00",
-      "issued": "2010-02-10T09:00:02.000+00:00",
+      "issued": "2010-02-10T08:56:00.000+00:00",
       "performer": [ {
         "reference": "Practitioner/1E473786-E7FA-785E-C911-A8D38FB56F20"
       } ],
@@ -10527,7 +10527,7 @@
         "reference": "Encounter/6ED5590B-146D-4B42-939E-2C35646ED7C1"
       },
       "effectiveDateTime": "2010-02-10T08:56:00+00:00",
-      "issued": "2010-02-10T09:00:02.000+00:00",
+      "issued": "2010-02-10T08:56:00.000+00:00",
       "performer": [ {
         "reference": "Practitioner/1E473786-E7FA-785E-C911-A8D38FB56F20"
       } ],
@@ -10578,7 +10578,7 @@
         "reference": "Encounter/6ED5590B-146D-4B42-939E-2C35646ED7C1"
       },
       "effectiveDateTime": "2010-02-10T08:56:00+00:00",
-      "issued": "2010-02-10T09:00:02.000+00:00",
+      "issued": "2010-02-10T08:56:00.000+00:00",
       "performer": [ {
         "reference": "Practitioner/1E473786-E7FA-785E-C911-A8D38FB56F20"
       } ],
@@ -10626,7 +10626,7 @@
         "reference": "Encounter/6ED5590B-146D-4B42-939E-2C35646ED7C1"
       },
       "effectiveDateTime": "2010-02-10T08:56:00+00:00",
-      "issued": "2010-02-10T09:00:02.000+00:00",
+      "issued": "2010-02-10T08:56:00.000+00:00",
       "performer": [ {
         "reference": "Practitioner/1E473786-E7FA-785E-C911-A8D38FB56F20"
       } ],
@@ -10675,7 +10675,7 @@
         "reference": "Encounter/6ED5590B-146D-4B42-939E-2C35646ED7C1"
       },
       "effectiveDateTime": "2010-02-10T08:56:00+00:00",
-      "issued": "2010-02-10T09:00:02.000+00:00",
+      "issued": "2010-02-10T08:56:00.000+00:00",
       "performer": [ {
         "reference": "Practitioner/1E473786-E7FA-785E-C911-A8D38FB56F20"
       } ],
@@ -10726,7 +10726,7 @@
         "reference": "Encounter/6ED5590B-146D-4B42-939E-2C35646ED7C1"
       },
       "effectiveDateTime": "2010-02-10T08:56:00+00:00",
-      "issued": "2010-02-10T09:00:02.000+00:00",
+      "issued": "2010-02-10T08:56:00.000+00:00",
       "performer": [ {
         "reference": "Practitioner/1E473786-E7FA-785E-C911-A8D38FB56F20"
       } ]
@@ -10772,7 +10772,7 @@
         "reference": "Encounter/6ED5590B-146D-4B42-939E-2C35646ED7C1"
       },
       "effectiveDateTime": "2010-02-10T08:56:00+00:00",
-      "issued": "2010-02-10T09:00:02.000+00:00",
+      "issued": "2010-02-10T08:56:00.000+00:00",
       "performer": [ {
         "reference": "Practitioner/1E473786-E7FA-785E-C911-A8D38FB56F20"
       } ],
@@ -10819,7 +10819,7 @@
         "reference": "Encounter/6ED5590B-146D-4B42-939E-2C35646ED7C1"
       },
       "effectiveDateTime": "2010-02-10T08:56:00+00:00",
-      "issued": "2010-02-10T09:00:02.000+00:00",
+      "issued": "2010-02-10T08:56:00.000+00:00",
       "performer": [ {
         "reference": "Practitioner/1E473786-E7FA-785E-C911-A8D38FB56F20"
       } ],
@@ -10870,7 +10870,7 @@
         "reference": "Encounter/6ED5590B-146D-4B42-939E-2C35646ED7C1"
       },
       "effectiveDateTime": "2010-02-10T08:56:00+00:00",
-      "issued": "2010-02-10T09:00:02.000+00:00",
+      "issued": "2010-02-10T08:56:00.000+00:00",
       "performer": [ {
         "reference": "Practitioner/1E473786-E7FA-785E-C911-A8D38FB56F20"
       } ],
@@ -10918,7 +10918,7 @@
         "reference": "Encounter/6ED5590B-146D-4B42-939E-2C35646ED7C1"
       },
       "effectiveDateTime": "2010-02-10T08:56:00+00:00",
-      "issued": "2010-02-10T09:00:02.000+00:00",
+      "issued": "2010-02-10T08:56:00.000+00:00",
       "performer": [ {
         "reference": "Practitioner/1E473786-E7FA-785E-C911-A8D38FB56F20"
       } ],
@@ -10970,7 +10970,7 @@
         "reference": "Encounter/6ED5590B-146D-4B42-939E-2C35646ED7C1"
       },
       "effectiveDateTime": "2010-02-10T08:56:00+00:00",
-      "issued": "2010-02-10T09:00:02.000+00:00",
+      "issued": "2010-02-10T08:56:00.000+00:00",
       "performer": [ {
         "reference": "Practitioner/1E473786-E7FA-785E-C911-A8D38FB56F20"
       } ],
@@ -11021,7 +11021,7 @@
         "reference": "Encounter/6ED5590B-146D-4B42-939E-2C35646ED7C1"
       },
       "effectiveDateTime": "2010-02-10T08:56:00+00:00",
-      "issued": "2010-02-10T09:00:02.000+00:00",
+      "issued": "2010-02-10T08:56:00.000+00:00",
       "performer": [ {
         "reference": "Practitioner/1E473786-E7FA-785E-C911-A8D38FB56F20"
       } ],
@@ -11072,7 +11072,7 @@
         "reference": "Encounter/6ED5590B-146D-4B42-939E-2C35646ED7C1"
       },
       "effectiveDateTime": "2010-02-10T08:56:00+00:00",
-      "issued": "2010-02-10T09:00:02.000+00:00",
+      "issued": "2010-02-10T08:56:00.000+00:00",
       "performer": [ {
         "reference": "Practitioner/1E473786-E7FA-785E-C911-A8D38FB56F20"
       } ],
@@ -11123,7 +11123,7 @@
         "reference": "Encounter/6ED5590B-146D-4B42-939E-2C35646ED7C1"
       },
       "effectiveDateTime": "2010-02-10T08:56:00+00:00",
-      "issued": "2010-02-10T09:00:02.000+00:00",
+      "issued": "2010-02-10T08:56:00.000+00:00",
       "performer": [ {
         "reference": "Practitioner/1E473786-E7FA-785E-C911-A8D38FB56F20"
       } ],
@@ -11174,7 +11174,7 @@
         "reference": "Encounter/F3CC75D0-299A-4014-AB63-E354AE15AEAA"
       },
       "effectiveDateTime": "2010-03-23T13:37:00+00:00",
-      "issued": "2010-03-23T14:45:53.000+00:00",
+      "issued": "2010-03-23T13:37:00.000+00:00",
       "performer": [ {
         "reference": "Practitioner/1E473786-E7FA-785E-C911-A8D38FB56F20"
       } ],
@@ -11219,7 +11219,7 @@
         "reference": "Patient/00000000-0000-0000-0000-000000000003"
       },
       "effectiveDateTime": "2001-03-30",
-      "issued": "2010-02-09T12:31:51.000+00:00",
+      "issued": "2001-03-30T00:00:00.000+00:00",
       "performer": [ {
         "reference": "Practitioner/C5DEFBF3-0174-BC6F-182C-B777B9C6FF43"
       } ],
@@ -11270,7 +11270,7 @@
         "reference": "Patient/00000000-0000-0000-0000-000000000003"
       },
       "effectiveDateTime": "2001-03-30",
-      "issued": "2010-02-09T12:31:51.000+00:00",
+      "issued": "2001-03-30T00:00:00.000+00:00",
       "performer": [ {
         "reference": "Practitioner/C5DEFBF3-0174-BC6F-182C-B777B9C6FF43"
       } ],
@@ -11324,7 +11324,7 @@
         "reference": "Patient/00000000-0000-0000-0000-000000000003"
       },
       "effectiveDateTime": "2001-03-30",
-      "issued": "2010-02-09T12:31:51.000+00:00",
+      "issued": "2001-03-30T00:00:00.000+00:00",
       "performer": [ {
         "reference": "Practitioner/C5DEFBF3-0174-BC6F-182C-B777B9C6FF43"
       } ],
@@ -11383,7 +11383,7 @@
         "reference": "Patient/00000000-0000-0000-0000-000000000003"
       },
       "effectiveDateTime": "2001-03-30",
-      "issued": "2010-02-09T12:31:51.000+00:00",
+      "issued": "2001-03-30T00:00:00.000+00:00",
       "performer": [ {
         "reference": "Practitioner/C5DEFBF3-0174-BC6F-182C-B777B9C6FF43"
       } ],
@@ -11444,7 +11444,7 @@
         "reference": "Patient/00000000-0000-0000-0000-000000000003"
       },
       "effectiveDateTime": "2001-03-30",
-      "issued": "2010-02-09T12:31:51.000+00:00",
+      "issued": "2001-03-30T00:00:00.000+00:00",
       "performer": [ {
         "reference": "Practitioner/C5DEFBF3-0174-BC6F-182C-B777B9C6FF43"
       } ],
@@ -11505,7 +11505,7 @@
         "reference": "Patient/00000000-0000-0000-0000-000000000003"
       },
       "effectiveDateTime": "2001-03-30",
-      "issued": "2010-02-09T12:31:51.000+00:00",
+      "issued": "2001-03-30T00:00:00.000+00:00",
       "performer": [ {
         "reference": "Practitioner/C5DEFBF3-0174-BC6F-182C-B777B9C6FF43"
       } ],
@@ -11564,7 +11564,7 @@
         "reference": "Patient/00000000-0000-0000-0000-000000000003"
       },
       "effectiveDateTime": "2001-03-30",
-      "issued": "2010-02-09T12:05:16.000+00:00",
+      "issued": "2001-03-30T00:00:00.000+00:00",
       "performer": [ {
         "reference": "Practitioner/C5DEFBF3-0174-BC6F-182C-B777B9C6FF43"
       } ],
@@ -11626,7 +11626,7 @@
         "reference": "Patient/00000000-0000-0000-0000-000000000003"
       },
       "effectiveDateTime": "2001-03-30",
-      "issued": "2010-02-09T12:05:16.000+00:00",
+      "issued": "2001-03-30T00:00:00.000+00:00",
       "performer": [ {
         "reference": "Practitioner/C5DEFBF3-0174-BC6F-182C-B777B9C6FF43"
       } ],
@@ -11688,7 +11688,7 @@
         "reference": "Patient/00000000-0000-0000-0000-000000000003"
       },
       "effectiveDateTime": "2002-03-22",
-      "issued": "2010-06-24T11:30:47.000+00:00",
+      "issued": "2002-03-22T00:00:00.000+00:00",
       "performer": [ {
         "reference": "Practitioner/1E473786-E7FA-785E-C911-A8D38FB56F20"
       } ],
@@ -11729,7 +11729,7 @@
         "reference": "Patient/00000000-0000-0000-0000-000000000003"
       },
       "effectiveDateTime": "2002-03-30",
-      "issued": "2010-06-24T11:52:01.000+00:00",
+      "issued": "2002-03-30T00:00:00.000+00:00",
       "performer": [ {
         "reference": "Practitioner/1E473786-E7FA-785E-C911-A8D38FB56F20"
       } ],
@@ -11788,7 +11788,7 @@
         "reference": "Patient/00000000-0000-0000-0000-000000000003"
       },
       "effectiveDateTime": "2002-03-30",
-      "issued": "2010-06-24T11:52:01.000+00:00",
+      "issued": "2002-03-30T00:00:00.000+00:00",
       "performer": [ {
         "reference": "Practitioner/1E473786-E7FA-785E-C911-A8D38FB56F20"
       } ],
@@ -11855,7 +11855,7 @@
         "reference": "Patient/00000000-0000-0000-0000-000000000003"
       },
       "effectiveDateTime": "2002-03-30",
-      "issued": "2010-06-24T11:52:01.000+00:00",
+      "issued": "2002-03-30T00:00:00.000+00:00",
       "performer": [ {
         "reference": "Practitioner/1E473786-E7FA-785E-C911-A8D38FB56F20"
       } ],
@@ -11917,7 +11917,7 @@
         "reference": "Patient/00000000-0000-0000-0000-000000000003"
       },
       "effectiveDateTime": "2002-03-30",
-      "issued": "2010-06-24T11:52:01.000+00:00",
+      "issued": "2002-03-30T00:00:00.000+00:00",
       "performer": [ {
         "reference": "Practitioner/1E473786-E7FA-785E-C911-A8D38FB56F20"
       } ],
@@ -11984,7 +11984,7 @@
         "reference": "Patient/00000000-0000-0000-0000-000000000003"
       },
       "effectiveDateTime": "2002-03-30",
-      "issued": "2010-06-24T11:52:01.000+00:00",
+      "issued": "2002-03-30T00:00:00.000+00:00",
       "performer": [ {
         "reference": "Practitioner/1E473786-E7FA-785E-C911-A8D38FB56F20"
       } ],
@@ -12051,7 +12051,7 @@
         "reference": "Patient/00000000-0000-0000-0000-000000000003"
       },
       "effectiveDateTime": "2002-03-30",
-      "issued": "2010-06-24T11:52:01.000+00:00",
+      "issued": "2002-03-30T00:00:00.000+00:00",
       "performer": [ {
         "reference": "Practitioner/1E473786-E7FA-785E-C911-A8D38FB56F20"
       } ],
@@ -12118,7 +12118,7 @@
         "reference": "Patient/00000000-0000-0000-0000-000000000003"
       },
       "effectiveDateTime": "2002-03-30",
-      "issued": "2010-06-24T11:52:01.000+00:00",
+      "issued": "2002-03-30T00:00:00.000+00:00",
       "performer": [ {
         "reference": "Practitioner/1E473786-E7FA-785E-C911-A8D38FB56F20"
       } ],
@@ -12180,7 +12180,7 @@
         "reference": "Patient/00000000-0000-0000-0000-000000000003"
       },
       "effectiveDateTime": "2002-03-30",
-      "issued": "2010-06-24T11:52:01.000+00:00",
+      "issued": "2002-03-30T00:00:00.000+00:00",
       "performer": [ {
         "reference": "Practitioner/1E473786-E7FA-785E-C911-A8D38FB56F20"
       } ],
@@ -12242,7 +12242,7 @@
         "reference": "Patient/00000000-0000-0000-0000-000000000003"
       },
       "effectiveDateTime": "2002-03-30",
-      "issued": "2010-06-24T11:52:01.000+00:00",
+      "issued": "2002-03-30T00:00:00.000+00:00",
       "performer": [ {
         "reference": "Practitioner/1E473786-E7FA-785E-C911-A8D38FB56F20"
       } ],
@@ -12304,7 +12304,7 @@
         "reference": "Patient/00000000-0000-0000-0000-000000000003"
       },
       "effectiveDateTime": "2002-03-30",
-      "issued": "2010-06-24T11:52:01.000+00:00",
+      "issued": "2002-03-30T00:00:00.000+00:00",
       "performer": [ {
         "reference": "Practitioner/1E473786-E7FA-785E-C911-A8D38FB56F20"
       } ],
@@ -12366,7 +12366,7 @@
         "reference": "Patient/00000000-0000-0000-0000-000000000003"
       },
       "effectiveDateTime": "2002-03-30",
-      "issued": "2010-06-24T11:52:01.000+00:00",
+      "issued": "2002-03-30T00:00:00.000+00:00",
       "performer": [ {
         "reference": "Practitioner/1E473786-E7FA-785E-C911-A8D38FB56F20"
       } ],
@@ -12428,7 +12428,7 @@
         "reference": "Patient/00000000-0000-0000-0000-000000000003"
       },
       "effectiveDateTime": "2002-03-30",
-      "issued": "2010-06-24T11:52:01.000+00:00",
+      "issued": "2002-03-30T00:00:00.000+00:00",
       "performer": [ {
         "reference": "Practitioner/1E473786-E7FA-785E-C911-A8D38FB56F20"
       } ],
@@ -12491,7 +12491,7 @@
         "reference": "Patient/00000000-0000-0000-0000-000000000003"
       },
       "effectiveDateTime": "2002-03-30",
-      "issued": "2010-06-24T11:52:01.000+00:00",
+      "issued": "2002-03-30T00:00:00.000+00:00",
       "performer": [ {
         "reference": "Practitioner/1E473786-E7FA-785E-C911-A8D38FB56F20"
       } ],
@@ -12553,7 +12553,7 @@
         "reference": "Patient/00000000-0000-0000-0000-000000000003"
       },
       "effectiveDateTime": "2010-03-23",
-      "issued": "2010-03-23T14:29:35.000+00:00",
+      "issued": "2010-03-23T00:00:00.000+00:00",
       "performer": [ {
         "reference": "Practitioner/1E473786-E7FA-785E-C911-A8D38FB56F20"
       } ],
@@ -12608,7 +12608,7 @@
         "reference": "Patient/00000000-0000-0000-0000-000000000003"
       },
       "effectiveDateTime": "2010-03-23",
-      "issued": "2010-03-23T14:29:58.000+00:00",
+      "issued": "2010-03-23T00:00:00.000+00:00",
       "performer": [ {
         "reference": "Practitioner/1E473786-E7FA-785E-C911-A8D38FB56F20"
       } ],
@@ -12665,7 +12665,7 @@
         "reference": "Patient/00000000-0000-0000-0000-000000000003"
       },
       "effectiveDateTime": "2010-03-23",
-      "issued": "2010-03-23T14:33:26.000+00:00",
+      "issued": "2010-03-23T00:00:00.000+00:00",
       "performer": [ {
         "reference": "Practitioner/1E473786-E7FA-785E-C911-A8D38FB56F20"
       } ],
@@ -12719,7 +12719,7 @@
         "reference": "Patient/00000000-0000-0000-0000-000000000003"
       },
       "effectiveDateTime": "2010-03-23",
-      "issued": "2010-03-23T14:33:48.000+00:00",
+      "issued": "2010-03-23T00:00:00.000+00:00",
       "performer": [ {
         "reference": "Practitioner/1E473786-E7FA-785E-C911-A8D38FB56F20"
       } ],
@@ -12782,7 +12782,7 @@
         "reference": "Patient/00000000-0000-0000-0000-000000000003"
       },
       "effectiveDateTime": "2010-03-23",
-      "issued": "2010-03-23T14:34:09.000+00:00",
+      "issued": "2010-03-23T00:00:00.000+00:00",
       "performer": [ {
         "reference": "Practitioner/1E473786-E7FA-785E-C911-A8D38FB56F20"
       } ],
@@ -12836,7 +12836,7 @@
         "reference": "Patient/00000000-0000-0000-0000-000000000003"
       },
       "effectiveDateTime": "2010-03-23",
-      "issued": "2010-03-23T14:37:32.000+00:00",
+      "issued": "2010-03-23T00:00:00.000+00:00",
       "performer": [ {
         "reference": "Practitioner/1E473786-E7FA-785E-C911-A8D38FB56F20"
       } ],
@@ -12890,7 +12890,7 @@
         "reference": "Patient/00000000-0000-0000-0000-000000000003"
       },
       "effectiveDateTime": "2010-03-23",
-      "issued": "2010-03-23T14:37:41.000+00:00",
+      "issued": "2010-03-23T00:00:00.000+00:00",
       "performer": [ {
         "reference": "Practitioner/1E473786-E7FA-785E-C911-A8D38FB56F20"
       } ],
@@ -12944,7 +12944,7 @@
         "reference": "Patient/00000000-0000-0000-0000-000000000003"
       },
       "effectiveDateTime": "2010-03-23",
-      "issued": "2010-03-23T14:38:02.000+00:00",
+      "issued": "2010-03-23T00:00:00.000+00:00",
       "performer": [ {
         "reference": "Practitioner/1E473786-E7FA-785E-C911-A8D38FB56F20"
       } ],

--- a/gp2gp-translator/src/integrationTest/resources/json/LargeMessage/expectedBundleScenario10.json
+++ b/gp2gp-translator/src/integrationTest/resources/json/LargeMessage/expectedBundleScenario10.json
@@ -1554,7 +1554,7 @@
         "reference": "Encounter/C07745C6-ADAC-11E2-883C-B639E5B05B1F"
       },
       "effectiveDateTime": "2000-03-31",
-      "issued": "2017-05-18T08:12:07.000+00:00",
+      "issued": "2000-03-31T00:00:00.000+00:00",
       "performer": [ {
         "reference": "Practitioner/298F8D0B-C3B9-0598-4D0E-3ADB6F7B1DEF"
       } ],
@@ -1598,7 +1598,7 @@
         "reference": "Encounter/C07745C6-ADAC-11E2-883C-B639E5B05B1F"
       },
       "effectiveDateTime": "2000-03-31",
-      "issued": "2017-05-18T08:12:07.000+00:00",
+      "issued": "2000-03-31T00:00:00.000+00:00",
       "performer": [ {
         "reference": "Practitioner/298F8D0B-C3B9-0598-4D0E-3ADB6F7B1DEF"
       } ],
@@ -1645,7 +1645,7 @@
         "reference": "Encounter/C07745C6-ADAC-11E2-883C-B639E5B05B1F"
       },
       "effectiveDateTime": "2000-03-31",
-      "issued": "2017-05-18T08:12:07.000+00:00",
+      "issued": "2000-03-31T00:00:00.000+00:00",
       "performer": [ {
         "reference": "Practitioner/298F8D0B-C3B9-0598-4D0E-3ADB6F7B1DEF"
       } ],
@@ -1692,7 +1692,7 @@
         "reference": "Encounter/C07745C6-ADAC-11E2-883C-B639E5B05B1F"
       },
       "effectiveDateTime": "2000-03-31",
-      "issued": "2017-05-18T08:12:07.000+00:00",
+      "issued": "2000-03-31T00:00:00.000+00:00",
       "performer": [ {
         "reference": "Practitioner/298F8D0B-C3B9-0598-4D0E-3ADB6F7B1DEF"
       } ],
@@ -1736,7 +1736,7 @@
         "reference": "Encounter/C07745C6-ADAC-11E2-883C-B639E5B05B1F"
       },
       "effectiveDateTime": "2000-03-31",
-      "issued": "2017-05-18T08:12:07.000+00:00",
+      "issued": "2000-03-31T00:00:00.000+00:00",
       "performer": [ {
         "reference": "Practitioner/298F8D0B-C3B9-0598-4D0E-3ADB6F7B1DEF"
       } ],
@@ -1780,7 +1780,7 @@
         "reference": "Encounter/C07745C6-ADAC-11E2-883C-B639E5B05B1F"
       },
       "effectiveDateTime": "2000-03-31",
-      "issued": "2017-05-18T08:12:07.000+00:00",
+      "issued": "2000-03-31T00:00:00.000+00:00",
       "performer": [ {
         "reference": "Practitioner/298F8D0B-C3B9-0598-4D0E-3ADB6F7B1DEF"
       } ],
@@ -1824,7 +1824,7 @@
         "reference": "Encounter/C07745C6-ADAC-11E2-883C-B639E5B05B1F"
       },
       "effectiveDateTime": "2000-03-31",
-      "issued": "2017-05-18T08:12:07.000+00:00",
+      "issued": "2000-03-31T00:00:00.000+00:00",
       "performer": [ {
         "reference": "Practitioner/298F8D0B-C3B9-0598-4D0E-3ADB6F7B1DEF"
       } ],
@@ -1868,7 +1868,7 @@
         "reference": "Encounter/C07745C6-ADAC-11E2-883C-B639E5B05B1F"
       },
       "effectiveDateTime": "2000-03-31",
-      "issued": "2017-05-18T08:12:07.000+00:00",
+      "issued": "2000-03-31T00:00:00.000+00:00",
       "performer": [ {
         "reference": "Practitioner/298F8D0B-C3B9-0598-4D0E-3ADB6F7B1DEF"
       } ],
@@ -1912,7 +1912,7 @@
         "reference": "Encounter/C07745C6-ADAC-11E2-883C-B639E5B05B1F"
       },
       "effectiveDateTime": "2000-03-31",
-      "issued": "2017-05-18T08:12:07.000+00:00",
+      "issued": "2000-03-31T00:00:00.000+00:00",
       "performer": [ {
         "reference": "Practitioner/298F8D0B-C3B9-0598-4D0E-3ADB6F7B1DEF"
       } ],
@@ -1956,7 +1956,7 @@
         "reference": "Encounter/C07745C6-ADAC-11E2-883C-B639E5B05B1F"
       },
       "effectiveDateTime": "2000-03-31",
-      "issued": "2017-05-18T08:12:07.000+00:00",
+      "issued": "2000-03-31T00:00:00.000+00:00",
       "performer": [ {
         "reference": "Practitioner/298F8D0B-C3B9-0598-4D0E-3ADB6F7B1DEF"
       } ],
@@ -2000,7 +2000,7 @@
         "reference": "Encounter/C07745C6-ADAC-11E2-883C-B639E5B05B1F"
       },
       "effectiveDateTime": "2000-03-31",
-      "issued": "2017-05-18T08:12:07.000+00:00",
+      "issued": "2000-03-31T00:00:00.000+00:00",
       "performer": [ {
         "reference": "Practitioner/298F8D0B-C3B9-0598-4D0E-3ADB6F7B1DEF"
       } ],
@@ -2044,7 +2044,7 @@
         "reference": "Encounter/C07745C6-ADAC-11E2-883C-B639E5B05B1F"
       },
       "effectiveDateTime": "2000-03-31",
-      "issued": "2017-05-18T08:12:07.000+00:00",
+      "issued": "2000-03-31T00:00:00.000+00:00",
       "performer": [ {
         "reference": "Practitioner/298F8D0B-C3B9-0598-4D0E-3ADB6F7B1DEF"
       } ],
@@ -2088,7 +2088,7 @@
         "reference": "Encounter/C07745C6-ADAC-11E2-883C-B639E5B05B1F"
       },
       "effectiveDateTime": "2000-03-31",
-      "issued": "2017-05-18T08:12:07.000+00:00",
+      "issued": "2000-03-31T00:00:00.000+00:00",
       "performer": [ {
         "reference": "Practitioner/298F8D0B-C3B9-0598-4D0E-3ADB6F7B1DEF"
       } ],
@@ -2132,7 +2132,7 @@
         "reference": "Encounter/C07745C6-ADAC-11E2-883C-B639E5B05B1F"
       },
       "effectiveDateTime": "2000-03-31",
-      "issued": "2017-05-18T08:12:07.000+00:00",
+      "issued": "2000-03-31T00:00:00.000+00:00",
       "performer": [ {
         "reference": "Practitioner/298F8D0B-C3B9-0598-4D0E-3ADB6F7B1DEF"
       } ],
@@ -2179,7 +2179,7 @@
         "reference": "Encounter/C07745C6-ADAC-11E2-883C-B639E5B05B1F"
       },
       "effectiveDateTime": "2000-03-31",
-      "issued": "2017-05-18T08:12:07.000+00:00",
+      "issued": "2000-03-31T00:00:00.000+00:00",
       "performer": [ {
         "reference": "Practitioner/298F8D0B-C3B9-0598-4D0E-3ADB6F7B1DEF"
       } ],
@@ -2226,7 +2226,7 @@
         "reference": "Encounter/C07745C6-ADAC-11E2-883C-B639E5B05B1F"
       },
       "effectiveDateTime": "2000-03-31",
-      "issued": "2017-05-18T08:12:07.000+00:00",
+      "issued": "2000-03-31T00:00:00.000+00:00",
       "performer": [ {
         "reference": "Practitioner/298F8D0B-C3B9-0598-4D0E-3ADB6F7B1DEF"
       } ],
@@ -2270,7 +2270,7 @@
         "reference": "Encounter/C07745C6-ADAC-11E2-883C-B639E5B05B1F"
       },
       "effectiveDateTime": "2000-03-31",
-      "issued": "2017-05-18T08:12:07.000+00:00",
+      "issued": "2000-03-31T00:00:00.000+00:00",
       "performer": [ {
         "reference": "Practitioner/298F8D0B-C3B9-0598-4D0E-3ADB6F7B1DEF"
       } ],
@@ -2314,7 +2314,7 @@
         "reference": "Encounter/C07745C6-ADAC-11E2-883C-B639E5B05B1F"
       },
       "effectiveDateTime": "2000-03-31",
-      "issued": "2017-05-18T08:12:07.000+00:00",
+      "issued": "2000-03-31T00:00:00.000+00:00",
       "performer": [ {
         "reference": "Practitioner/298F8D0B-C3B9-0598-4D0E-3ADB6F7B1DEF"
       } ],
@@ -2358,7 +2358,7 @@
         "reference": "Encounter/C07745C6-ADAC-11E2-883C-B639E5B05B1F"
       },
       "effectiveDateTime": "2000-03-31",
-      "issued": "2017-05-18T08:12:07.000+00:00",
+      "issued": "2000-03-31T00:00:00.000+00:00",
       "performer": [ {
         "reference": "Practitioner/298F8D0B-C3B9-0598-4D0E-3ADB6F7B1DEF"
       } ],
@@ -2402,7 +2402,7 @@
         "reference": "Encounter/C07745C6-ADAC-11E2-883C-B639E5B05B1F"
       },
       "effectiveDateTime": "2000-03-31",
-      "issued": "2017-05-18T08:12:07.000+00:00",
+      "issued": "2000-03-31T00:00:00.000+00:00",
       "performer": [ {
         "reference": "Practitioner/298F8D0B-C3B9-0598-4D0E-3ADB6F7B1DEF"
       } ],
@@ -2449,7 +2449,7 @@
         "reference": "Encounter/C07745C6-ADAC-11E2-883C-B639E5B05B1F"
       },
       "effectiveDateTime": "2000-03-31",
-      "issued": "2017-05-18T08:12:07.000+00:00",
+      "issued": "2000-03-31T00:00:00.000+00:00",
       "performer": [ {
         "reference": "Practitioner/298F8D0B-C3B9-0598-4D0E-3ADB6F7B1DEF"
       } ],
@@ -2496,7 +2496,7 @@
         "reference": "Encounter/C07745C6-ADAC-11E2-883C-B639E5B05B1F"
       },
       "effectiveDateTime": "2000-03-31",
-      "issued": "2017-05-18T08:12:07.000+00:00",
+      "issued": "2000-03-31T00:00:00.000+00:00",
       "performer": [ {
         "reference": "Practitioner/298F8D0B-C3B9-0598-4D0E-3ADB6F7B1DEF"
       } ],
@@ -2540,7 +2540,7 @@
         "reference": "Encounter/C07745C6-ADAC-11E2-883C-B639E5B05B1F"
       },
       "effectiveDateTime": "2000-03-31",
-      "issued": "2017-05-18T08:12:07.000+00:00",
+      "issued": "2000-03-31T00:00:00.000+00:00",
       "performer": [ {
         "reference": "Practitioner/298F8D0B-C3B9-0598-4D0E-3ADB6F7B1DEF"
       } ],
@@ -2584,7 +2584,7 @@
         "reference": "Encounter/C07745C6-ADAC-11E2-883C-B639E5B05B1F"
       },
       "effectiveDateTime": "2000-03-31",
-      "issued": "2017-05-18T08:12:07.000+00:00",
+      "issued": "2000-03-31T00:00:00.000+00:00",
       "performer": [ {
         "reference": "Practitioner/298F8D0B-C3B9-0598-4D0E-3ADB6F7B1DEF"
       } ],
@@ -2628,7 +2628,7 @@
         "reference": "Encounter/C07745C6-ADAC-11E2-883C-B639E5B05B1F"
       },
       "effectiveDateTime": "2000-03-31",
-      "issued": "2017-05-18T08:12:07.000+00:00",
+      "issued": "2000-03-31T00:00:00.000+00:00",
       "performer": [ {
         "reference": "Practitioner/298F8D0B-C3B9-0598-4D0E-3ADB6F7B1DEF"
       } ],
@@ -2672,7 +2672,7 @@
         "reference": "Encounter/C07745C6-ADAC-11E2-883C-B639E5B05B1F"
       },
       "effectiveDateTime": "2000-03-31",
-      "issued": "2017-05-18T08:12:07.000+00:00",
+      "issued": "2000-03-31T00:00:00.000+00:00",
       "performer": [ {
         "reference": "Practitioner/298F8D0B-C3B9-0598-4D0E-3ADB6F7B1DEF"
       } ],
@@ -2716,7 +2716,7 @@
         "reference": "Encounter/C07745C6-ADAC-11E2-883C-B639E5B05B1F"
       },
       "effectiveDateTime": "2000-03-31",
-      "issued": "2017-05-18T08:12:07.000+00:00",
+      "issued": "2000-03-31T00:00:00.000+00:00",
       "performer": [ {
         "reference": "Practitioner/298F8D0B-C3B9-0598-4D0E-3ADB6F7B1DEF"
       } ],
@@ -2760,7 +2760,7 @@
         "reference": "Encounter/C07745C6-ADAC-11E2-883C-B639E5B05B1F"
       },
       "effectiveDateTime": "2000-03-31",
-      "issued": "2017-05-18T08:12:07.000+00:00",
+      "issued": "2000-03-31T00:00:00.000+00:00",
       "performer": [ {
         "reference": "Practitioner/298F8D0B-C3B9-0598-4D0E-3ADB6F7B1DEF"
       } ],
@@ -2807,7 +2807,7 @@
         "reference": "Encounter/C07745C6-ADAC-11E2-883C-B639E5B05B1F"
       },
       "effectiveDateTime": "2000-03-31",
-      "issued": "2017-05-18T08:12:07.000+00:00",
+      "issued": "2000-03-31T00:00:00.000+00:00",
       "performer": [ {
         "reference": "Practitioner/298F8D0B-C3B9-0598-4D0E-3ADB6F7B1DEF"
       } ],
@@ -2854,7 +2854,7 @@
         "reference": "Encounter/C07745C6-ADAC-11E2-883C-B639E5B05B1F"
       },
       "effectiveDateTime": "2000-03-31",
-      "issued": "2017-05-18T08:12:07.000+00:00",
+      "issued": "2000-03-31T00:00:00.000+00:00",
       "performer": [ {
         "reference": "Practitioner/298F8D0B-C3B9-0598-4D0E-3ADB6F7B1DEF"
       } ],
@@ -2898,7 +2898,7 @@
         "reference": "Encounter/C07745C6-ADAC-11E2-883C-B639E5B05B1F"
       },
       "effectiveDateTime": "2000-03-31",
-      "issued": "2017-05-18T08:12:07.000+00:00",
+      "issued": "2000-03-31T00:00:00.000+00:00",
       "performer": [ {
         "reference": "Practitioner/298F8D0B-C3B9-0598-4D0E-3ADB6F7B1DEF"
       } ],
@@ -2942,7 +2942,7 @@
         "reference": "Encounter/C07745C6-ADAC-11E2-883C-B639E5B05B1F"
       },
       "effectiveDateTime": "2000-03-31",
-      "issued": "2017-05-18T08:12:07.000+00:00",
+      "issued": "2000-03-31T00:00:00.000+00:00",
       "performer": [ {
         "reference": "Practitioner/298F8D0B-C3B9-0598-4D0E-3ADB6F7B1DEF"
       } ],
@@ -2986,7 +2986,7 @@
         "reference": "Encounter/C07745C6-ADAC-11E2-883C-B639E5B05B1F"
       },
       "effectiveDateTime": "2000-03-31",
-      "issued": "2017-05-18T08:12:07.000+00:00",
+      "issued": "2000-03-31T00:00:00.000+00:00",
       "performer": [ {
         "reference": "Practitioner/298F8D0B-C3B9-0598-4D0E-3ADB6F7B1DEF"
       } ],
@@ -3030,7 +3030,7 @@
         "reference": "Encounter/C07745C6-ADAC-11E2-883C-B639E5B05B1F"
       },
       "effectiveDateTime": "2000-03-31",
-      "issued": "2017-05-18T08:12:07.000+00:00",
+      "issued": "2000-03-31T00:00:00.000+00:00",
       "performer": [ {
         "reference": "Practitioner/298F8D0B-C3B9-0598-4D0E-3ADB6F7B1DEF"
       } ],
@@ -3074,7 +3074,7 @@
         "reference": "Encounter/C07745C6-ADAC-11E2-883C-B639E5B05B1F"
       },
       "effectiveDateTime": "2000-03-31",
-      "issued": "2017-05-18T08:12:07.000+00:00",
+      "issued": "2000-03-31T00:00:00.000+00:00",
       "performer": [ {
         "reference": "Practitioner/298F8D0B-C3B9-0598-4D0E-3ADB6F7B1DEF"
       } ],
@@ -3118,7 +3118,7 @@
         "reference": "Encounter/C07745C6-ADAC-11E2-883C-B639E5B05B1F"
       },
       "effectiveDateTime": "2000-03-31",
-      "issued": "2017-05-18T08:12:07.000+00:00",
+      "issued": "2000-03-31T00:00:00.000+00:00",
       "performer": [ {
         "reference": "Practitioner/298F8D0B-C3B9-0598-4D0E-3ADB6F7B1DEF"
       } ],
@@ -3162,7 +3162,7 @@
         "reference": "Encounter/C07745C6-ADAC-11E2-883C-B639E5B05B1F"
       },
       "effectiveDateTime": "2000-03-31",
-      "issued": "2017-05-18T08:12:07.000+00:00",
+      "issued": "2000-03-31T00:00:00.000+00:00",
       "performer": [ {
         "reference": "Practitioner/298F8D0B-C3B9-0598-4D0E-3ADB6F7B1DEF"
       } ],
@@ -3209,7 +3209,7 @@
         "reference": "Encounter/C07745C6-ADAC-11E2-883C-B639E5B05B1F"
       },
       "effectiveDateTime": "2000-03-31",
-      "issued": "2017-05-18T08:12:07.000+00:00",
+      "issued": "2000-03-31T00:00:00.000+00:00",
       "performer": [ {
         "reference": "Practitioner/298F8D0B-C3B9-0598-4D0E-3ADB6F7B1DEF"
       } ],
@@ -3256,7 +3256,7 @@
         "reference": "Encounter/C07745C6-ADAC-11E2-883C-B639E5B05B1F"
       },
       "effectiveDateTime": "2000-03-31",
-      "issued": "2017-05-18T08:12:07.000+00:00",
+      "issued": "2000-03-31T00:00:00.000+00:00",
       "performer": [ {
         "reference": "Practitioner/298F8D0B-C3B9-0598-4D0E-3ADB6F7B1DEF"
       } ],
@@ -3303,7 +3303,7 @@
         "reference": "Encounter/C07745C6-ADAC-11E2-883C-B639E5B05B1F"
       },
       "effectiveDateTime": "2000-03-31",
-      "issued": "2017-05-18T08:12:07.000+00:00",
+      "issued": "2000-03-31T00:00:00.000+00:00",
       "performer": [ {
         "reference": "Practitioner/298F8D0B-C3B9-0598-4D0E-3ADB6F7B1DEF"
       } ],
@@ -3350,7 +3350,7 @@
         "reference": "Encounter/C07745C6-ADAC-11E2-883C-B639E5B05B1F"
       },
       "effectiveDateTime": "2000-03-31",
-      "issued": "2017-05-18T08:12:07.000+00:00",
+      "issued": "2000-03-31T00:00:00.000+00:00",
       "performer": [ {
         "reference": "Practitioner/298F8D0B-C3B9-0598-4D0E-3ADB6F7B1DEF"
       } ],
@@ -3397,7 +3397,7 @@
         "reference": "Encounter/C07745C6-ADAC-11E2-883C-B639E5B05B1F"
       },
       "effectiveDateTime": "2000-03-31",
-      "issued": "2017-05-18T08:12:07.000+00:00",
+      "issued": "2000-03-31T00:00:00.000+00:00",
       "performer": [ {
         "reference": "Practitioner/298F8D0B-C3B9-0598-4D0E-3ADB6F7B1DEF"
       } ],
@@ -3441,7 +3441,7 @@
         "reference": "Encounter/C07745C6-ADAC-11E2-883C-B639E5B05B1F"
       },
       "effectiveDateTime": "2000-03-31",
-      "issued": "2017-05-18T08:12:07.000+00:00",
+      "issued": "2000-03-31T00:00:00.000+00:00",
       "performer": [ {
         "reference": "Practitioner/298F8D0B-C3B9-0598-4D0E-3ADB6F7B1DEF"
       } ],
@@ -3485,7 +3485,7 @@
         "reference": "Encounter/C07745C6-ADAC-11E2-883C-B639E5B05B1F"
       },
       "effectiveDateTime": "2000-03-31",
-      "issued": "2017-05-18T08:12:07.000+00:00",
+      "issued": "2000-03-31T00:00:00.000+00:00",
       "performer": [ {
         "reference": "Practitioner/298F8D0B-C3B9-0598-4D0E-3ADB6F7B1DEF"
       } ],
@@ -3532,7 +3532,7 @@
         "reference": "Encounter/C07745C6-ADAC-11E2-883C-B639E5B05B1F"
       },
       "effectiveDateTime": "2000-03-31",
-      "issued": "2017-05-18T08:12:07.000+00:00",
+      "issued": "2000-03-31T00:00:00.000+00:00",
       "performer": [ {
         "reference": "Practitioner/298F8D0B-C3B9-0598-4D0E-3ADB6F7B1DEF"
       } ],
@@ -3576,7 +3576,7 @@
         "reference": "Encounter/C07745C6-ADAC-11E2-883C-B639E5B05B1F"
       },
       "effectiveDateTime": "2000-03-31",
-      "issued": "2017-05-18T08:12:07.000+00:00",
+      "issued": "2000-03-31T00:00:00.000+00:00",
       "performer": [ {
         "reference": "Practitioner/298F8D0B-C3B9-0598-4D0E-3ADB6F7B1DEF"
       } ],
@@ -3620,7 +3620,7 @@
         "reference": "Encounter/C07745C6-ADAC-11E2-883C-B639E5B05B1F"
       },
       "effectiveDateTime": "2000-03-31",
-      "issued": "2017-05-18T08:12:07.000+00:00",
+      "issued": "2000-03-31T00:00:00.000+00:00",
       "performer": [ {
         "reference": "Practitioner/298F8D0B-C3B9-0598-4D0E-3ADB6F7B1DEF"
       } ],
@@ -3664,7 +3664,7 @@
         "reference": "Encounter/C07745C6-ADAC-11E2-883C-B639E5B05B1F"
       },
       "effectiveDateTime": "2000-03-31",
-      "issued": "2017-05-18T08:12:07.000+00:00",
+      "issued": "2000-03-31T00:00:00.000+00:00",
       "performer": [ {
         "reference": "Practitioner/298F8D0B-C3B9-0598-4D0E-3ADB6F7B1DEF"
       } ],
@@ -3708,7 +3708,7 @@
         "reference": "Encounter/C07745C6-ADAC-11E2-883C-B639E5B05B1F"
       },
       "effectiveDateTime": "2000-03-31",
-      "issued": "2017-05-18T08:12:07.000+00:00",
+      "issued": "2000-03-31T00:00:00.000+00:00",
       "performer": [ {
         "reference": "Practitioner/298F8D0B-C3B9-0598-4D0E-3ADB6F7B1DEF"
       } ],
@@ -3755,7 +3755,7 @@
         "reference": "Encounter/C07745C6-ADAC-11E2-883C-B639E5B05B1F"
       },
       "effectiveDateTime": "2000-03-31",
-      "issued": "2017-05-18T08:12:07.000+00:00",
+      "issued": "2000-03-31T00:00:00.000+00:00",
       "performer": [ {
         "reference": "Practitioner/298F8D0B-C3B9-0598-4D0E-3ADB6F7B1DEF"
       } ],
@@ -3802,7 +3802,7 @@
         "reference": "Encounter/C07745C6-ADAC-11E2-883C-B639E5B05B1F"
       },
       "effectiveDateTime": "2000-03-31",
-      "issued": "2017-05-18T08:12:07.000+00:00",
+      "issued": "2000-03-31T00:00:00.000+00:00",
       "performer": [ {
         "reference": "Practitioner/298F8D0B-C3B9-0598-4D0E-3ADB6F7B1DEF"
       } ],
@@ -3849,7 +3849,7 @@
         "reference": "Encounter/C07745C6-ADAC-11E2-883C-B639E5B05B1F"
       },
       "effectiveDateTime": "2000-03-31",
-      "issued": "2017-05-18T08:12:07.000+00:00",
+      "issued": "2000-03-31T00:00:00.000+00:00",
       "performer": [ {
         "reference": "Practitioner/298F8D0B-C3B9-0598-4D0E-3ADB6F7B1DEF"
       } ],
@@ -3896,7 +3896,7 @@
         "reference": "Encounter/C07745C6-ADAC-11E2-883C-B639E5B05B1F"
       },
       "effectiveDateTime": "2000-03-31",
-      "issued": "2017-05-18T08:12:07.000+00:00",
+      "issued": "2000-03-31T00:00:00.000+00:00",
       "performer": [ {
         "reference": "Practitioner/298F8D0B-C3B9-0598-4D0E-3ADB6F7B1DEF"
       } ],
@@ -3943,7 +3943,7 @@
         "reference": "Encounter/C07745C6-ADAC-11E2-883C-B639E5B05B1F"
       },
       "effectiveDateTime": "2000-03-31",
-      "issued": "2017-05-18T08:12:07.000+00:00",
+      "issued": "2000-03-31T00:00:00.000+00:00",
       "performer": [ {
         "reference": "Practitioner/298F8D0B-C3B9-0598-4D0E-3ADB6F7B1DEF"
       } ],
@@ -3990,7 +3990,7 @@
         "reference": "Encounter/C07745C6-ADAC-11E2-883C-B639E5B05B1F"
       },
       "effectiveDateTime": "2000-03-31",
-      "issued": "2017-05-18T08:12:07.000+00:00",
+      "issued": "2000-03-31T00:00:00.000+00:00",
       "performer": [ {
         "reference": "Practitioner/298F8D0B-C3B9-0598-4D0E-3ADB6F7B1DEF"
       } ],
@@ -4037,7 +4037,7 @@
         "reference": "Encounter/C07745C6-ADAC-11E2-883C-B639E5B05B1F"
       },
       "effectiveDateTime": "2000-03-31",
-      "issued": "2017-05-18T08:12:07.000+00:00",
+      "issued": "2000-03-31T00:00:00.000+00:00",
       "performer": [ {
         "reference": "Practitioner/298F8D0B-C3B9-0598-4D0E-3ADB6F7B1DEF"
       } ],
@@ -4084,7 +4084,7 @@
         "reference": "Encounter/C07745C6-ADAC-11E2-883C-B639E5B05B1F"
       },
       "effectiveDateTime": "2000-03-31",
-      "issued": "2017-05-18T08:12:07.000+00:00",
+      "issued": "2000-03-31T00:00:00.000+00:00",
       "performer": [ {
         "reference": "Practitioner/298F8D0B-C3B9-0598-4D0E-3ADB6F7B1DEF"
       } ],
@@ -4131,7 +4131,7 @@
         "reference": "Encounter/C07745C6-ADAC-11E2-883C-B639E5B05B1F"
       },
       "effectiveDateTime": "2000-03-31",
-      "issued": "2017-05-18T08:12:07.000+00:00",
+      "issued": "2000-03-31T00:00:00.000+00:00",
       "performer": [ {
         "reference": "Practitioner/298F8D0B-C3B9-0598-4D0E-3ADB6F7B1DEF"
       } ],
@@ -4175,7 +4175,7 @@
         "reference": "Encounter/C07745C6-ADAC-11E2-883C-B639E5B05B1F"
       },
       "effectiveDateTime": "2000-03-31",
-      "issued": "2017-05-18T08:12:07.000+00:00",
+      "issued": "2000-03-31T00:00:00.000+00:00",
       "performer": [ {
         "reference": "Practitioner/298F8D0B-C3B9-0598-4D0E-3ADB6F7B1DEF"
       } ],
@@ -4219,7 +4219,7 @@
         "reference": "Encounter/C07745C6-ADAC-11E2-883C-B639E5B05B1F"
       },
       "effectiveDateTime": "2000-03-31",
-      "issued": "2017-05-18T08:12:07.000+00:00",
+      "issued": "2000-03-31T00:00:00.000+00:00",
       "performer": [ {
         "reference": "Practitioner/298F8D0B-C3B9-0598-4D0E-3ADB6F7B1DEF"
       } ],
@@ -4266,7 +4266,7 @@
         "reference": "Encounter/C07745C6-ADAC-11E2-883C-B639E5B05B1F"
       },
       "effectiveDateTime": "2000-03-31",
-      "issued": "2017-05-18T08:12:07.000+00:00",
+      "issued": "2000-03-31T00:00:00.000+00:00",
       "performer": [ {
         "reference": "Practitioner/298F8D0B-C3B9-0598-4D0E-3ADB6F7B1DEF"
       } ],
@@ -4313,7 +4313,7 @@
         "reference": "Encounter/C07745C6-ADAC-11E2-883C-B639E5B05B1F"
       },
       "effectiveDateTime": "2000-03-31",
-      "issued": "2017-05-18T08:12:07.000+00:00",
+      "issued": "2000-03-31T00:00:00.000+00:00",
       "performer": [ {
         "reference": "Practitioner/298F8D0B-C3B9-0598-4D0E-3ADB6F7B1DEF"
       } ],
@@ -4360,7 +4360,7 @@
         "reference": "Encounter/C07745C6-ADAC-11E2-883C-B639E5B05B1F"
       },
       "effectiveDateTime": "2000-03-31",
-      "issued": "2017-05-18T08:12:07.000+00:00",
+      "issued": "2000-03-31T00:00:00.000+00:00",
       "performer": [ {
         "reference": "Practitioner/298F8D0B-C3B9-0598-4D0E-3ADB6F7B1DEF"
       } ],
@@ -4404,7 +4404,7 @@
         "reference": "Encounter/C07745C6-ADAC-11E2-883C-B639E5B05B1F"
       },
       "effectiveDateTime": "2000-03-31",
-      "issued": "2017-05-18T08:12:07.000+00:00",
+      "issued": "2000-03-31T00:00:00.000+00:00",
       "performer": [ {
         "reference": "Practitioner/298F8D0B-C3B9-0598-4D0E-3ADB6F7B1DEF"
       } ],
@@ -4448,7 +4448,7 @@
         "reference": "Encounter/C07745C6-ADAC-11E2-883C-B639E5B05B1F"
       },
       "effectiveDateTime": "2000-03-31",
-      "issued": "2017-05-18T08:12:07.000+00:00",
+      "issued": "2000-03-31T00:00:00.000+00:00",
       "performer": [ {
         "reference": "Practitioner/298F8D0B-C3B9-0598-4D0E-3ADB6F7B1DEF"
       } ],
@@ -4492,7 +4492,7 @@
         "reference": "Encounter/C07745C6-ADAC-11E2-883C-B639E5B05B1F"
       },
       "effectiveDateTime": "2000-03-31",
-      "issued": "2017-05-18T08:12:07.000+00:00",
+      "issued": "2000-03-31T00:00:00.000+00:00",
       "performer": [ {
         "reference": "Practitioner/298F8D0B-C3B9-0598-4D0E-3ADB6F7B1DEF"
       } ],
@@ -4536,7 +4536,7 @@
         "reference": "Encounter/C07745C6-ADAC-11E2-883C-B639E5B05B1F"
       },
       "effectiveDateTime": "2000-03-31",
-      "issued": "2017-05-18T08:12:07.000+00:00",
+      "issued": "2000-03-31T00:00:00.000+00:00",
       "performer": [ {
         "reference": "Practitioner/298F8D0B-C3B9-0598-4D0E-3ADB6F7B1DEF"
       } ],
@@ -4583,7 +4583,7 @@
         "reference": "Encounter/C07745C6-ADAC-11E2-883C-B639E5B05B1F"
       },
       "effectiveDateTime": "2000-03-31",
-      "issued": "2017-05-18T08:12:07.000+00:00",
+      "issued": "2000-03-31T00:00:00.000+00:00",
       "performer": [ {
         "reference": "Practitioner/298F8D0B-C3B9-0598-4D0E-3ADB6F7B1DEF"
       } ],
@@ -4627,7 +4627,7 @@
         "reference": "Encounter/C07745C6-ADAC-11E2-883C-B639E5B05B1F"
       },
       "effectiveDateTime": "2000-03-31",
-      "issued": "2017-05-18T08:12:07.000+00:00",
+      "issued": "2000-03-31T00:00:00.000+00:00",
       "performer": [ {
         "reference": "Practitioner/298F8D0B-C3B9-0598-4D0E-3ADB6F7B1DEF"
       } ],
@@ -4671,7 +4671,7 @@
         "reference": "Encounter/C07745C6-ADAC-11E2-883C-B639E5B05B1F"
       },
       "effectiveDateTime": "2000-03-31",
-      "issued": "2017-05-18T08:12:07.000+00:00",
+      "issued": "2000-03-31T00:00:00.000+00:00",
       "performer": [ {
         "reference": "Practitioner/298F8D0B-C3B9-0598-4D0E-3ADB6F7B1DEF"
       } ],
@@ -4715,7 +4715,7 @@
         "reference": "Encounter/C07745C6-ADAC-11E2-883C-B639E5B05B1F"
       },
       "effectiveDateTime": "2000-03-31",
-      "issued": "2017-05-18T08:12:07.000+00:00",
+      "issued": "2000-03-31T00:00:00.000+00:00",
       "performer": [ {
         "reference": "Practitioner/298F8D0B-C3B9-0598-4D0E-3ADB6F7B1DEF"
       } ],
@@ -4759,7 +4759,7 @@
         "reference": "Encounter/C07745C6-ADAC-11E2-883C-B639E5B05B1F"
       },
       "effectiveDateTime": "2000-03-31",
-      "issued": "2017-05-18T08:12:07.000+00:00",
+      "issued": "2000-03-31T00:00:00.000+00:00",
       "performer": [ {
         "reference": "Practitioner/298F8D0B-C3B9-0598-4D0E-3ADB6F7B1DEF"
       } ],
@@ -4803,7 +4803,7 @@
         "reference": "Encounter/C07745C6-ADAC-11E2-883C-B639E5B05B1F"
       },
       "effectiveDateTime": "2000-03-31",
-      "issued": "2017-05-18T08:12:07.000+00:00",
+      "issued": "2000-03-31T00:00:00.000+00:00",
       "performer": [ {
         "reference": "Practitioner/298F8D0B-C3B9-0598-4D0E-3ADB6F7B1DEF"
       } ],
@@ -4847,7 +4847,7 @@
         "reference": "Encounter/C07745C6-ADAC-11E2-883C-B639E5B05B1F"
       },
       "effectiveDateTime": "2000-03-31",
-      "issued": "2017-05-18T08:12:07.000+00:00",
+      "issued": "2000-03-31T00:00:00.000+00:00",
       "performer": [ {
         "reference": "Practitioner/298F8D0B-C3B9-0598-4D0E-3ADB6F7B1DEF"
       } ],
@@ -4891,7 +4891,7 @@
         "reference": "Encounter/C07745C6-ADAC-11E2-883C-B639E5B05B1F"
       },
       "effectiveDateTime": "2000-03-31",
-      "issued": "2017-05-18T08:12:07.000+00:00",
+      "issued": "2000-03-31T00:00:00.000+00:00",
       "performer": [ {
         "reference": "Practitioner/298F8D0B-C3B9-0598-4D0E-3ADB6F7B1DEF"
       } ],
@@ -4935,7 +4935,7 @@
         "reference": "Encounter/C07745C6-ADAC-11E2-883C-B639E5B05B1F"
       },
       "effectiveDateTime": "2000-03-31",
-      "issued": "2017-05-18T08:12:07.000+00:00",
+      "issued": "2000-03-31T00:00:00.000+00:00",
       "performer": [ {
         "reference": "Practitioner/298F8D0B-C3B9-0598-4D0E-3ADB6F7B1DEF"
       } ],
@@ -4979,7 +4979,7 @@
         "reference": "Encounter/C07745C6-ADAC-11E2-883C-B639E5B05B1F"
       },
       "effectiveDateTime": "2000-03-31",
-      "issued": "2017-05-18T08:12:07.000+00:00",
+      "issued": "2000-03-31T00:00:00.000+00:00",
       "performer": [ {
         "reference": "Practitioner/298F8D0B-C3B9-0598-4D0E-3ADB6F7B1DEF"
       } ],
@@ -5023,7 +5023,7 @@
         "reference": "Encounter/C07745C6-ADAC-11E2-883C-B639E5B05B1F"
       },
       "effectiveDateTime": "2000-03-31",
-      "issued": "2017-05-18T08:12:07.000+00:00",
+      "issued": "2000-03-31T00:00:00.000+00:00",
       "performer": [ {
         "reference": "Practitioner/298F8D0B-C3B9-0598-4D0E-3ADB6F7B1DEF"
       } ],
@@ -5067,7 +5067,7 @@
         "reference": "Encounter/C07745C6-ADAC-11E2-883C-B639E5B05B1F"
       },
       "effectiveDateTime": "2000-03-31",
-      "issued": "2017-05-18T08:12:07.000+00:00",
+      "issued": "2000-03-31T00:00:00.000+00:00",
       "performer": [ {
         "reference": "Practitioner/298F8D0B-C3B9-0598-4D0E-3ADB6F7B1DEF"
       } ],
@@ -5111,7 +5111,7 @@
         "reference": "Encounter/C07745C6-ADAC-11E2-883C-B639E5B05B1F"
       },
       "effectiveDateTime": "2000-03-31",
-      "issued": "2017-05-18T08:12:07.000+00:00",
+      "issued": "2000-03-31T00:00:00.000+00:00",
       "performer": [ {
         "reference": "Practitioner/298F8D0B-C3B9-0598-4D0E-3ADB6F7B1DEF"
       } ],
@@ -5155,7 +5155,7 @@
         "reference": "Encounter/C07745C6-ADAC-11E2-883C-B639E5B05B1F"
       },
       "effectiveDateTime": "2000-03-31",
-      "issued": "2017-05-18T08:12:07.000+00:00",
+      "issued": "2000-03-31T00:00:00.000+00:00",
       "performer": [ {
         "reference": "Practitioner/298F8D0B-C3B9-0598-4D0E-3ADB6F7B1DEF"
       } ],
@@ -5199,7 +5199,7 @@
         "reference": "Encounter/C07745C6-ADAC-11E2-883C-B639E5B05B1F"
       },
       "effectiveDateTime": "2000-03-31",
-      "issued": "2017-05-18T08:12:07.000+00:00",
+      "issued": "2000-03-31T00:00:00.000+00:00",
       "performer": [ {
         "reference": "Practitioner/298F8D0B-C3B9-0598-4D0E-3ADB6F7B1DEF"
       } ],
@@ -5243,7 +5243,7 @@
         "reference": "Encounter/C07745C6-ADAC-11E2-883C-B639E5B05B1F"
       },
       "effectiveDateTime": "2000-03-31",
-      "issued": "2017-05-18T08:12:07.000+00:00",
+      "issued": "2000-03-31T00:00:00.000+00:00",
       "performer": [ {
         "reference": "Practitioner/298F8D0B-C3B9-0598-4D0E-3ADB6F7B1DEF"
       } ],
@@ -5287,7 +5287,7 @@
         "reference": "Encounter/C07745C6-ADAC-11E2-883C-B639E5B05B1F"
       },
       "effectiveDateTime": "2000-03-31",
-      "issued": "2017-05-18T08:12:07.000+00:00",
+      "issued": "2000-03-31T00:00:00.000+00:00",
       "performer": [ {
         "reference": "Practitioner/298F8D0B-C3B9-0598-4D0E-3ADB6F7B1DEF"
       } ],
@@ -5334,7 +5334,7 @@
         "reference": "Encounter/C07745C6-ADAC-11E2-883C-B639E5B05B1F"
       },
       "effectiveDateTime": "2000-03-31",
-      "issued": "2017-05-18T08:12:07.000+00:00",
+      "issued": "2000-03-31T00:00:00.000+00:00",
       "performer": [ {
         "reference": "Practitioner/298F8D0B-C3B9-0598-4D0E-3ADB6F7B1DEF"
       } ],
@@ -5378,7 +5378,7 @@
         "reference": "Encounter/C07745C6-ADAC-11E2-883C-B639E5B05B1F"
       },
       "effectiveDateTime": "2000-03-31",
-      "issued": "2017-05-18T08:12:07.000+00:00",
+      "issued": "2000-03-31T00:00:00.000+00:00",
       "performer": [ {
         "reference": "Practitioner/298F8D0B-C3B9-0598-4D0E-3ADB6F7B1DEF"
       } ],
@@ -5425,7 +5425,7 @@
         "reference": "Encounter/C07745C6-ADAC-11E2-883C-B639E5B05B1F"
       },
       "effectiveDateTime": "2000-03-31",
-      "issued": "2017-05-18T08:12:07.000+00:00",
+      "issued": "2000-03-31T00:00:00.000+00:00",
       "performer": [ {
         "reference": "Practitioner/298F8D0B-C3B9-0598-4D0E-3ADB6F7B1DEF"
       } ],
@@ -5472,7 +5472,7 @@
         "reference": "Encounter/C07745C6-ADAC-11E2-883C-B639E5B05B1F"
       },
       "effectiveDateTime": "2000-03-31",
-      "issued": "2017-05-18T08:12:07.000+00:00",
+      "issued": "2000-03-31T00:00:00.000+00:00",
       "performer": [ {
         "reference": "Practitioner/298F8D0B-C3B9-0598-4D0E-3ADB6F7B1DEF"
       } ],
@@ -5519,7 +5519,7 @@
         "reference": "Encounter/C07745C6-ADAC-11E2-883C-B639E5B05B1F"
       },
       "effectiveDateTime": "2000-03-31",
-      "issued": "2017-05-18T08:12:07.000+00:00",
+      "issued": "2000-03-31T00:00:00.000+00:00",
       "performer": [ {
         "reference": "Practitioner/298F8D0B-C3B9-0598-4D0E-3ADB6F7B1DEF"
       } ],
@@ -5563,7 +5563,7 @@
         "reference": "Encounter/C07745C6-ADAC-11E2-883C-B639E5B05B1F"
       },
       "effectiveDateTime": "2000-03-31",
-      "issued": "2017-05-18T08:12:07.000+00:00",
+      "issued": "2000-03-31T00:00:00.000+00:00",
       "performer": [ {
         "reference": "Practitioner/298F8D0B-C3B9-0598-4D0E-3ADB6F7B1DEF"
       } ],
@@ -5607,7 +5607,7 @@
         "reference": "Encounter/C07745C6-ADAC-11E2-883C-B639E5B05B1F"
       },
       "effectiveDateTime": "2000-03-31",
-      "issued": "2017-05-18T08:12:07.000+00:00",
+      "issued": "2000-03-31T00:00:00.000+00:00",
       "performer": [ {
         "reference": "Practitioner/298F8D0B-C3B9-0598-4D0E-3ADB6F7B1DEF"
       } ],
@@ -5651,7 +5651,7 @@
         "reference": "Encounter/C07745C6-ADAC-11E2-883C-B639E5B05B1F"
       },
       "effectiveDateTime": "2000-03-31",
-      "issued": "2017-05-18T08:12:07.000+00:00",
+      "issued": "2000-03-31T00:00:00.000+00:00",
       "performer": [ {
         "reference": "Practitioner/298F8D0B-C3B9-0598-4D0E-3ADB6F7B1DEF"
       } ],
@@ -5698,7 +5698,7 @@
         "reference": "Encounter/C07745C6-ADAC-11E2-883C-B639E5B05B1F"
       },
       "effectiveDateTime": "2000-03-31",
-      "issued": "2017-05-18T08:12:07.000+00:00",
+      "issued": "2000-03-31T00:00:00.000+00:00",
       "performer": [ {
         "reference": "Practitioner/298F8D0B-C3B9-0598-4D0E-3ADB6F7B1DEF"
       } ],
@@ -5745,7 +5745,7 @@
         "reference": "Encounter/C07745C6-ADAC-11E2-883C-B639E5B05B1F"
       },
       "effectiveDateTime": "2000-03-31",
-      "issued": "2017-05-18T08:12:07.000+00:00",
+      "issued": "2000-03-31T00:00:00.000+00:00",
       "performer": [ {
         "reference": "Practitioner/298F8D0B-C3B9-0598-4D0E-3ADB6F7B1DEF"
       } ],
@@ -5792,7 +5792,7 @@
         "reference": "Encounter/C07745C6-ADAC-11E2-883C-B639E5B05B1F"
       },
       "effectiveDateTime": "2000-03-31",
-      "issued": "2017-05-18T08:12:07.000+00:00",
+      "issued": "2000-03-31T00:00:00.000+00:00",
       "performer": [ {
         "reference": "Practitioner/298F8D0B-C3B9-0598-4D0E-3ADB6F7B1DEF"
       } ],
@@ -5836,7 +5836,7 @@
         "reference": "Encounter/C07745C6-ADAC-11E2-883C-B639E5B05B1F"
       },
       "effectiveDateTime": "2000-03-31",
-      "issued": "2017-05-18T08:12:07.000+00:00",
+      "issued": "2000-03-31T00:00:00.000+00:00",
       "performer": [ {
         "reference": "Practitioner/298F8D0B-C3B9-0598-4D0E-3ADB6F7B1DEF"
       } ],
@@ -5880,7 +5880,7 @@
         "reference": "Encounter/C07745C6-ADAC-11E2-883C-B639E5B05B1F"
       },
       "effectiveDateTime": "2000-03-31",
-      "issued": "2017-05-18T08:12:07.000+00:00",
+      "issued": "2000-03-31T00:00:00.000+00:00",
       "performer": [ {
         "reference": "Practitioner/298F8D0B-C3B9-0598-4D0E-3ADB6F7B1DEF"
       } ],
@@ -5927,7 +5927,7 @@
         "reference": "Encounter/C07745C6-ADAC-11E2-883C-B639E5B05B1F"
       },
       "effectiveDateTime": "2000-03-31",
-      "issued": "2017-05-18T08:12:07.000+00:00",
+      "issued": "2000-03-31T00:00:00.000+00:00",
       "performer": [ {
         "reference": "Practitioner/298F8D0B-C3B9-0598-4D0E-3ADB6F7B1DEF"
       } ],
@@ -5974,7 +5974,7 @@
         "reference": "Encounter/C07745C6-ADAC-11E2-883C-B639E5B05B1F"
       },
       "effectiveDateTime": "2000-03-31",
-      "issued": "2017-05-18T08:12:07.000+00:00",
+      "issued": "2000-03-31T00:00:00.000+00:00",
       "performer": [ {
         "reference": "Practitioner/298F8D0B-C3B9-0598-4D0E-3ADB6F7B1DEF"
       } ],
@@ -6021,7 +6021,7 @@
         "reference": "Encounter/C07745C6-ADAC-11E2-883C-B639E5B05B1F"
       },
       "effectiveDateTime": "2000-03-31",
-      "issued": "2017-05-18T08:12:07.000+00:00",
+      "issued": "2000-03-31T00:00:00.000+00:00",
       "performer": [ {
         "reference": "Practitioner/298F8D0B-C3B9-0598-4D0E-3ADB6F7B1DEF"
       } ],
@@ -6065,7 +6065,7 @@
         "reference": "Encounter/C11B5062-ADAC-11E2-9964-B639E5B05B1F"
       },
       "effectiveDateTime": "2000-03-31",
-      "issued": "2017-05-18T08:12:07.000+00:00",
+      "issued": "2000-03-31T00:00:00.000+00:00",
       "performer": [ {
         "reference": "Practitioner/298F8D0B-C3B9-0598-4D0E-3ADB6F7B1DEF"
       } ],
@@ -6109,7 +6109,7 @@
         "reference": "Encounter/C11B5062-ADAC-11E2-9964-B639E5B05B1F"
       },
       "effectiveDateTime": "2000-03-31",
-      "issued": "2017-05-18T08:12:07.000+00:00",
+      "issued": "2000-03-31T00:00:00.000+00:00",
       "performer": [ {
         "reference": "Practitioner/298F8D0B-C3B9-0598-4D0E-3ADB6F7B1DEF"
       } ],
@@ -6153,7 +6153,7 @@
         "reference": "Encounter/C11B5062-ADAC-11E2-9964-B639E5B05B1F"
       },
       "effectiveDateTime": "2000-03-31",
-      "issued": "2017-05-18T08:12:07.000+00:00",
+      "issued": "2000-03-31T00:00:00.000+00:00",
       "performer": [ {
         "reference": "Practitioner/298F8D0B-C3B9-0598-4D0E-3ADB6F7B1DEF"
       } ],
@@ -6197,7 +6197,7 @@
         "reference": "Encounter/C11B5062-ADAC-11E2-9964-B639E5B05B1F"
       },
       "effectiveDateTime": "2000-03-31",
-      "issued": "2017-05-18T08:12:07.000+00:00",
+      "issued": "2000-03-31T00:00:00.000+00:00",
       "performer": [ {
         "reference": "Practitioner/298F8D0B-C3B9-0598-4D0E-3ADB6F7B1DEF"
       } ],
@@ -6244,7 +6244,7 @@
         "reference": "Encounter/C11B5062-ADAC-11E2-9964-B639E5B05B1F"
       },
       "effectiveDateTime": "2000-03-31",
-      "issued": "2017-05-18T08:12:07.000+00:00",
+      "issued": "2000-03-31T00:00:00.000+00:00",
       "performer": [ {
         "reference": "Practitioner/298F8D0B-C3B9-0598-4D0E-3ADB6F7B1DEF"
       } ],
@@ -6291,7 +6291,7 @@
         "reference": "Encounter/C11B5062-ADAC-11E2-9964-B639E5B05B1F"
       },
       "effectiveDateTime": "2000-03-31",
-      "issued": "2017-05-18T08:12:07.000+00:00",
+      "issued": "2000-03-31T00:00:00.000+00:00",
       "performer": [ {
         "reference": "Practitioner/298F8D0B-C3B9-0598-4D0E-3ADB6F7B1DEF"
       } ],
@@ -6335,7 +6335,7 @@
         "reference": "Encounter/C11B5062-ADAC-11E2-9964-B639E5B05B1F"
       },
       "effectiveDateTime": "2000-03-31",
-      "issued": "2017-05-18T08:12:07.000+00:00",
+      "issued": "2000-03-31T00:00:00.000+00:00",
       "performer": [ {
         "reference": "Practitioner/298F8D0B-C3B9-0598-4D0E-3ADB6F7B1DEF"
       } ],
@@ -6382,7 +6382,7 @@
         "reference": "Encounter/C11B5062-ADAC-11E2-9964-B639E5B05B1F"
       },
       "effectiveDateTime": "2000-03-31",
-      "issued": "2017-05-18T08:12:07.000+00:00",
+      "issued": "2000-03-31T00:00:00.000+00:00",
       "performer": [ {
         "reference": "Practitioner/298F8D0B-C3B9-0598-4D0E-3ADB6F7B1DEF"
       } ],
@@ -6429,7 +6429,7 @@
         "reference": "Encounter/C11B5062-ADAC-11E2-9964-B639E5B05B1F"
       },
       "effectiveDateTime": "2000-03-31",
-      "issued": "2017-05-18T08:12:07.000+00:00",
+      "issued": "2000-03-31T00:00:00.000+00:00",
       "performer": [ {
         "reference": "Practitioner/298F8D0B-C3B9-0598-4D0E-3ADB6F7B1DEF"
       } ],
@@ -6476,7 +6476,7 @@
         "reference": "Encounter/C11B5062-ADAC-11E2-9964-B639E5B05B1F"
       },
       "effectiveDateTime": "2000-03-31",
-      "issued": "2017-05-18T08:12:07.000+00:00",
+      "issued": "2000-03-31T00:00:00.000+00:00",
       "performer": [ {
         "reference": "Practitioner/298F8D0B-C3B9-0598-4D0E-3ADB6F7B1DEF"
       } ],
@@ -6520,7 +6520,7 @@
         "reference": "Encounter/C11B5062-ADAC-11E2-9964-B639E5B05B1F"
       },
       "effectiveDateTime": "2000-03-31",
-      "issued": "2017-05-18T08:12:07.000+00:00",
+      "issued": "2000-03-31T00:00:00.000+00:00",
       "performer": [ {
         "reference": "Practitioner/298F8D0B-C3B9-0598-4D0E-3ADB6F7B1DEF"
       } ],
@@ -6564,7 +6564,7 @@
         "reference": "Encounter/C11B5062-ADAC-11E2-9964-B639E5B05B1F"
       },
       "effectiveDateTime": "2000-03-31",
-      "issued": "2017-05-18T08:12:07.000+00:00",
+      "issued": "2000-03-31T00:00:00.000+00:00",
       "performer": [ {
         "reference": "Practitioner/298F8D0B-C3B9-0598-4D0E-3ADB6F7B1DEF"
       } ],
@@ -6608,7 +6608,7 @@
         "reference": "Encounter/C11B5062-ADAC-11E2-9964-B639E5B05B1F"
       },
       "effectiveDateTime": "2000-03-31",
-      "issued": "2017-05-18T08:12:07.000+00:00",
+      "issued": "2000-03-31T00:00:00.000+00:00",
       "performer": [ {
         "reference": "Practitioner/298F8D0B-C3B9-0598-4D0E-3ADB6F7B1DEF"
       } ],
@@ -6655,7 +6655,7 @@
         "reference": "Encounter/C11B5062-ADAC-11E2-9964-B639E5B05B1F"
       },
       "effectiveDateTime": "2000-03-31",
-      "issued": "2017-05-18T08:12:07.000+00:00",
+      "issued": "2000-03-31T00:00:00.000+00:00",
       "performer": [ {
         "reference": "Practitioner/298F8D0B-C3B9-0598-4D0E-3ADB6F7B1DEF"
       } ],
@@ -6699,7 +6699,7 @@
         "reference": "Encounter/C11B5062-ADAC-11E2-9964-B639E5B05B1F"
       },
       "effectiveDateTime": "2000-03-31",
-      "issued": "2017-05-18T08:12:07.000+00:00",
+      "issued": "2000-03-31T00:00:00.000+00:00",
       "performer": [ {
         "reference": "Practitioner/298F8D0B-C3B9-0598-4D0E-3ADB6F7B1DEF"
       } ],
@@ -6743,7 +6743,7 @@
         "reference": "Encounter/C11B5062-ADAC-11E2-9964-B639E5B05B1F"
       },
       "effectiveDateTime": "2000-03-31",
-      "issued": "2017-05-18T08:12:07.000+00:00",
+      "issued": "2000-03-31T00:00:00.000+00:00",
       "performer": [ {
         "reference": "Practitioner/298F8D0B-C3B9-0598-4D0E-3ADB6F7B1DEF"
       } ],
@@ -6787,7 +6787,7 @@
         "reference": "Encounter/C11B5062-ADAC-11E2-9964-B639E5B05B1F"
       },
       "effectiveDateTime": "2000-03-31",
-      "issued": "2017-05-18T08:12:07.000+00:00",
+      "issued": "2000-03-31T00:00:00.000+00:00",
       "performer": [ {
         "reference": "Practitioner/298F8D0B-C3B9-0598-4D0E-3ADB6F7B1DEF"
       } ],
@@ -6834,7 +6834,7 @@
         "reference": "Encounter/C11B5062-ADAC-11E2-9964-B639E5B05B1F"
       },
       "effectiveDateTime": "2000-03-31",
-      "issued": "2017-05-18T08:12:07.000+00:00",
+      "issued": "2000-03-31T00:00:00.000+00:00",
       "performer": [ {
         "reference": "Practitioner/298F8D0B-C3B9-0598-4D0E-3ADB6F7B1DEF"
       } ],
@@ -6878,7 +6878,7 @@
         "reference": "Encounter/C11B5062-ADAC-11E2-9964-B639E5B05B1F"
       },
       "effectiveDateTime": "2000-03-31",
-      "issued": "2017-05-18T08:12:07.000+00:00",
+      "issued": "2000-03-31T00:00:00.000+00:00",
       "performer": [ {
         "reference": "Practitioner/298F8D0B-C3B9-0598-4D0E-3ADB6F7B1DEF"
       } ],
@@ -6922,7 +6922,7 @@
         "reference": "Encounter/C11B5062-ADAC-11E2-9964-B639E5B05B1F"
       },
       "effectiveDateTime": "2000-03-31",
-      "issued": "2017-05-18T08:12:07.000+00:00",
+      "issued": "2000-03-31T00:00:00.000+00:00",
       "performer": [ {
         "reference": "Practitioner/298F8D0B-C3B9-0598-4D0E-3ADB6F7B1DEF"
       } ],
@@ -6969,7 +6969,7 @@
         "reference": "Encounter/C11B5062-ADAC-11E2-9964-B639E5B05B1F"
       },
       "effectiveDateTime": "2000-03-31",
-      "issued": "2017-05-18T08:12:07.000+00:00",
+      "issued": "2000-03-31T00:00:00.000+00:00",
       "performer": [ {
         "reference": "Practitioner/298F8D0B-C3B9-0598-4D0E-3ADB6F7B1DEF"
       } ],
@@ -7016,7 +7016,7 @@
         "reference": "Encounter/C11B5062-ADAC-11E2-9964-B639E5B05B1F"
       },
       "effectiveDateTime": "2000-03-31",
-      "issued": "2017-05-18T08:12:07.000+00:00",
+      "issued": "2000-03-31T00:00:00.000+00:00",
       "performer": [ {
         "reference": "Practitioner/298F8D0B-C3B9-0598-4D0E-3ADB6F7B1DEF"
       } ],
@@ -7063,7 +7063,7 @@
         "reference": "Encounter/C11B5062-ADAC-11E2-9964-B639E5B05B1F"
       },
       "effectiveDateTime": "2000-03-31",
-      "issued": "2017-05-18T08:12:07.000+00:00",
+      "issued": "2000-03-31T00:00:00.000+00:00",
       "performer": [ {
         "reference": "Practitioner/298F8D0B-C3B9-0598-4D0E-3ADB6F7B1DEF"
       } ],
@@ -7107,7 +7107,7 @@
         "reference": "Encounter/C11B5062-ADAC-11E2-9964-B639E5B05B1F"
       },
       "effectiveDateTime": "2000-03-31",
-      "issued": "2017-05-18T08:12:07.000+00:00",
+      "issued": "2000-03-31T00:00:00.000+00:00",
       "performer": [ {
         "reference": "Practitioner/298F8D0B-C3B9-0598-4D0E-3ADB6F7B1DEF"
       } ],
@@ -7151,7 +7151,7 @@
         "reference": "Encounter/C11B5062-ADAC-11E2-9964-B639E5B05B1F"
       },
       "effectiveDateTime": "2000-03-31",
-      "issued": "2017-05-18T08:12:07.000+00:00",
+      "issued": "2000-03-31T00:00:00.000+00:00",
       "performer": [ {
         "reference": "Practitioner/298F8D0B-C3B9-0598-4D0E-3ADB6F7B1DEF"
       } ],
@@ -7195,7 +7195,7 @@
         "reference": "Encounter/C11B5062-ADAC-11E2-9964-B639E5B05B1F"
       },
       "effectiveDateTime": "2000-03-31",
-      "issued": "2017-05-18T08:12:07.000+00:00",
+      "issued": "2000-03-31T00:00:00.000+00:00",
       "performer": [ {
         "reference": "Practitioner/298F8D0B-C3B9-0598-4D0E-3ADB6F7B1DEF"
       } ],
@@ -7239,7 +7239,7 @@
         "reference": "Encounter/C11B5062-ADAC-11E2-9964-B639E5B05B1F"
       },
       "effectiveDateTime": "2000-03-31",
-      "issued": "2017-05-18T08:12:07.000+00:00",
+      "issued": "2000-03-31T00:00:00.000+00:00",
       "performer": [ {
         "reference": "Practitioner/298F8D0B-C3B9-0598-4D0E-3ADB6F7B1DEF"
       } ],
@@ -7283,7 +7283,7 @@
         "reference": "Encounter/C11B5062-ADAC-11E2-9964-B639E5B05B1F"
       },
       "effectiveDateTime": "2000-03-31",
-      "issued": "2017-05-18T08:12:07.000+00:00",
+      "issued": "2000-03-31T00:00:00.000+00:00",
       "performer": [ {
         "reference": "Practitioner/298F8D0B-C3B9-0598-4D0E-3ADB6F7B1DEF"
       } ],
@@ -7330,7 +7330,7 @@
         "reference": "Encounter/C11B5062-ADAC-11E2-9964-B639E5B05B1F"
       },
       "effectiveDateTime": "2000-03-31",
-      "issued": "2017-05-18T08:12:07.000+00:00",
+      "issued": "2000-03-31T00:00:00.000+00:00",
       "performer": [ {
         "reference": "Practitioner/298F8D0B-C3B9-0598-4D0E-3ADB6F7B1DEF"
       } ],
@@ -7374,7 +7374,7 @@
         "reference": "Encounter/C11B5062-ADAC-11E2-9964-B639E5B05B1F"
       },
       "effectiveDateTime": "2000-03-31",
-      "issued": "2017-05-18T08:12:07.000+00:00",
+      "issued": "2000-03-31T00:00:00.000+00:00",
       "performer": [ {
         "reference": "Practitioner/298F8D0B-C3B9-0598-4D0E-3ADB6F7B1DEF"
       } ],
@@ -7418,7 +7418,7 @@
         "reference": "Encounter/C11B5062-ADAC-11E2-9964-B639E5B05B1F"
       },
       "effectiveDateTime": "2000-03-31",
-      "issued": "2017-05-18T08:12:07.000+00:00",
+      "issued": "2000-03-31T00:00:00.000+00:00",
       "performer": [ {
         "reference": "Practitioner/298F8D0B-C3B9-0598-4D0E-3ADB6F7B1DEF"
       } ],
@@ -7462,7 +7462,7 @@
         "reference": "Encounter/C11B5062-ADAC-11E2-9964-B639E5B05B1F"
       },
       "effectiveDateTime": "2000-03-31",
-      "issued": "2017-05-18T08:12:07.000+00:00",
+      "issued": "2000-03-31T00:00:00.000+00:00",
       "performer": [ {
         "reference": "Practitioner/298F8D0B-C3B9-0598-4D0E-3ADB6F7B1DEF"
       } ],
@@ -7506,7 +7506,7 @@
         "reference": "Encounter/C11B5062-ADAC-11E2-9964-B639E5B05B1F"
       },
       "effectiveDateTime": "2000-03-31",
-      "issued": "2017-05-18T08:12:07.000+00:00",
+      "issued": "2000-03-31T00:00:00.000+00:00",
       "performer": [ {
         "reference": "Practitioner/298F8D0B-C3B9-0598-4D0E-3ADB6F7B1DEF"
       } ],
@@ -7550,7 +7550,7 @@
         "reference": "Encounter/C11B5062-ADAC-11E2-9964-B639E5B05B1F"
       },
       "effectiveDateTime": "2000-03-31",
-      "issued": "2017-05-18T08:12:07.000+00:00",
+      "issued": "2000-03-31T00:00:00.000+00:00",
       "performer": [ {
         "reference": "Practitioner/298F8D0B-C3B9-0598-4D0E-3ADB6F7B1DEF"
       } ],
@@ -7594,7 +7594,7 @@
         "reference": "Encounter/C11B5062-ADAC-11E2-9964-B639E5B05B1F"
       },
       "effectiveDateTime": "2000-03-31",
-      "issued": "2017-05-18T08:12:07.000+00:00",
+      "issued": "2000-03-31T00:00:00.000+00:00",
       "performer": [ {
         "reference": "Practitioner/298F8D0B-C3B9-0598-4D0E-3ADB6F7B1DEF"
       } ],
@@ -7638,7 +7638,7 @@
         "reference": "Encounter/C11B5062-ADAC-11E2-9964-B639E5B05B1F"
       },
       "effectiveDateTime": "2000-03-31",
-      "issued": "2017-05-18T08:12:07.000+00:00",
+      "issued": "2000-03-31T00:00:00.000+00:00",
       "performer": [ {
         "reference": "Practitioner/298F8D0B-C3B9-0598-4D0E-3ADB6F7B1DEF"
       } ],
@@ -7682,7 +7682,7 @@
         "reference": "Encounter/C11B5062-ADAC-11E2-9964-B639E5B05B1F"
       },
       "effectiveDateTime": "2000-03-31",
-      "issued": "2017-05-18T08:12:07.000+00:00",
+      "issued": "2000-03-31T00:00:00.000+00:00",
       "performer": [ {
         "reference": "Practitioner/298F8D0B-C3B9-0598-4D0E-3ADB6F7B1DEF"
       } ],
@@ -7729,7 +7729,7 @@
         "reference": "Encounter/C11B5062-ADAC-11E2-9964-B639E5B05B1F"
       },
       "effectiveDateTime": "2000-03-31",
-      "issued": "2017-05-18T08:12:07.000+00:00",
+      "issued": "2000-03-31T00:00:00.000+00:00",
       "performer": [ {
         "reference": "Practitioner/298F8D0B-C3B9-0598-4D0E-3ADB6F7B1DEF"
       } ],
@@ -7776,7 +7776,7 @@
         "reference": "Encounter/C11B5062-ADAC-11E2-9964-B639E5B05B1F"
       },
       "effectiveDateTime": "2000-03-31",
-      "issued": "2017-05-18T08:12:07.000+00:00",
+      "issued": "2000-03-31T00:00:00.000+00:00",
       "performer": [ {
         "reference": "Practitioner/298F8D0B-C3B9-0598-4D0E-3ADB6F7B1DEF"
       } ],
@@ -7820,7 +7820,7 @@
         "reference": "Encounter/C11B5062-ADAC-11E2-9964-B639E5B05B1F"
       },
       "effectiveDateTime": "2000-03-31",
-      "issued": "2017-05-18T08:12:07.000+00:00",
+      "issued": "2000-03-31T00:00:00.000+00:00",
       "performer": [ {
         "reference": "Practitioner/298F8D0B-C3B9-0598-4D0E-3ADB6F7B1DEF"
       } ],
@@ -7864,7 +7864,7 @@
         "reference": "Encounter/C11B5062-ADAC-11E2-9964-B639E5B05B1F"
       },
       "effectiveDateTime": "2000-03-31",
-      "issued": "2017-05-18T08:12:07.000+00:00",
+      "issued": "2000-03-31T00:00:00.000+00:00",
       "performer": [ {
         "reference": "Practitioner/298F8D0B-C3B9-0598-4D0E-3ADB6F7B1DEF"
       } ],
@@ -7908,7 +7908,7 @@
         "reference": "Encounter/C11B5062-ADAC-11E2-9964-B639E5B05B1F"
       },
       "effectiveDateTime": "2000-03-31",
-      "issued": "2017-05-18T08:12:07.000+00:00",
+      "issued": "2000-03-31T00:00:00.000+00:00",
       "performer": [ {
         "reference": "Practitioner/298F8D0B-C3B9-0598-4D0E-3ADB6F7B1DEF"
       } ],
@@ -7952,7 +7952,7 @@
         "reference": "Encounter/C11B5062-ADAC-11E2-9964-B639E5B05B1F"
       },
       "effectiveDateTime": "2000-03-31",
-      "issued": "2017-05-18T08:12:07.000+00:00",
+      "issued": "2000-03-31T00:00:00.000+00:00",
       "performer": [ {
         "reference": "Practitioner/298F8D0B-C3B9-0598-4D0E-3ADB6F7B1DEF"
       } ],
@@ -7996,7 +7996,7 @@
         "reference": "Encounter/C11B5062-ADAC-11E2-9964-B639E5B05B1F"
       },
       "effectiveDateTime": "2000-03-31",
-      "issued": "2017-05-18T08:12:07.000+00:00",
+      "issued": "2000-03-31T00:00:00.000+00:00",
       "performer": [ {
         "reference": "Practitioner/298F8D0B-C3B9-0598-4D0E-3ADB6F7B1DEF"
       } ],
@@ -8040,7 +8040,7 @@
         "reference": "Encounter/C11B5062-ADAC-11E2-9964-B639E5B05B1F"
       },
       "effectiveDateTime": "2000-03-31",
-      "issued": "2017-05-18T08:12:07.000+00:00",
+      "issued": "2000-03-31T00:00:00.000+00:00",
       "performer": [ {
         "reference": "Practitioner/298F8D0B-C3B9-0598-4D0E-3ADB6F7B1DEF"
       } ],
@@ -8084,7 +8084,7 @@
         "reference": "Encounter/C11B5062-ADAC-11E2-9964-B639E5B05B1F"
       },
       "effectiveDateTime": "2000-03-31",
-      "issued": "2017-05-18T08:12:07.000+00:00",
+      "issued": "2000-03-31T00:00:00.000+00:00",
       "performer": [ {
         "reference": "Practitioner/298F8D0B-C3B9-0598-4D0E-3ADB6F7B1DEF"
       } ],
@@ -8128,7 +8128,7 @@
         "reference": "Encounter/C11B5062-ADAC-11E2-9964-B639E5B05B1F"
       },
       "effectiveDateTime": "2000-03-31",
-      "issued": "2017-05-18T08:12:07.000+00:00",
+      "issued": "2000-03-31T00:00:00.000+00:00",
       "performer": [ {
         "reference": "Practitioner/298F8D0B-C3B9-0598-4D0E-3ADB6F7B1DEF"
       } ],
@@ -8172,7 +8172,7 @@
         "reference": "Encounter/C11B5062-ADAC-11E2-9964-B639E5B05B1F"
       },
       "effectiveDateTime": "2000-03-31",
-      "issued": "2017-05-18T08:12:07.000+00:00",
+      "issued": "2000-03-31T00:00:00.000+00:00",
       "performer": [ {
         "reference": "Practitioner/298F8D0B-C3B9-0598-4D0E-3ADB6F7B1DEF"
       } ],
@@ -8216,7 +8216,7 @@
         "reference": "Encounter/C11B5062-ADAC-11E2-9964-B639E5B05B1F"
       },
       "effectiveDateTime": "2000-03-31",
-      "issued": "2017-05-18T08:12:07.000+00:00",
+      "issued": "2000-03-31T00:00:00.000+00:00",
       "performer": [ {
         "reference": "Practitioner/298F8D0B-C3B9-0598-4D0E-3ADB6F7B1DEF"
       } ],
@@ -8263,7 +8263,7 @@
         "reference": "Encounter/C11B5062-ADAC-11E2-9964-B639E5B05B1F"
       },
       "effectiveDateTime": "2000-03-31",
-      "issued": "2017-05-18T08:12:07.000+00:00",
+      "issued": "2000-03-31T00:00:00.000+00:00",
       "performer": [ {
         "reference": "Practitioner/298F8D0B-C3B9-0598-4D0E-3ADB6F7B1DEF"
       } ],
@@ -8310,7 +8310,7 @@
         "reference": "Encounter/C11B5062-ADAC-11E2-9964-B639E5B05B1F"
       },
       "effectiveDateTime": "2000-03-31",
-      "issued": "2017-05-18T08:12:07.000+00:00",
+      "issued": "2000-03-31T00:00:00.000+00:00",
       "performer": [ {
         "reference": "Practitioner/298F8D0B-C3B9-0598-4D0E-3ADB6F7B1DEF"
       } ],
@@ -8357,7 +8357,7 @@
         "reference": "Encounter/C11B5062-ADAC-11E2-9964-B639E5B05B1F"
       },
       "effectiveDateTime": "2000-03-31",
-      "issued": "2017-05-18T08:12:07.000+00:00",
+      "issued": "2000-03-31T00:00:00.000+00:00",
       "performer": [ {
         "reference": "Practitioner/298F8D0B-C3B9-0598-4D0E-3ADB6F7B1DEF"
       } ],
@@ -8404,7 +8404,7 @@
         "reference": "Encounter/C11B5062-ADAC-11E2-9964-B639E5B05B1F"
       },
       "effectiveDateTime": "2000-03-31",
-      "issued": "2017-05-18T08:12:07.000+00:00",
+      "issued": "2000-03-31T00:00:00.000+00:00",
       "performer": [ {
         "reference": "Practitioner/298F8D0B-C3B9-0598-4D0E-3ADB6F7B1DEF"
       } ],
@@ -8448,7 +8448,7 @@
         "reference": "Encounter/C11B5062-ADAC-11E2-9964-B639E5B05B1F"
       },
       "effectiveDateTime": "2000-03-31",
-      "issued": "2017-05-18T08:12:07.000+00:00",
+      "issued": "2000-03-31T00:00:00.000+00:00",
       "performer": [ {
         "reference": "Practitioner/298F8D0B-C3B9-0598-4D0E-3ADB6F7B1DEF"
       } ],
@@ -8492,7 +8492,7 @@
         "reference": "Encounter/C11B5062-ADAC-11E2-9964-B639E5B05B1F"
       },
       "effectiveDateTime": "2000-03-31",
-      "issued": "2017-05-18T08:12:07.000+00:00",
+      "issued": "2000-03-31T00:00:00.000+00:00",
       "performer": [ {
         "reference": "Practitioner/298F8D0B-C3B9-0598-4D0E-3ADB6F7B1DEF"
       } ],
@@ -8536,7 +8536,7 @@
         "reference": "Encounter/C11B5062-ADAC-11E2-9964-B639E5B05B1F"
       },
       "effectiveDateTime": "2000-03-31",
-      "issued": "2017-05-18T08:12:07.000+00:00",
+      "issued": "2000-03-31T00:00:00.000+00:00",
       "performer": [ {
         "reference": "Practitioner/298F8D0B-C3B9-0598-4D0E-3ADB6F7B1DEF"
       } ],
@@ -8580,7 +8580,7 @@
         "reference": "Encounter/C11B5062-ADAC-11E2-9964-B639E5B05B1F"
       },
       "effectiveDateTime": "2000-03-31",
-      "issued": "2017-05-18T08:12:07.000+00:00",
+      "issued": "2000-03-31T00:00:00.000+00:00",
       "performer": [ {
         "reference": "Practitioner/298F8D0B-C3B9-0598-4D0E-3ADB6F7B1DEF"
       } ],
@@ -8624,7 +8624,7 @@
         "reference": "Encounter/C11B5062-ADAC-11E2-9964-B639E5B05B1F"
       },
       "effectiveDateTime": "2000-03-31",
-      "issued": "2017-05-18T08:12:07.000+00:00",
+      "issued": "2000-03-31T00:00:00.000+00:00",
       "performer": [ {
         "reference": "Practitioner/298F8D0B-C3B9-0598-4D0E-3ADB6F7B1DEF"
       } ],
@@ -8668,7 +8668,7 @@
         "reference": "Encounter/C11B5062-ADAC-11E2-9964-B639E5B05B1F"
       },
       "effectiveDateTime": "2000-03-31",
-      "issued": "2017-05-18T08:12:07.000+00:00",
+      "issued": "2000-03-31T00:00:00.000+00:00",
       "performer": [ {
         "reference": "Practitioner/298F8D0B-C3B9-0598-4D0E-3ADB6F7B1DEF"
       } ],
@@ -8712,7 +8712,7 @@
         "reference": "Encounter/C11B5062-ADAC-11E2-9964-B639E5B05B1F"
       },
       "effectiveDateTime": "2000-03-31",
-      "issued": "2017-05-18T08:12:07.000+00:00",
+      "issued": "2000-03-31T00:00:00.000+00:00",
       "performer": [ {
         "reference": "Practitioner/298F8D0B-C3B9-0598-4D0E-3ADB6F7B1DEF"
       } ],
@@ -8756,7 +8756,7 @@
         "reference": "Encounter/C11B5062-ADAC-11E2-9964-B639E5B05B1F"
       },
       "effectiveDateTime": "2000-03-31",
-      "issued": "2017-05-18T08:12:07.000+00:00",
+      "issued": "2000-03-31T00:00:00.000+00:00",
       "performer": [ {
         "reference": "Practitioner/298F8D0B-C3B9-0598-4D0E-3ADB6F7B1DEF"
       } ],
@@ -8800,7 +8800,7 @@
         "reference": "Encounter/C11B5062-ADAC-11E2-9964-B639E5B05B1F"
       },
       "effectiveDateTime": "2000-03-31",
-      "issued": "2017-05-18T08:12:07.000+00:00",
+      "issued": "2000-03-31T00:00:00.000+00:00",
       "performer": [ {
         "reference": "Practitioner/298F8D0B-C3B9-0598-4D0E-3ADB6F7B1DEF"
       } ],
@@ -8847,7 +8847,7 @@
         "reference": "Encounter/C11B5062-ADAC-11E2-9964-B639E5B05B1F"
       },
       "effectiveDateTime": "2000-03-31",
-      "issued": "2017-05-18T08:12:07.000+00:00",
+      "issued": "2000-03-31T00:00:00.000+00:00",
       "performer": [ {
         "reference": "Practitioner/298F8D0B-C3B9-0598-4D0E-3ADB6F7B1DEF"
       } ],
@@ -8894,7 +8894,7 @@
         "reference": "Encounter/C11B5062-ADAC-11E2-9964-B639E5B05B1F"
       },
       "effectiveDateTime": "2000-03-31",
-      "issued": "2017-05-18T08:12:07.000+00:00",
+      "issued": "2000-03-31T00:00:00.000+00:00",
       "performer": [ {
         "reference": "Practitioner/298F8D0B-C3B9-0598-4D0E-3ADB6F7B1DEF"
       } ],
@@ -8941,7 +8941,7 @@
         "reference": "Encounter/C11B5062-ADAC-11E2-9964-B639E5B05B1F"
       },
       "effectiveDateTime": "2000-03-31",
-      "issued": "2017-05-18T08:12:07.000+00:00",
+      "issued": "2000-03-31T00:00:00.000+00:00",
       "performer": [ {
         "reference": "Practitioner/298F8D0B-C3B9-0598-4D0E-3ADB6F7B1DEF"
       } ],
@@ -8988,7 +8988,7 @@
         "reference": "Encounter/C11B5062-ADAC-11E2-9964-B639E5B05B1F"
       },
       "effectiveDateTime": "2000-03-31",
-      "issued": "2017-05-18T08:12:07.000+00:00",
+      "issued": "2000-03-31T00:00:00.000+00:00",
       "performer": [ {
         "reference": "Practitioner/298F8D0B-C3B9-0598-4D0E-3ADB6F7B1DEF"
       } ],
@@ -9035,7 +9035,7 @@
         "reference": "Encounter/C11B5062-ADAC-11E2-9964-B639E5B05B1F"
       },
       "effectiveDateTime": "2000-03-31",
-      "issued": "2017-05-18T08:12:07.000+00:00",
+      "issued": "2000-03-31T00:00:00.000+00:00",
       "performer": [ {
         "reference": "Practitioner/298F8D0B-C3B9-0598-4D0E-3ADB6F7B1DEF"
       } ],
@@ -9082,7 +9082,7 @@
         "reference": "Encounter/C11B5062-ADAC-11E2-9964-B639E5B05B1F"
       },
       "effectiveDateTime": "2000-03-31",
-      "issued": "2017-05-18T08:12:07.000+00:00",
+      "issued": "2000-03-31T00:00:00.000+00:00",
       "performer": [ {
         "reference": "Practitioner/298F8D0B-C3B9-0598-4D0E-3ADB6F7B1DEF"
       } ],
@@ -9126,7 +9126,7 @@
         "reference": "Encounter/C11B5062-ADAC-11E2-9964-B639E5B05B1F"
       },
       "effectiveDateTime": "2000-03-31",
-      "issued": "2017-05-18T08:12:07.000+00:00",
+      "issued": "2000-03-31T00:00:00.000+00:00",
       "performer": [ {
         "reference": "Practitioner/298F8D0B-C3B9-0598-4D0E-3ADB6F7B1DEF"
       } ],
@@ -9170,7 +9170,7 @@
         "reference": "Encounter/C11B5062-ADAC-11E2-9964-B639E5B05B1F"
       },
       "effectiveDateTime": "2000-03-31",
-      "issued": "2017-05-18T08:12:07.000+00:00",
+      "issued": "2000-03-31T00:00:00.000+00:00",
       "performer": [ {
         "reference": "Practitioner/298F8D0B-C3B9-0598-4D0E-3ADB6F7B1DEF"
       } ],
@@ -9214,7 +9214,7 @@
         "reference": "Encounter/C11B5062-ADAC-11E2-9964-B639E5B05B1F"
       },
       "effectiveDateTime": "2000-03-31",
-      "issued": "2017-05-18T08:12:07.000+00:00",
+      "issued": "2000-03-31T00:00:00.000+00:00",
       "performer": [ {
         "reference": "Practitioner/298F8D0B-C3B9-0598-4D0E-3ADB6F7B1DEF"
       } ],
@@ -9258,7 +9258,7 @@
         "reference": "Encounter/C11B5062-ADAC-11E2-9964-B639E5B05B1F"
       },
       "effectiveDateTime": "2000-03-31",
-      "issued": "2017-05-18T08:12:07.000+00:00",
+      "issued": "2000-03-31T00:00:00.000+00:00",
       "performer": [ {
         "reference": "Practitioner/298F8D0B-C3B9-0598-4D0E-3ADB6F7B1DEF"
       } ],
@@ -9305,7 +9305,7 @@
         "reference": "Encounter/C11B5062-ADAC-11E2-9964-B639E5B05B1F"
       },
       "effectiveDateTime": "2000-03-31",
-      "issued": "2017-05-18T08:12:07.000+00:00",
+      "issued": "2000-03-31T00:00:00.000+00:00",
       "performer": [ {
         "reference": "Practitioner/298F8D0B-C3B9-0598-4D0E-3ADB6F7B1DEF"
       } ],
@@ -9352,7 +9352,7 @@
         "reference": "Encounter/C11B5062-ADAC-11E2-9964-B639E5B05B1F"
       },
       "effectiveDateTime": "2000-03-31",
-      "issued": "2017-05-18T08:12:07.000+00:00",
+      "issued": "2000-03-31T00:00:00.000+00:00",
       "performer": [ {
         "reference": "Practitioner/298F8D0B-C3B9-0598-4D0E-3ADB6F7B1DEF"
       } ],
@@ -9396,7 +9396,7 @@
         "reference": "Encounter/C11B5062-ADAC-11E2-9964-B639E5B05B1F"
       },
       "effectiveDateTime": "2000-03-31",
-      "issued": "2017-05-18T08:12:07.000+00:00",
+      "issued": "2000-03-31T00:00:00.000+00:00",
       "performer": [ {
         "reference": "Practitioner/298F8D0B-C3B9-0598-4D0E-3ADB6F7B1DEF"
       } ],
@@ -9443,7 +9443,7 @@
         "reference": "Encounter/C11B5062-ADAC-11E2-9964-B639E5B05B1F"
       },
       "effectiveDateTime": "2000-03-31",
-      "issued": "2017-05-18T08:12:07.000+00:00",
+      "issued": "2000-03-31T00:00:00.000+00:00",
       "performer": [ {
         "reference": "Practitioner/298F8D0B-C3B9-0598-4D0E-3ADB6F7B1DEF"
       } ],
@@ -9490,7 +9490,7 @@
         "reference": "Encounter/C11B5062-ADAC-11E2-9964-B639E5B05B1F"
       },
       "effectiveDateTime": "2000-03-31",
-      "issued": "2017-05-18T08:12:07.000+00:00",
+      "issued": "2000-03-31T00:00:00.000+00:00",
       "performer": [ {
         "reference": "Practitioner/298F8D0B-C3B9-0598-4D0E-3ADB6F7B1DEF"
       } ],
@@ -9537,7 +9537,7 @@
         "reference": "Encounter/C11B5062-ADAC-11E2-9964-B639E5B05B1F"
       },
       "effectiveDateTime": "2000-03-31",
-      "issued": "2017-05-18T08:12:07.000+00:00",
+      "issued": "2000-03-31T00:00:00.000+00:00",
       "performer": [ {
         "reference": "Practitioner/298F8D0B-C3B9-0598-4D0E-3ADB6F7B1DEF"
       } ],
@@ -9581,7 +9581,7 @@
         "reference": "Encounter/C11B5062-ADAC-11E2-9964-B639E5B05B1F"
       },
       "effectiveDateTime": "2000-03-31",
-      "issued": "2017-05-18T08:12:07.000+00:00",
+      "issued": "2000-03-31T00:00:00.000+00:00",
       "performer": [ {
         "reference": "Practitioner/298F8D0B-C3B9-0598-4D0E-3ADB6F7B1DEF"
       } ],
@@ -9625,7 +9625,7 @@
         "reference": "Encounter/C11B5062-ADAC-11E2-9964-B639E5B05B1F"
       },
       "effectiveDateTime": "2000-03-31",
-      "issued": "2017-05-18T08:12:07.000+00:00",
+      "issued": "2000-03-31T00:00:00.000+00:00",
       "performer": [ {
         "reference": "Practitioner/298F8D0B-C3B9-0598-4D0E-3ADB6F7B1DEF"
       } ],
@@ -9672,7 +9672,7 @@
         "reference": "Encounter/C11B5062-ADAC-11E2-9964-B639E5B05B1F"
       },
       "effectiveDateTime": "2000-03-31",
-      "issued": "2017-05-18T08:12:07.000+00:00",
+      "issued": "2000-03-31T00:00:00.000+00:00",
       "performer": [ {
         "reference": "Practitioner/298F8D0B-C3B9-0598-4D0E-3ADB6F7B1DEF"
       } ],
@@ -9719,7 +9719,7 @@
         "reference": "Encounter/C11B5062-ADAC-11E2-9964-B639E5B05B1F"
       },
       "effectiveDateTime": "2000-03-31",
-      "issued": "2017-05-18T08:12:07.000+00:00",
+      "issued": "2000-03-31T00:00:00.000+00:00",
       "performer": [ {
         "reference": "Practitioner/298F8D0B-C3B9-0598-4D0E-3ADB6F7B1DEF"
       } ],
@@ -9766,7 +9766,7 @@
         "reference": "Encounter/C11B5062-ADAC-11E2-9964-B639E5B05B1F"
       },
       "effectiveDateTime": "2000-03-31",
-      "issued": "2017-05-18T08:12:07.000+00:00",
+      "issued": "2000-03-31T00:00:00.000+00:00",
       "performer": [ {
         "reference": "Practitioner/298F8D0B-C3B9-0598-4D0E-3ADB6F7B1DEF"
       } ],
@@ -9813,7 +9813,7 @@
         "reference": "Encounter/C11B5062-ADAC-11E2-9964-B639E5B05B1F"
       },
       "effectiveDateTime": "2000-03-31",
-      "issued": "2017-05-18T08:12:07.000+00:00",
+      "issued": "2000-03-31T00:00:00.000+00:00",
       "performer": [ {
         "reference": "Practitioner/298F8D0B-C3B9-0598-4D0E-3ADB6F7B1DEF"
       } ],
@@ -9860,7 +9860,7 @@
         "reference": "Encounter/C11B5062-ADAC-11E2-9964-B639E5B05B1F"
       },
       "effectiveDateTime": "2000-03-31",
-      "issued": "2017-05-18T08:12:07.000+00:00",
+      "issued": "2000-03-31T00:00:00.000+00:00",
       "performer": [ {
         "reference": "Practitioner/298F8D0B-C3B9-0598-4D0E-3ADB6F7B1DEF"
       } ],
@@ -9907,7 +9907,7 @@
         "reference": "Encounter/C11B5062-ADAC-11E2-9964-B639E5B05B1F"
       },
       "effectiveDateTime": "2000-03-31",
-      "issued": "2017-05-18T08:12:07.000+00:00",
+      "issued": "2000-03-31T00:00:00.000+00:00",
       "performer": [ {
         "reference": "Practitioner/298F8D0B-C3B9-0598-4D0E-3ADB6F7B1DEF"
       } ],
@@ -9951,7 +9951,7 @@
         "reference": "Encounter/C11B5062-ADAC-11E2-9964-B639E5B05B1F"
       },
       "effectiveDateTime": "2000-03-31",
-      "issued": "2017-05-18T08:12:07.000+00:00",
+      "issued": "2000-03-31T00:00:00.000+00:00",
       "performer": [ {
         "reference": "Practitioner/298F8D0B-C3B9-0598-4D0E-3ADB6F7B1DEF"
       } ],
@@ -9995,7 +9995,7 @@
         "reference": "Encounter/C11B5062-ADAC-11E2-9964-B639E5B05B1F"
       },
       "effectiveDateTime": "2000-03-31",
-      "issued": "2017-05-18T08:12:07.000+00:00",
+      "issued": "2000-03-31T00:00:00.000+00:00",
       "performer": [ {
         "reference": "Practitioner/298F8D0B-C3B9-0598-4D0E-3ADB6F7B1DEF"
       } ],
@@ -10042,7 +10042,7 @@
         "reference": "Encounter/C11B5062-ADAC-11E2-9964-B639E5B05B1F"
       },
       "effectiveDateTime": "2000-03-31",
-      "issued": "2017-05-18T08:12:07.000+00:00",
+      "issued": "2000-03-31T00:00:00.000+00:00",
       "performer": [ {
         "reference": "Practitioner/298F8D0B-C3B9-0598-4D0E-3ADB6F7B1DEF"
       } ],
@@ -10089,7 +10089,7 @@
         "reference": "Encounter/C11B5062-ADAC-11E2-9964-B639E5B05B1F"
       },
       "effectiveDateTime": "2000-03-31",
-      "issued": "2017-05-18T08:12:07.000+00:00",
+      "issued": "2000-03-31T00:00:00.000+00:00",
       "performer": [ {
         "reference": "Practitioner/298F8D0B-C3B9-0598-4D0E-3ADB6F7B1DEF"
       } ],
@@ -10136,7 +10136,7 @@
         "reference": "Encounter/C11B5062-ADAC-11E2-9964-B639E5B05B1F"
       },
       "effectiveDateTime": "2000-03-31",
-      "issued": "2017-05-18T08:12:07.000+00:00",
+      "issued": "2000-03-31T00:00:00.000+00:00",
       "performer": [ {
         "reference": "Practitioner/298F8D0B-C3B9-0598-4D0E-3ADB6F7B1DEF"
       } ],
@@ -10180,7 +10180,7 @@
         "reference": "Encounter/C11B5062-ADAC-11E2-9964-B639E5B05B1F"
       },
       "effectiveDateTime": "2000-03-31",
-      "issued": "2017-05-18T08:12:07.000+00:00",
+      "issued": "2000-03-31T00:00:00.000+00:00",
       "performer": [ {
         "reference": "Practitioner/298F8D0B-C3B9-0598-4D0E-3ADB6F7B1DEF"
       } ],
@@ -10224,7 +10224,7 @@
         "reference": "Encounter/C11B5062-ADAC-11E2-9964-B639E5B05B1F"
       },
       "effectiveDateTime": "2000-03-31",
-      "issued": "2017-05-18T08:12:07.000+00:00",
+      "issued": "2000-03-31T00:00:00.000+00:00",
       "performer": [ {
         "reference": "Practitioner/298F8D0B-C3B9-0598-4D0E-3ADB6F7B1DEF"
       } ],
@@ -10268,7 +10268,7 @@
         "reference": "Encounter/C11B5062-ADAC-11E2-9964-B639E5B05B1F"
       },
       "effectiveDateTime": "2000-03-31",
-      "issued": "2017-05-18T08:12:07.000+00:00",
+      "issued": "2000-03-31T00:00:00.000+00:00",
       "performer": [ {
         "reference": "Practitioner/298F8D0B-C3B9-0598-4D0E-3ADB6F7B1DEF"
       } ],
@@ -10312,7 +10312,7 @@
         "reference": "Encounter/C11B5062-ADAC-11E2-9964-B639E5B05B1F"
       },
       "effectiveDateTime": "2000-03-31",
-      "issued": "2017-05-18T08:12:07.000+00:00",
+      "issued": "2000-03-31T00:00:00.000+00:00",
       "performer": [ {
         "reference": "Practitioner/298F8D0B-C3B9-0598-4D0E-3ADB6F7B1DEF"
       } ],
@@ -10356,7 +10356,7 @@
         "reference": "Encounter/C11B5062-ADAC-11E2-9964-B639E5B05B1F"
       },
       "effectiveDateTime": "2000-03-31",
-      "issued": "2017-05-18T08:12:07.000+00:00",
+      "issued": "2000-03-31T00:00:00.000+00:00",
       "performer": [ {
         "reference": "Practitioner/298F8D0B-C3B9-0598-4D0E-3ADB6F7B1DEF"
       } ],
@@ -10400,7 +10400,7 @@
         "reference": "Encounter/C11B5062-ADAC-11E2-9964-B639E5B05B1F"
       },
       "effectiveDateTime": "2000-03-31",
-      "issued": "2017-05-18T08:12:07.000+00:00",
+      "issued": "2000-03-31T00:00:00.000+00:00",
       "performer": [ {
         "reference": "Practitioner/298F8D0B-C3B9-0598-4D0E-3ADB6F7B1DEF"
       } ],
@@ -10447,7 +10447,7 @@
         "reference": "Encounter/C11B5062-ADAC-11E2-9964-B639E5B05B1F"
       },
       "effectiveDateTime": "2000-03-31",
-      "issued": "2017-05-18T08:12:07.000+00:00",
+      "issued": "2000-03-31T00:00:00.000+00:00",
       "performer": [ {
         "reference": "Practitioner/298F8D0B-C3B9-0598-4D0E-3ADB6F7B1DEF"
       } ],
@@ -10491,7 +10491,7 @@
         "reference": "Encounter/C11B5062-ADAC-11E2-9964-B639E5B05B1F"
       },
       "effectiveDateTime": "2000-03-31",
-      "issued": "2017-05-18T08:12:07.000+00:00",
+      "issued": "2000-03-31T00:00:00.000+00:00",
       "performer": [ {
         "reference": "Practitioner/298F8D0B-C3B9-0598-4D0E-3ADB6F7B1DEF"
       } ],
@@ -10535,7 +10535,7 @@
         "reference": "Encounter/C11B5062-ADAC-11E2-9964-B639E5B05B1F"
       },
       "effectiveDateTime": "2000-03-31",
-      "issued": "2017-05-18T08:12:07.000+00:00",
+      "issued": "2000-03-31T00:00:00.000+00:00",
       "performer": [ {
         "reference": "Practitioner/298F8D0B-C3B9-0598-4D0E-3ADB6F7B1DEF"
       } ],

--- a/gp2gp-translator/src/integrationTest/resources/json/LargeMessage/expectedBundleScenario11.json
+++ b/gp2gp-translator/src/integrationTest/resources/json/LargeMessage/expectedBundleScenario11.json
@@ -1,6 +1,6 @@
 {
   "resourceType": "Bundle",
-  "id": "00000000-0000-0000-0000-000000000001",
+  "id": "00000000-0000-0000-0000-000000000002",
   "meta": {
     "profile": [ "https://fhir.nhs.uk/STU3/StructureDefinition/GPConnect-StructuredRecord-Bundle-1" ]
   },
@@ -8,7 +8,7 @@
   "entry": [ {
     "resource": {
       "resourceType": "Patient",
-      "id": "00000000-0000-0000-0000-000000000002",
+      "id": "00000000-0000-0000-0000-000000000003",
       "meta": {
         "versionId": "1521806400000",
         "profile": [ "https://fhir.nhs.uk/STU3/StructureDefinition/CareConnect-GPC-Patient-1" ]
@@ -106,7 +106,7 @@
         "text": "GP Surgery"
       } ],
       "subject": {
-        "reference": "Patient/00000000-0000-0000-0000-000000000002"
+        "reference": "Patient/00000000-0000-0000-0000-000000000003"
       },
       "participant": [ {
         "type": [ {
@@ -163,7 +163,7 @@
         "text": "GP Surgery"
       } ],
       "subject": {
-        "reference": "Patient/00000000-0000-0000-0000-000000000002"
+        "reference": "Patient/00000000-0000-0000-0000-000000000003"
       },
       "participant": [ {
         "type": [ {
@@ -210,7 +210,7 @@
         } ]
       },
       "subject": {
-        "reference": "Patient/00000000-0000-0000-0000-000000000002"
+        "reference": "Patient/00000000-0000-0000-0000-000000000003"
       },
       "encounter": {
         "reference": "Encounter/C07745C6-ADAC-11E2-883C-B639E5B05B1F"
@@ -247,7 +247,7 @@
         } ]
       },
       "subject": {
-        "reference": "Patient/00000000-0000-0000-0000-000000000002"
+        "reference": "Patient/00000000-0000-0000-0000-000000000003"
       },
       "encounter": {
         "reference": "Encounter/C11B5062-ADAC-11E2-9964-B639E5B05B1F"
@@ -284,7 +284,7 @@
         } ]
       },
       "subject": {
-        "reference": "Patient/00000000-0000-0000-0000-000000000002"
+        "reference": "Patient/00000000-0000-0000-0000-000000000003"
       },
       "encounter": {
         "reference": "Encounter/C07745C6-ADAC-11E2-883C-B639E5B05B1F"
@@ -321,7 +321,7 @@
         } ]
       },
       "subject": {
-        "reference": "Patient/00000000-0000-0000-0000-000000000002"
+        "reference": "Patient/00000000-0000-0000-0000-000000000003"
       },
       "encounter": {
         "reference": "Encounter/C11B5062-ADAC-11E2-9964-B639E5B05B1F"
@@ -358,7 +358,7 @@
         } ]
       },
       "subject": {
-        "reference": "Patient/00000000-0000-0000-0000-000000000002"
+        "reference": "Patient/00000000-0000-0000-0000-000000000003"
       },
       "encounter": {
         "reference": "Encounter/C07745C6-ADAC-11E2-883C-B639E5B05B1F"
@@ -791,7 +791,7 @@
         } ]
       },
       "subject": {
-        "reference": "Patient/00000000-0000-0000-0000-000000000002"
+        "reference": "Patient/00000000-0000-0000-0000-000000000003"
       },
       "encounter": {
         "reference": "Encounter/C11B5062-ADAC-11E2-9964-B639E5B05B1F"
@@ -1209,7 +1209,7 @@
   }, {
     "resource": {
       "resourceType": "Medication",
-      "id": "00000000-0000-0000-0000-000000000004",
+      "id": "00000000-0000-0000-0000-000000000005",
       "meta": {
         "profile": [ "https://fhir.nhs.uk/STU3/StructureDefinition/CareConnect-GPC-Medication-1" ]
       },
@@ -1253,10 +1253,10 @@
       "status": "completed",
       "intent": "order",
       "medicationReference": {
-        "reference": "Medication/00000000-0000-0000-0000-000000000004"
+        "reference": "Medication/00000000-0000-0000-0000-000000000005"
       },
       "subject": {
-        "reference": "Patient/00000000-0000-0000-0000-000000000002"
+        "reference": "Patient/00000000-0000-0000-0000-000000000003"
       },
       "authoredOn": "2016-09-01",
       "requester": {
@@ -1307,10 +1307,10 @@
       "status": "completed",
       "intent": "order",
       "medicationReference": {
-        "reference": "Medication/00000000-0000-0000-0000-000000000004"
+        "reference": "Medication/00000000-0000-0000-0000-000000000005"
       },
       "subject": {
-        "reference": "Patient/00000000-0000-0000-0000-000000000002"
+        "reference": "Patient/00000000-0000-0000-0000-000000000003"
       },
       "authoredOn": "2016-09-01",
       "requester": {
@@ -1361,10 +1361,10 @@
       "status": "completed",
       "intent": "order",
       "medicationReference": {
-        "reference": "Medication/00000000-0000-0000-0000-000000000004"
+        "reference": "Medication/00000000-0000-0000-0000-000000000005"
       },
       "subject": {
-        "reference": "Patient/00000000-0000-0000-0000-000000000002"
+        "reference": "Patient/00000000-0000-0000-0000-000000000003"
       },
       "authoredOn": "2016-09-01",
       "requester": {
@@ -1415,10 +1415,10 @@
       "status": "completed",
       "intent": "order",
       "medicationReference": {
-        "reference": "Medication/00000000-0000-0000-0000-000000000004"
+        "reference": "Medication/00000000-0000-0000-0000-000000000005"
       },
       "subject": {
-        "reference": "Patient/00000000-0000-0000-0000-000000000002"
+        "reference": "Patient/00000000-0000-0000-0000-000000000003"
       },
       "authoredOn": "2016-09-01",
       "requester": {
@@ -1445,7 +1445,7 @@
   }, {
     "resource": {
       "resourceType": "Medication",
-      "id": "00000000-0000-0000-0000-000000000005",
+      "id": "00000000-0000-0000-0000-000000000006",
       "meta": {
         "profile": [ "https://fhir.nhs.uk/STU3/StructureDefinition/CareConnect-GPC-Medication-1" ]
       },
@@ -1489,10 +1489,10 @@
       "status": "completed",
       "intent": "order",
       "medicationReference": {
-        "reference": "Medication/00000000-0000-0000-0000-000000000005"
+        "reference": "Medication/00000000-0000-0000-0000-000000000006"
       },
       "subject": {
-        "reference": "Patient/00000000-0000-0000-0000-000000000002"
+        "reference": "Patient/00000000-0000-0000-0000-000000000003"
       },
       "authoredOn": "2016-09-01",
       "requester": {
@@ -1548,13 +1548,13 @@
         "text": "Fibreoptic endoscopic sclerotherapy to lesion upper GI tract"
       },
       "subject": {
-        "reference": "Patient/00000000-0000-0000-0000-000000000002"
+        "reference": "Patient/00000000-0000-0000-0000-000000000003"
       },
       "context": {
         "reference": "Encounter/C07745C6-ADAC-11E2-883C-B639E5B05B1F"
       },
       "effectiveDateTime": "2000-03-31",
-      "issued": "2017-05-18T08:12:07.000+00:00",
+      "issued": "2000-03-31T00:00:00.000+00:00",
       "performer": [ {
         "reference": "Practitioner/298F8D0B-C3B9-0598-4D0E-3ADB6F7B1DEF"
       } ],
@@ -1592,13 +1592,13 @@
         "text": "Fibreoptic endoscopic destruction lesion upper GI tract NEC"
       },
       "subject": {
-        "reference": "Patient/00000000-0000-0000-0000-000000000002"
+        "reference": "Patient/00000000-0000-0000-0000-000000000003"
       },
       "context": {
         "reference": "Encounter/C07745C6-ADAC-11E2-883C-B639E5B05B1F"
       },
       "effectiveDateTime": "2000-03-31",
-      "issued": "2017-05-18T08:12:07.000+00:00",
+      "issued": "2000-03-31T00:00:00.000+00:00",
       "performer": [ {
         "reference": "Practitioner/298F8D0B-C3B9-0598-4D0E-3ADB6F7B1DEF"
       } ],
@@ -1639,13 +1639,13 @@
         "text": "Endoscopic injection haemostasis of duodenal ulcer"
       },
       "subject": {
-        "reference": "Patient/00000000-0000-0000-0000-000000000002"
+        "reference": "Patient/00000000-0000-0000-0000-000000000003"
       },
       "context": {
         "reference": "Encounter/C07745C6-ADAC-11E2-883C-B639E5B05B1F"
       },
       "effectiveDateTime": "2000-03-31",
-      "issued": "2017-05-18T08:12:07.000+00:00",
+      "issued": "2000-03-31T00:00:00.000+00:00",
       "performer": [ {
         "reference": "Practitioner/298F8D0B-C3B9-0598-4D0E-3ADB6F7B1DEF"
       } ],
@@ -1686,13 +1686,13 @@
         "text": "Endoscopic injection haemostasis of gastric ulcer"
       },
       "subject": {
-        "reference": "Patient/00000000-0000-0000-0000-000000000002"
+        "reference": "Patient/00000000-0000-0000-0000-000000000003"
       },
       "context": {
         "reference": "Encounter/C07745C6-ADAC-11E2-883C-B639E5B05B1F"
       },
       "effectiveDateTime": "2000-03-31",
-      "issued": "2017-05-18T08:12:07.000+00:00",
+      "issued": "2000-03-31T00:00:00.000+00:00",
       "performer": [ {
         "reference": "Practitioner/298F8D0B-C3B9-0598-4D0E-3ADB6F7B1DEF"
       } ],
@@ -1730,13 +1730,13 @@
         "text": "Fibre endosc injec therapy les upper gastrointest tract NEC"
       },
       "subject": {
-        "reference": "Patient/00000000-0000-0000-0000-000000000002"
+        "reference": "Patient/00000000-0000-0000-0000-000000000003"
       },
       "context": {
         "reference": "Encounter/C07745C6-ADAC-11E2-883C-B639E5B05B1F"
       },
       "effectiveDateTime": "2000-03-31",
-      "issued": "2017-05-18T08:12:07.000+00:00",
+      "issued": "2000-03-31T00:00:00.000+00:00",
       "performer": [ {
         "reference": "Practitioner/298F8D0B-C3B9-0598-4D0E-3ADB6F7B1DEF"
       } ],
@@ -1774,13 +1774,13 @@
         "text": "Fibreopt endoscop rubber band ligation of upper GIT varices"
       },
       "subject": {
-        "reference": "Patient/00000000-0000-0000-0000-000000000002"
+        "reference": "Patient/00000000-0000-0000-0000-000000000003"
       },
       "context": {
         "reference": "Encounter/C07745C6-ADAC-11E2-883C-B639E5B05B1F"
       },
       "effectiveDateTime": "2000-03-31",
-      "issued": "2017-05-18T08:12:07.000+00:00",
+      "issued": "2000-03-31T00:00:00.000+00:00",
       "performer": [ {
         "reference": "Practitioner/298F8D0B-C3B9-0598-4D0E-3ADB6F7B1DEF"
       } ],
@@ -1818,13 +1818,13 @@
         "text": "Fibreoptic endoscopic extirpation lesion upper GI tract OS"
       },
       "subject": {
-        "reference": "Patient/00000000-0000-0000-0000-000000000002"
+        "reference": "Patient/00000000-0000-0000-0000-000000000003"
       },
       "context": {
         "reference": "Encounter/C07745C6-ADAC-11E2-883C-B639E5B05B1F"
       },
       "effectiveDateTime": "2000-03-31",
-      "issued": "2017-05-18T08:12:07.000+00:00",
+      "issued": "2000-03-31T00:00:00.000+00:00",
       "performer": [ {
         "reference": "Practitioner/298F8D0B-C3B9-0598-4D0E-3ADB6F7B1DEF"
       } ],
@@ -1862,13 +1862,13 @@
         "text": "Fibreoptic endoscopic extirpation lesion upper GI tract NOS"
       },
       "subject": {
-        "reference": "Patient/00000000-0000-0000-0000-000000000002"
+        "reference": "Patient/00000000-0000-0000-0000-000000000003"
       },
       "context": {
         "reference": "Encounter/C07745C6-ADAC-11E2-883C-B639E5B05B1F"
       },
       "effectiveDateTime": "2000-03-31",
-      "issued": "2017-05-18T08:12:07.000+00:00",
+      "issued": "2000-03-31T00:00:00.000+00:00",
       "performer": [ {
         "reference": "Practitioner/298F8D0B-C3B9-0598-4D0E-3ADB6F7B1DEF"
       } ],
@@ -1906,13 +1906,13 @@
         "text": "Other therapeutic fibreoptic endoscopy on upper GI tract"
       },
       "subject": {
-        "reference": "Patient/00000000-0000-0000-0000-000000000002"
+        "reference": "Patient/00000000-0000-0000-0000-000000000003"
       },
       "context": {
         "reference": "Encounter/C07745C6-ADAC-11E2-883C-B639E5B05B1F"
       },
       "effectiveDateTime": "2000-03-31",
-      "issued": "2017-05-18T08:12:07.000+00:00",
+      "issued": "2000-03-31T00:00:00.000+00:00",
       "performer": [ {
         "reference": "Practitioner/298F8D0B-C3B9-0598-4D0E-3ADB6F7B1DEF"
       } ],
@@ -1950,13 +1950,13 @@
         "text": "Other therapeutic gastroscopy"
       },
       "subject": {
-        "reference": "Patient/00000000-0000-0000-0000-000000000002"
+        "reference": "Patient/00000000-0000-0000-0000-000000000003"
       },
       "context": {
         "reference": "Encounter/C07745C6-ADAC-11E2-883C-B639E5B05B1F"
       },
       "effectiveDateTime": "2000-03-31",
-      "issued": "2017-05-18T08:12:07.000+00:00",
+      "issued": "2000-03-31T00:00:00.000+00:00",
       "performer": [ {
         "reference": "Practitioner/298F8D0B-C3B9-0598-4D0E-3ADB6F7B1DEF"
       } ],
@@ -1994,13 +1994,13 @@
         "text": "Fibreoptic endoscopic insertion prosthesis in upper GI tract"
       },
       "subject": {
-        "reference": "Patient/00000000-0000-0000-0000-000000000002"
+        "reference": "Patient/00000000-0000-0000-0000-000000000003"
       },
       "context": {
         "reference": "Encounter/C07745C6-ADAC-11E2-883C-B639E5B05B1F"
       },
       "effectiveDateTime": "2000-03-31",
-      "issued": "2017-05-18T08:12:07.000+00:00",
+      "issued": "2000-03-31T00:00:00.000+00:00",
       "performer": [ {
         "reference": "Practitioner/298F8D0B-C3B9-0598-4D0E-3ADB6F7B1DEF"
       } ],
@@ -2038,13 +2038,13 @@
         "text": "Fibreoptic endoscopic removal of FB from upper GI tract"
       },
       "subject": {
-        "reference": "Patient/00000000-0000-0000-0000-000000000002"
+        "reference": "Patient/00000000-0000-0000-0000-000000000003"
       },
       "context": {
         "reference": "Encounter/C07745C6-ADAC-11E2-883C-B639E5B05B1F"
       },
       "effectiveDateTime": "2000-03-31",
-      "issued": "2017-05-18T08:12:07.000+00:00",
+      "issued": "2000-03-31T00:00:00.000+00:00",
       "performer": [ {
         "reference": "Practitioner/298F8D0B-C3B9-0598-4D0E-3ADB6F7B1DEF"
       } ],
@@ -2082,13 +2082,13 @@
         "text": "Fibreoptic endoscopic dilation of upper GI tract"
       },
       "subject": {
-        "reference": "Patient/00000000-0000-0000-0000-000000000002"
+        "reference": "Patient/00000000-0000-0000-0000-000000000003"
       },
       "context": {
         "reference": "Encounter/C07745C6-ADAC-11E2-883C-B639E5B05B1F"
       },
       "effectiveDateTime": "2000-03-31",
-      "issued": "2017-05-18T08:12:07.000+00:00",
+      "issued": "2000-03-31T00:00:00.000+00:00",
       "performer": [ {
         "reference": "Practitioner/298F8D0B-C3B9-0598-4D0E-3ADB6F7B1DEF"
       } ],
@@ -2126,13 +2126,13 @@
         "text": "Fibreoptic dilation of oesophagus"
       },
       "subject": {
-        "reference": "Patient/00000000-0000-0000-0000-000000000002"
+        "reference": "Patient/00000000-0000-0000-0000-000000000003"
       },
       "context": {
         "reference": "Encounter/C07745C6-ADAC-11E2-883C-B639E5B05B1F"
       },
       "effectiveDateTime": "2000-03-31",
-      "issued": "2017-05-18T08:12:07.000+00:00",
+      "issued": "2000-03-31T00:00:00.000+00:00",
       "performer": [ {
         "reference": "Practitioner/298F8D0B-C3B9-0598-4D0E-3ADB6F7B1DEF"
       } ],
@@ -2173,13 +2173,13 @@
         "text": "Temporary percutaneous endoscopic gastrostomy"
       },
       "subject": {
-        "reference": "Patient/00000000-0000-0000-0000-000000000002"
+        "reference": "Patient/00000000-0000-0000-0000-000000000003"
       },
       "context": {
         "reference": "Encounter/C07745C6-ADAC-11E2-883C-B639E5B05B1F"
       },
       "effectiveDateTime": "2000-03-31",
-      "issued": "2017-05-18T08:12:07.000+00:00",
+      "issued": "2000-03-31T00:00:00.000+00:00",
       "performer": [ {
         "reference": "Practitioner/298F8D0B-C3B9-0598-4D0E-3ADB6F7B1DEF"
       } ],
@@ -2220,13 +2220,13 @@
         "text": "Permanent percutaneous endoscopic gastrostomy"
       },
       "subject": {
-        "reference": "Patient/00000000-0000-0000-0000-000000000002"
+        "reference": "Patient/00000000-0000-0000-0000-000000000003"
       },
       "context": {
         "reference": "Encounter/C07745C6-ADAC-11E2-883C-B639E5B05B1F"
       },
       "effectiveDateTime": "2000-03-31",
-      "issued": "2017-05-18T08:12:07.000+00:00",
+      "issued": "2000-03-31T00:00:00.000+00:00",
       "performer": [ {
         "reference": "Practitioner/298F8D0B-C3B9-0598-4D0E-3ADB6F7B1DEF"
       } ],
@@ -2264,13 +2264,13 @@
         "text": "Fibreop endoscop reduction intussusception gastroenterostomy"
       },
       "subject": {
-        "reference": "Patient/00000000-0000-0000-0000-000000000002"
+        "reference": "Patient/00000000-0000-0000-0000-000000000003"
       },
       "context": {
         "reference": "Encounter/C07745C6-ADAC-11E2-883C-B639E5B05B1F"
       },
       "effectiveDateTime": "2000-03-31",
-      "issued": "2017-05-18T08:12:07.000+00:00",
+      "issued": "2000-03-31T00:00:00.000+00:00",
       "performer": [ {
         "reference": "Practitioner/298F8D0B-C3B9-0598-4D0E-3ADB6F7B1DEF"
       } ],
@@ -2308,13 +2308,13 @@
         "text": "Fibreoptic endoscopic percutaneous insert gastrostomy (PEG)"
       },
       "subject": {
-        "reference": "Patient/00000000-0000-0000-0000-000000000002"
+        "reference": "Patient/00000000-0000-0000-0000-000000000003"
       },
       "context": {
         "reference": "Encounter/C07745C6-ADAC-11E2-883C-B639E5B05B1F"
       },
       "effectiveDateTime": "2000-03-31",
-      "issued": "2017-05-18T08:12:07.000+00:00",
+      "issued": "2000-03-31T00:00:00.000+00:00",
       "performer": [ {
         "reference": "Practitioner/298F8D0B-C3B9-0598-4D0E-3ADB6F7B1DEF"
       } ],
@@ -2352,13 +2352,13 @@
         "text": "Fib end pressure-controlled balloon dilat low oesoph sphinc"
       },
       "subject": {
-        "reference": "Patient/00000000-0000-0000-0000-000000000002"
+        "reference": "Patient/00000000-0000-0000-0000-000000000003"
       },
       "context": {
         "reference": "Encounter/C07745C6-ADAC-11E2-883C-B639E5B05B1F"
       },
       "effectiveDateTime": "2000-03-31",
-      "issued": "2017-05-18T08:12:07.000+00:00",
+      "issued": "2000-03-31T00:00:00.000+00:00",
       "performer": [ {
         "reference": "Practitioner/298F8D0B-C3B9-0598-4D0E-3ADB6F7B1DEF"
       } ],
@@ -2396,13 +2396,13 @@
         "text": "Fibreoptic endoscopic dilation of upper GI tract NEC"
       },
       "subject": {
-        "reference": "Patient/00000000-0000-0000-0000-000000000002"
+        "reference": "Patient/00000000-0000-0000-0000-000000000003"
       },
       "context": {
         "reference": "Encounter/C07745C6-ADAC-11E2-883C-B639E5B05B1F"
       },
       "effectiveDateTime": "2000-03-31",
-      "issued": "2017-05-18T08:12:07.000+00:00",
+      "issued": "2000-03-31T00:00:00.000+00:00",
       "performer": [ {
         "reference": "Practitioner/298F8D0B-C3B9-0598-4D0E-3ADB6F7B1DEF"
       } ],
@@ -2443,13 +2443,13 @@
         "text": "Fibreoptic endoscopic removal of gastrostomy tube"
       },
       "subject": {
-        "reference": "Patient/00000000-0000-0000-0000-000000000002"
+        "reference": "Patient/00000000-0000-0000-0000-000000000003"
       },
       "context": {
         "reference": "Encounter/C07745C6-ADAC-11E2-883C-B639E5B05B1F"
       },
       "effectiveDateTime": "2000-03-31",
-      "issued": "2017-05-18T08:12:07.000+00:00",
+      "issued": "2000-03-31T00:00:00.000+00:00",
       "performer": [ {
         "reference": "Practitioner/298F8D0B-C3B9-0598-4D0E-3ADB6F7B1DEF"
       } ],
@@ -2490,13 +2490,13 @@
         "text": "Fibreoptic endoscopic percutaneous insertion of gastrostomy"
       },
       "subject": {
-        "reference": "Patient/00000000-0000-0000-0000-000000000002"
+        "reference": "Patient/00000000-0000-0000-0000-000000000003"
       },
       "context": {
         "reference": "Encounter/C07745C6-ADAC-11E2-883C-B639E5B05B1F"
       },
       "effectiveDateTime": "2000-03-31",
-      "issued": "2017-05-18T08:12:07.000+00:00",
+      "issued": "2000-03-31T00:00:00.000+00:00",
       "performer": [ {
         "reference": "Practitioner/298F8D0B-C3B9-0598-4D0E-3ADB6F7B1DEF"
       } ],
@@ -2534,13 +2534,13 @@
         "text": "Other fibreoptic therapeutic endoscopy on upper GI tract OS"
       },
       "subject": {
-        "reference": "Patient/00000000-0000-0000-0000-000000000002"
+        "reference": "Patient/00000000-0000-0000-0000-000000000003"
       },
       "context": {
         "reference": "Encounter/C07745C6-ADAC-11E2-883C-B639E5B05B1F"
       },
       "effectiveDateTime": "2000-03-31",
-      "issued": "2017-05-18T08:12:07.000+00:00",
+      "issued": "2000-03-31T00:00:00.000+00:00",
       "performer": [ {
         "reference": "Practitioner/298F8D0B-C3B9-0598-4D0E-3ADB6F7B1DEF"
       } ],
@@ -2578,13 +2578,13 @@
         "text": "Other fibreoptic therapeutic endoscopy on upper GI tract NOS"
       },
       "subject": {
-        "reference": "Patient/00000000-0000-0000-0000-000000000002"
+        "reference": "Patient/00000000-0000-0000-0000-000000000003"
       },
       "context": {
         "reference": "Encounter/C07745C6-ADAC-11E2-883C-B639E5B05B1F"
       },
       "effectiveDateTime": "2000-03-31",
-      "issued": "2017-05-18T08:12:07.000+00:00",
+      "issued": "2000-03-31T00:00:00.000+00:00",
       "performer": [ {
         "reference": "Practitioner/298F8D0B-C3B9-0598-4D0E-3ADB6F7B1DEF"
       } ],
@@ -2622,13 +2622,13 @@
         "text": "Diagnostic fibreoptic endoscopic exam of upper GI tract"
       },
       "subject": {
-        "reference": "Patient/00000000-0000-0000-0000-000000000002"
+        "reference": "Patient/00000000-0000-0000-0000-000000000003"
       },
       "context": {
         "reference": "Encounter/C07745C6-ADAC-11E2-883C-B639E5B05B1F"
       },
       "effectiveDateTime": "2000-03-31",
-      "issued": "2017-05-18T08:12:07.000+00:00",
+      "issued": "2000-03-31T00:00:00.000+00:00",
       "performer": [ {
         "reference": "Practitioner/298F8D0B-C3B9-0598-4D0E-3ADB6F7B1DEF"
       } ],
@@ -2666,13 +2666,13 @@
         "text": "Diagnostic fibreoptic gastroscopy"
       },
       "subject": {
-        "reference": "Patient/00000000-0000-0000-0000-000000000002"
+        "reference": "Patient/00000000-0000-0000-0000-000000000003"
       },
       "context": {
         "reference": "Encounter/C07745C6-ADAC-11E2-883C-B639E5B05B1F"
       },
       "effectiveDateTime": "2000-03-31",
-      "issued": "2017-05-18T08:12:07.000+00:00",
+      "issued": "2000-03-31T00:00:00.000+00:00",
       "performer": [ {
         "reference": "Practitioner/298F8D0B-C3B9-0598-4D0E-3ADB6F7B1DEF"
       } ],
@@ -2710,13 +2710,13 @@
         "text": "Diagnostic fibreoptic endoscopy & biopsy of upper GI tract"
       },
       "subject": {
-        "reference": "Patient/00000000-0000-0000-0000-000000000002"
+        "reference": "Patient/00000000-0000-0000-0000-000000000003"
       },
       "context": {
         "reference": "Encounter/C07745C6-ADAC-11E2-883C-B639E5B05B1F"
       },
       "effectiveDateTime": "2000-03-31",
-      "issued": "2017-05-18T08:12:07.000+00:00",
+      "issued": "2000-03-31T00:00:00.000+00:00",
       "performer": [ {
         "reference": "Practitioner/298F8D0B-C3B9-0598-4D0E-3ADB6F7B1DEF"
       } ],
@@ -2754,13 +2754,13 @@
         "text": "Diagnostic gastroscopy NEC"
       },
       "subject": {
-        "reference": "Patient/00000000-0000-0000-0000-000000000002"
+        "reference": "Patient/00000000-0000-0000-0000-000000000003"
       },
       "context": {
         "reference": "Encounter/C07745C6-ADAC-11E2-883C-B639E5B05B1F"
       },
       "effectiveDateTime": "2000-03-31",
-      "issued": "2017-05-18T08:12:07.000+00:00",
+      "issued": "2000-03-31T00:00:00.000+00:00",
       "performer": [ {
         "reference": "Practitioner/298F8D0B-C3B9-0598-4D0E-3ADB6F7B1DEF"
       } ],
@@ -2801,13 +2801,13 @@
         "text": "Diagnostic gastroscopy via stoma"
       },
       "subject": {
-        "reference": "Patient/00000000-0000-0000-0000-000000000002"
+        "reference": "Patient/00000000-0000-0000-0000-000000000003"
       },
       "context": {
         "reference": "Encounter/C07745C6-ADAC-11E2-883C-B639E5B05B1F"
       },
       "effectiveDateTime": "2000-03-31",
-      "issued": "2017-05-18T08:12:07.000+00:00",
+      "issued": "2000-03-31T00:00:00.000+00:00",
       "performer": [ {
         "reference": "Practitioner/298F8D0B-C3B9-0598-4D0E-3ADB6F7B1DEF"
       } ],
@@ -2848,13 +2848,13 @@
         "text": "Gastroesophagoscopy via gastrotomy"
       },
       "subject": {
-        "reference": "Patient/00000000-0000-0000-0000-000000000002"
+        "reference": "Patient/00000000-0000-0000-0000-000000000003"
       },
       "context": {
         "reference": "Encounter/C07745C6-ADAC-11E2-883C-B639E5B05B1F"
       },
       "effectiveDateTime": "2000-03-31",
-      "issued": "2017-05-18T08:12:07.000+00:00",
+      "issued": "2000-03-31T00:00:00.000+00:00",
       "performer": [ {
         "reference": "Practitioner/298F8D0B-C3B9-0598-4D0E-3ADB6F7B1DEF"
       } ],
@@ -2892,13 +2892,13 @@
         "text": "Endoscopic upper gastrointestinal ultrasound"
       },
       "subject": {
-        "reference": "Patient/00000000-0000-0000-0000-000000000002"
+        "reference": "Patient/00000000-0000-0000-0000-000000000003"
       },
       "context": {
         "reference": "Encounter/C07745C6-ADAC-11E2-883C-B639E5B05B1F"
       },
       "effectiveDateTime": "2000-03-31",
-      "issued": "2017-05-18T08:12:07.000+00:00",
+      "issued": "2000-03-31T00:00:00.000+00:00",
       "performer": [ {
         "reference": "Practitioner/298F8D0B-C3B9-0598-4D0E-3ADB6F7B1DEF"
       } ],
@@ -2936,13 +2936,13 @@
         "text": "Fibreoptic endoscopic ultrasound examination of upper GIT"
       },
       "subject": {
-        "reference": "Patient/00000000-0000-0000-0000-000000000002"
+        "reference": "Patient/00000000-0000-0000-0000-000000000003"
       },
       "context": {
         "reference": "Encounter/C07745C6-ADAC-11E2-883C-B639E5B05B1F"
       },
       "effectiveDateTime": "2000-03-31",
-      "issued": "2017-05-18T08:12:07.000+00:00",
+      "issued": "2000-03-31T00:00:00.000+00:00",
       "performer": [ {
         "reference": "Practitioner/298F8D0B-C3B9-0598-4D0E-3ADB6F7B1DEF"
       } ],
@@ -2980,13 +2980,13 @@
         "text": "Diag fibre endos insert Bravo pH caps upper gastroint tract"
       },
       "subject": {
-        "reference": "Patient/00000000-0000-0000-0000-000000000002"
+        "reference": "Patient/00000000-0000-0000-0000-000000000003"
       },
       "context": {
         "reference": "Encounter/C07745C6-ADAC-11E2-883C-B639E5B05B1F"
       },
       "effectiveDateTime": "2000-03-31",
-      "issued": "2017-05-18T08:12:07.000+00:00",
+      "issued": "2000-03-31T00:00:00.000+00:00",
       "performer": [ {
         "reference": "Practitioner/298F8D0B-C3B9-0598-4D0E-3ADB6F7B1DEF"
       } ],
@@ -3024,13 +3024,13 @@
         "text": "Fibr endos exam upp gastrointest tract stain gastric mucosa"
       },
       "subject": {
-        "reference": "Patient/00000000-0000-0000-0000-000000000002"
+        "reference": "Patient/00000000-0000-0000-0000-000000000003"
       },
       "context": {
         "reference": "Encounter/C07745C6-ADAC-11E2-883C-B639E5B05B1F"
       },
       "effectiveDateTime": "2000-03-31",
-      "issued": "2017-05-18T08:12:07.000+00:00",
+      "issued": "2000-03-31T00:00:00.000+00:00",
       "performer": [ {
         "reference": "Practitioner/298F8D0B-C3B9-0598-4D0E-3ADB6F7B1DEF"
       } ],
@@ -3068,13 +3068,13 @@
         "text": "Diagnostic fibreoptic endoscopic exam upper GI tract OS"
       },
       "subject": {
-        "reference": "Patient/00000000-0000-0000-0000-000000000002"
+        "reference": "Patient/00000000-0000-0000-0000-000000000003"
       },
       "context": {
         "reference": "Encounter/C07745C6-ADAC-11E2-883C-B639E5B05B1F"
       },
       "effectiveDateTime": "2000-03-31",
-      "issued": "2017-05-18T08:12:07.000+00:00",
+      "issued": "2000-03-31T00:00:00.000+00:00",
       "performer": [ {
         "reference": "Practitioner/298F8D0B-C3B9-0598-4D0E-3ADB6F7B1DEF"
       } ],
@@ -3112,13 +3112,13 @@
         "text": "Diagnostic fibreoptic endoscopic exam upper GI tract NOS"
       },
       "subject": {
-        "reference": "Patient/00000000-0000-0000-0000-000000000002"
+        "reference": "Patient/00000000-0000-0000-0000-000000000003"
       },
       "context": {
         "reference": "Encounter/C07745C6-ADAC-11E2-883C-B639E5B05B1F"
       },
       "effectiveDateTime": "2000-03-31",
-      "issued": "2017-05-18T08:12:07.000+00:00",
+      "issued": "2000-03-31T00:00:00.000+00:00",
       "performer": [ {
         "reference": "Practitioner/298F8D0B-C3B9-0598-4D0E-3ADB6F7B1DEF"
       } ],
@@ -3156,13 +3156,13 @@
         "text": "Gastroscopy NEC"
       },
       "subject": {
-        "reference": "Patient/00000000-0000-0000-0000-000000000002"
+        "reference": "Patient/00000000-0000-0000-0000-000000000003"
       },
       "context": {
         "reference": "Encounter/C07745C6-ADAC-11E2-883C-B639E5B05B1F"
       },
       "effectiveDateTime": "2000-03-31",
-      "issued": "2017-05-18T08:12:07.000+00:00",
+      "issued": "2000-03-31T00:00:00.000+00:00",
       "performer": [ {
         "reference": "Practitioner/298F8D0B-C3B9-0598-4D0E-3ADB6F7B1DEF"
       } ],
@@ -3203,13 +3203,13 @@
         "text": "Upper Gastrointestinal endoscopy"
       },
       "subject": {
-        "reference": "Patient/00000000-0000-0000-0000-000000000002"
+        "reference": "Patient/00000000-0000-0000-0000-000000000003"
       },
       "context": {
         "reference": "Encounter/C07745C6-ADAC-11E2-883C-B639E5B05B1F"
       },
       "effectiveDateTime": "2000-03-31",
-      "issued": "2017-05-18T08:12:07.000+00:00",
+      "issued": "2000-03-31T00:00:00.000+00:00",
       "performer": [ {
         "reference": "Practitioner/298F8D0B-C3B9-0598-4D0E-3ADB6F7B1DEF"
       } ],
@@ -3250,13 +3250,13 @@
         "text": "Intubation of stomach"
       },
       "subject": {
-        "reference": "Patient/00000000-0000-0000-0000-000000000002"
+        "reference": "Patient/00000000-0000-0000-0000-000000000003"
       },
       "context": {
         "reference": "Encounter/C07745C6-ADAC-11E2-883C-B639E5B05B1F"
       },
       "effectiveDateTime": "2000-03-31",
-      "issued": "2017-05-18T08:12:07.000+00:00",
+      "issued": "2000-03-31T00:00:00.000+00:00",
       "performer": [ {
         "reference": "Practitioner/298F8D0B-C3B9-0598-4D0E-3ADB6F7B1DEF"
       } ],
@@ -3297,13 +3297,13 @@
         "text": "Intubation of stomach for ph manometry"
       },
       "subject": {
-        "reference": "Patient/00000000-0000-0000-0000-000000000002"
+        "reference": "Patient/00000000-0000-0000-0000-000000000003"
       },
       "context": {
         "reference": "Encounter/C07745C6-ADAC-11E2-883C-B639E5B05B1F"
       },
       "effectiveDateTime": "2000-03-31",
-      "issued": "2017-05-18T08:12:07.000+00:00",
+      "issued": "2000-03-31T00:00:00.000+00:00",
       "performer": [ {
         "reference": "Practitioner/298F8D0B-C3B9-0598-4D0E-3ADB6F7B1DEF"
       } ],
@@ -3344,13 +3344,13 @@
         "text": "Intubation of stomach for pressure manometry"
       },
       "subject": {
-        "reference": "Patient/00000000-0000-0000-0000-000000000002"
+        "reference": "Patient/00000000-0000-0000-0000-000000000003"
       },
       "context": {
         "reference": "Encounter/C07745C6-ADAC-11E2-883C-B639E5B05B1F"
       },
       "effectiveDateTime": "2000-03-31",
-      "issued": "2017-05-18T08:12:07.000+00:00",
+      "issued": "2000-03-31T00:00:00.000+00:00",
       "performer": [ {
         "reference": "Practitioner/298F8D0B-C3B9-0598-4D0E-3ADB6F7B1DEF"
       } ],
@@ -3391,13 +3391,13 @@
         "text": "Irrigation of stomach"
       },
       "subject": {
-        "reference": "Patient/00000000-0000-0000-0000-000000000002"
+        "reference": "Patient/00000000-0000-0000-0000-000000000003"
       },
       "context": {
         "reference": "Encounter/C07745C6-ADAC-11E2-883C-B639E5B05B1F"
       },
       "effectiveDateTime": "2000-03-31",
-      "issued": "2017-05-18T08:12:07.000+00:00",
+      "issued": "2000-03-31T00:00:00.000+00:00",
       "performer": [ {
         "reference": "Practitioner/298F8D0B-C3B9-0598-4D0E-3ADB6F7B1DEF"
       } ],
@@ -3435,13 +3435,13 @@
         "text": "Lavage of stomach"
       },
       "subject": {
-        "reference": "Patient/00000000-0000-0000-0000-000000000002"
+        "reference": "Patient/00000000-0000-0000-0000-000000000003"
       },
       "context": {
         "reference": "Encounter/C07745C6-ADAC-11E2-883C-B639E5B05B1F"
       },
       "effectiveDateTime": "2000-03-31",
-      "issued": "2017-05-18T08:12:07.000+00:00",
+      "issued": "2000-03-31T00:00:00.000+00:00",
       "performer": [ {
         "reference": "Practitioner/298F8D0B-C3B9-0598-4D0E-3ADB6F7B1DEF"
       } ],
@@ -3479,13 +3479,13 @@
         "text": "Washout of stomach"
       },
       "subject": {
-        "reference": "Patient/00000000-0000-0000-0000-000000000002"
+        "reference": "Patient/00000000-0000-0000-0000-000000000003"
       },
       "context": {
         "reference": "Encounter/C07745C6-ADAC-11E2-883C-B639E5B05B1F"
       },
       "effectiveDateTime": "2000-03-31",
-      "issued": "2017-05-18T08:12:07.000+00:00",
+      "issued": "2000-03-31T00:00:00.000+00:00",
       "performer": [ {
         "reference": "Practitioner/298F8D0B-C3B9-0598-4D0E-3ADB6F7B1DEF"
       } ],
@@ -3526,13 +3526,13 @@
         "text": "Intubation of stomach for study of gastric secretion"
       },
       "subject": {
-        "reference": "Patient/00000000-0000-0000-0000-000000000002"
+        "reference": "Patient/00000000-0000-0000-0000-000000000003"
       },
       "context": {
         "reference": "Encounter/C07745C6-ADAC-11E2-883C-B639E5B05B1F"
       },
       "effectiveDateTime": "2000-03-31",
-      "issued": "2017-05-18T08:12:07.000+00:00",
+      "issued": "2000-03-31T00:00:00.000+00:00",
       "performer": [ {
         "reference": "Practitioner/298F8D0B-C3B9-0598-4D0E-3ADB6F7B1DEF"
       } ],
@@ -3570,13 +3570,13 @@
         "text": "Intubation of stomach NEC"
       },
       "subject": {
-        "reference": "Patient/00000000-0000-0000-0000-000000000002"
+        "reference": "Patient/00000000-0000-0000-0000-000000000003"
       },
       "context": {
         "reference": "Encounter/C07745C6-ADAC-11E2-883C-B639E5B05B1F"
       },
       "effectiveDateTime": "2000-03-31",
-      "issued": "2017-05-18T08:12:07.000+00:00",
+      "issued": "2000-03-31T00:00:00.000+00:00",
       "performer": [ {
         "reference": "Practitioner/298F8D0B-C3B9-0598-4D0E-3ADB6F7B1DEF"
       } ],
@@ -3614,13 +3614,13 @@
         "text": "Other specified intubation of stomach"
       },
       "subject": {
-        "reference": "Patient/00000000-0000-0000-0000-000000000002"
+        "reference": "Patient/00000000-0000-0000-0000-000000000003"
       },
       "context": {
         "reference": "Encounter/C07745C6-ADAC-11E2-883C-B639E5B05B1F"
       },
       "effectiveDateTime": "2000-03-31",
-      "issued": "2017-05-18T08:12:07.000+00:00",
+      "issued": "2000-03-31T00:00:00.000+00:00",
       "performer": [ {
         "reference": "Practitioner/298F8D0B-C3B9-0598-4D0E-3ADB6F7B1DEF"
       } ],
@@ -3658,13 +3658,13 @@
         "text": "Intubation of stomach NOS"
       },
       "subject": {
-        "reference": "Patient/00000000-0000-0000-0000-000000000002"
+        "reference": "Patient/00000000-0000-0000-0000-000000000003"
       },
       "context": {
         "reference": "Encounter/C07745C6-ADAC-11E2-883C-B639E5B05B1F"
       },
       "effectiveDateTime": "2000-03-31",
-      "issued": "2017-05-18T08:12:07.000+00:00",
+      "issued": "2000-03-31T00:00:00.000+00:00",
       "performer": [ {
         "reference": "Practitioner/298F8D0B-C3B9-0598-4D0E-3ADB6F7B1DEF"
       } ],
@@ -3702,13 +3702,13 @@
         "text": "Other operations on stomach"
       },
       "subject": {
-        "reference": "Patient/00000000-0000-0000-0000-000000000002"
+        "reference": "Patient/00000000-0000-0000-0000-000000000003"
       },
       "context": {
         "reference": "Encounter/C07745C6-ADAC-11E2-883C-B639E5B05B1F"
       },
       "effectiveDateTime": "2000-03-31",
-      "issued": "2017-05-18T08:12:07.000+00:00",
+      "issued": "2000-03-31T00:00:00.000+00:00",
       "performer": [ {
         "reference": "Practitioner/298F8D0B-C3B9-0598-4D0E-3ADB6F7B1DEF"
       } ],
@@ -3749,13 +3749,13 @@
         "text": "Insertion of gastric bubble"
       },
       "subject": {
-        "reference": "Patient/00000000-0000-0000-0000-000000000002"
+        "reference": "Patient/00000000-0000-0000-0000-000000000003"
       },
       "context": {
         "reference": "Encounter/C07745C6-ADAC-11E2-883C-B639E5B05B1F"
       },
       "effectiveDateTime": "2000-03-31",
-      "issued": "2017-05-18T08:12:07.000+00:00",
+      "issued": "2000-03-31T00:00:00.000+00:00",
       "performer": [ {
         "reference": "Practitioner/298F8D0B-C3B9-0598-4D0E-3ADB6F7B1DEF"
       } ],
@@ -3796,13 +3796,13 @@
         "text": "Insertion of gastric balloon"
       },
       "subject": {
-        "reference": "Patient/00000000-0000-0000-0000-000000000002"
+        "reference": "Patient/00000000-0000-0000-0000-000000000003"
       },
       "context": {
         "reference": "Encounter/C07745C6-ADAC-11E2-883C-B639E5B05B1F"
       },
       "effectiveDateTime": "2000-03-31",
-      "issued": "2017-05-18T08:12:07.000+00:00",
+      "issued": "2000-03-31T00:00:00.000+00:00",
       "performer": [ {
         "reference": "Practitioner/298F8D0B-C3B9-0598-4D0E-3ADB6F7B1DEF"
       } ],
@@ -3843,13 +3843,13 @@
         "text": "Attention to gastric bubble"
       },
       "subject": {
-        "reference": "Patient/00000000-0000-0000-0000-000000000002"
+        "reference": "Patient/00000000-0000-0000-0000-000000000003"
       },
       "context": {
         "reference": "Encounter/C07745C6-ADAC-11E2-883C-B639E5B05B1F"
       },
       "effectiveDateTime": "2000-03-31",
-      "issued": "2017-05-18T08:12:07.000+00:00",
+      "issued": "2000-03-31T00:00:00.000+00:00",
       "performer": [ {
         "reference": "Practitioner/298F8D0B-C3B9-0598-4D0E-3ADB6F7B1DEF"
       } ],
@@ -3890,13 +3890,13 @@
         "text": "Induction of emesis"
       },
       "subject": {
-        "reference": "Patient/00000000-0000-0000-0000-000000000002"
+        "reference": "Patient/00000000-0000-0000-0000-000000000003"
       },
       "context": {
         "reference": "Encounter/C07745C6-ADAC-11E2-883C-B639E5B05B1F"
       },
       "effectiveDateTime": "2000-03-31",
-      "issued": "2017-05-18T08:12:07.000+00:00",
+      "issued": "2000-03-31T00:00:00.000+00:00",
       "performer": [ {
         "reference": "Practitioner/298F8D0B-C3B9-0598-4D0E-3ADB6F7B1DEF"
       } ],
@@ -3937,13 +3937,13 @@
         "text": "Administration of activated charcoal"
       },
       "subject": {
-        "reference": "Patient/00000000-0000-0000-0000-000000000002"
+        "reference": "Patient/00000000-0000-0000-0000-000000000003"
       },
       "context": {
         "reference": "Encounter/C07745C6-ADAC-11E2-883C-B639E5B05B1F"
       },
       "effectiveDateTime": "2000-03-31",
-      "issued": "2017-05-18T08:12:07.000+00:00",
+      "issued": "2000-03-31T00:00:00.000+00:00",
       "performer": [ {
         "reference": "Practitioner/298F8D0B-C3B9-0598-4D0E-3ADB6F7B1DEF"
       } ],
@@ -3984,13 +3984,13 @@
         "text": "Removal of gastric bubble"
       },
       "subject": {
-        "reference": "Patient/00000000-0000-0000-0000-000000000002"
+        "reference": "Patient/00000000-0000-0000-0000-000000000003"
       },
       "context": {
         "reference": "Encounter/C07745C6-ADAC-11E2-883C-B639E5B05B1F"
       },
       "effectiveDateTime": "2000-03-31",
-      "issued": "2017-05-18T08:12:07.000+00:00",
+      "issued": "2000-03-31T00:00:00.000+00:00",
       "performer": [ {
         "reference": "Practitioner/298F8D0B-C3B9-0598-4D0E-3ADB6F7B1DEF"
       } ],
@@ -4031,13 +4031,13 @@
         "text": "Removal of gastric balloon"
       },
       "subject": {
-        "reference": "Patient/00000000-0000-0000-0000-000000000002"
+        "reference": "Patient/00000000-0000-0000-0000-000000000003"
       },
       "context": {
         "reference": "Encounter/C07745C6-ADAC-11E2-883C-B639E5B05B1F"
       },
       "effectiveDateTime": "2000-03-31",
-      "issued": "2017-05-18T08:12:07.000+00:00",
+      "issued": "2000-03-31T00:00:00.000+00:00",
       "performer": [ {
         "reference": "Practitioner/298F8D0B-C3B9-0598-4D0E-3ADB6F7B1DEF"
       } ],
@@ -4078,13 +4078,13 @@
         "text": "Insertion of gastric balloon"
       },
       "subject": {
-        "reference": "Patient/00000000-0000-0000-0000-000000000002"
+        "reference": "Patient/00000000-0000-0000-0000-000000000003"
       },
       "context": {
         "reference": "Encounter/C07745C6-ADAC-11E2-883C-B639E5B05B1F"
       },
       "effectiveDateTime": "2000-03-31",
-      "issued": "2017-05-18T08:12:07.000+00:00",
+      "issued": "2000-03-31T00:00:00.000+00:00",
       "performer": [ {
         "reference": "Practitioner/298F8D0B-C3B9-0598-4D0E-3ADB6F7B1DEF"
       } ],
@@ -4125,13 +4125,13 @@
         "text": "Attention to gastric balloon"
       },
       "subject": {
-        "reference": "Patient/00000000-0000-0000-0000-000000000002"
+        "reference": "Patient/00000000-0000-0000-0000-000000000003"
       },
       "context": {
         "reference": "Encounter/C07745C6-ADAC-11E2-883C-B639E5B05B1F"
       },
       "effectiveDateTime": "2000-03-31",
-      "issued": "2017-05-18T08:12:07.000+00:00",
+      "issued": "2000-03-31T00:00:00.000+00:00",
       "performer": [ {
         "reference": "Practitioner/298F8D0B-C3B9-0598-4D0E-3ADB6F7B1DEF"
       } ],
@@ -4169,13 +4169,13 @@
         "text": "Other specified other operation on stomach"
       },
       "subject": {
-        "reference": "Patient/00000000-0000-0000-0000-000000000002"
+        "reference": "Patient/00000000-0000-0000-0000-000000000003"
       },
       "context": {
         "reference": "Encounter/C07745C6-ADAC-11E2-883C-B639E5B05B1F"
       },
       "effectiveDateTime": "2000-03-31",
-      "issued": "2017-05-18T08:12:07.000+00:00",
+      "issued": "2000-03-31T00:00:00.000+00:00",
       "performer": [ {
         "reference": "Practitioner/298F8D0B-C3B9-0598-4D0E-3ADB6F7B1DEF"
       } ],
@@ -4213,13 +4213,13 @@
         "text": "Other operation on stomach NOS"
       },
       "subject": {
-        "reference": "Patient/00000000-0000-0000-0000-000000000002"
+        "reference": "Patient/00000000-0000-0000-0000-000000000003"
       },
       "context": {
         "reference": "Encounter/C07745C6-ADAC-11E2-883C-B639E5B05B1F"
       },
       "effectiveDateTime": "2000-03-31",
-      "issued": "2017-05-18T08:12:07.000+00:00",
+      "issued": "2000-03-31T00:00:00.000+00:00",
       "performer": [ {
         "reference": "Practitioner/298F8D0B-C3B9-0598-4D0E-3ADB6F7B1DEF"
       } ],
@@ -4260,13 +4260,13 @@
         "text": "Operations on gastric ulcer"
       },
       "subject": {
-        "reference": "Patient/00000000-0000-0000-0000-000000000002"
+        "reference": "Patient/00000000-0000-0000-0000-000000000003"
       },
       "context": {
         "reference": "Encounter/C07745C6-ADAC-11E2-883C-B639E5B05B1F"
       },
       "effectiveDateTime": "2000-03-31",
-      "issued": "2017-05-18T08:12:07.000+00:00",
+      "issued": "2000-03-31T00:00:00.000+00:00",
       "performer": [ {
         "reference": "Practitioner/298F8D0B-C3B9-0598-4D0E-3ADB6F7B1DEF"
       } ],
@@ -4307,13 +4307,13 @@
         "text": "Stomach ulcer operations"
       },
       "subject": {
-        "reference": "Patient/00000000-0000-0000-0000-000000000002"
+        "reference": "Patient/00000000-0000-0000-0000-000000000003"
       },
       "context": {
         "reference": "Encounter/C07745C6-ADAC-11E2-883C-B639E5B05B1F"
       },
       "effectiveDateTime": "2000-03-31",
-      "issued": "2017-05-18T08:12:07.000+00:00",
+      "issued": "2000-03-31T00:00:00.000+00:00",
       "performer": [ {
         "reference": "Practitioner/298F8D0B-C3B9-0598-4D0E-3ADB6F7B1DEF"
       } ],
@@ -4354,13 +4354,13 @@
         "text": "Closure of perforated gastric ulcer"
       },
       "subject": {
-        "reference": "Patient/00000000-0000-0000-0000-000000000002"
+        "reference": "Patient/00000000-0000-0000-0000-000000000003"
       },
       "context": {
         "reference": "Encounter/C07745C6-ADAC-11E2-883C-B639E5B05B1F"
       },
       "effectiveDateTime": "2000-03-31",
-      "issued": "2017-05-18T08:12:07.000+00:00",
+      "issued": "2000-03-31T00:00:00.000+00:00",
       "performer": [ {
         "reference": "Practitioner/298F8D0B-C3B9-0598-4D0E-3ADB6F7B1DEF"
       } ],
@@ -4398,13 +4398,13 @@
         "text": "Closure of gastric ulcer NEC"
       },
       "subject": {
-        "reference": "Patient/00000000-0000-0000-0000-000000000002"
+        "reference": "Patient/00000000-0000-0000-0000-000000000003"
       },
       "context": {
         "reference": "Encounter/C07745C6-ADAC-11E2-883C-B639E5B05B1F"
       },
       "effectiveDateTime": "2000-03-31",
-      "issued": "2017-05-18T08:12:07.000+00:00",
+      "issued": "2000-03-31T00:00:00.000+00:00",
       "performer": [ {
         "reference": "Practitioner/298F8D0B-C3B9-0598-4D0E-3ADB6F7B1DEF"
       } ],
@@ -4442,13 +4442,13 @@
         "text": "Suture of ulcer of stomach NEC"
       },
       "subject": {
-        "reference": "Patient/00000000-0000-0000-0000-000000000002"
+        "reference": "Patient/00000000-0000-0000-0000-000000000003"
       },
       "context": {
         "reference": "Encounter/C07745C6-ADAC-11E2-883C-B639E5B05B1F"
       },
       "effectiveDateTime": "2000-03-31",
-      "issued": "2017-05-18T08:12:07.000+00:00",
+      "issued": "2000-03-31T00:00:00.000+00:00",
       "performer": [ {
         "reference": "Practitioner/298F8D0B-C3B9-0598-4D0E-3ADB6F7B1DEF"
       } ],
@@ -4486,13 +4486,13 @@
         "text": "Other specified operation on gastric ulcer"
       },
       "subject": {
-        "reference": "Patient/00000000-0000-0000-0000-000000000002"
+        "reference": "Patient/00000000-0000-0000-0000-000000000003"
       },
       "context": {
         "reference": "Encounter/C07745C6-ADAC-11E2-883C-B639E5B05B1F"
       },
       "effectiveDateTime": "2000-03-31",
-      "issued": "2017-05-18T08:12:07.000+00:00",
+      "issued": "2000-03-31T00:00:00.000+00:00",
       "performer": [ {
         "reference": "Practitioner/298F8D0B-C3B9-0598-4D0E-3ADB6F7B1DEF"
       } ],
@@ -4530,13 +4530,13 @@
         "text": "Operation on gastric ulcer NOS"
       },
       "subject": {
-        "reference": "Patient/00000000-0000-0000-0000-000000000002"
+        "reference": "Patient/00000000-0000-0000-0000-000000000003"
       },
       "context": {
         "reference": "Encounter/C07745C6-ADAC-11E2-883C-B639E5B05B1F"
       },
       "effectiveDateTime": "2000-03-31",
-      "issued": "2017-05-18T08:12:07.000+00:00",
+      "issued": "2000-03-31T00:00:00.000+00:00",
       "performer": [ {
         "reference": "Practitioner/298F8D0B-C3B9-0598-4D0E-3ADB6F7B1DEF"
       } ],
@@ -4577,13 +4577,13 @@
         "text": "Fibreoptic endoscopic extirpation of lesion of stomach"
       },
       "subject": {
-        "reference": "Patient/00000000-0000-0000-0000-000000000002"
+        "reference": "Patient/00000000-0000-0000-0000-000000000003"
       },
       "context": {
         "reference": "Encounter/C07745C6-ADAC-11E2-883C-B639E5B05B1F"
       },
       "effectiveDateTime": "2000-03-31",
-      "issued": "2017-05-18T08:12:07.000+00:00",
+      "issued": "2000-03-31T00:00:00.000+00:00",
       "performer": [ {
         "reference": "Practitioner/298F8D0B-C3B9-0598-4D0E-3ADB6F7B1DEF"
       } ],
@@ -4621,13 +4621,13 @@
         "text": "Fibreoptic endoscopic submucosal resection lesion of stomach"
       },
       "subject": {
-        "reference": "Patient/00000000-0000-0000-0000-000000000002"
+        "reference": "Patient/00000000-0000-0000-0000-000000000003"
       },
       "context": {
         "reference": "Encounter/C07745C6-ADAC-11E2-883C-B639E5B05B1F"
       },
       "effectiveDateTime": "2000-03-31",
-      "issued": "2017-05-18T08:12:07.000+00:00",
+      "issued": "2000-03-31T00:00:00.000+00:00",
       "performer": [ {
         "reference": "Practitioner/298F8D0B-C3B9-0598-4D0E-3ADB6F7B1DEF"
       } ],
@@ -4665,13 +4665,13 @@
         "text": "Fibreoptic endoscopic photodynamic therapy lesion of stomach"
       },
       "subject": {
-        "reference": "Patient/00000000-0000-0000-0000-000000000002"
+        "reference": "Patient/00000000-0000-0000-0000-000000000003"
       },
       "context": {
         "reference": "Encounter/C07745C6-ADAC-11E2-883C-B639E5B05B1F"
       },
       "effectiveDateTime": "2000-03-31",
-      "issued": "2017-05-18T08:12:07.000+00:00",
+      "issued": "2000-03-31T00:00:00.000+00:00",
       "performer": [ {
         "reference": "Practitioner/298F8D0B-C3B9-0598-4D0E-3ADB6F7B1DEF"
       } ],
@@ -4709,13 +4709,13 @@
         "text": "OS fibreoptic endoscopic extirpation of lesion of stomach"
       },
       "subject": {
-        "reference": "Patient/00000000-0000-0000-0000-000000000002"
+        "reference": "Patient/00000000-0000-0000-0000-000000000003"
       },
       "context": {
         "reference": "Encounter/C07745C6-ADAC-11E2-883C-B639E5B05B1F"
       },
       "effectiveDateTime": "2000-03-31",
-      "issued": "2017-05-18T08:12:07.000+00:00",
+      "issued": "2000-03-31T00:00:00.000+00:00",
       "performer": [ {
         "reference": "Practitioner/298F8D0B-C3B9-0598-4D0E-3ADB6F7B1DEF"
       } ],
@@ -4753,13 +4753,13 @@
         "text": "Fibreoptic endoscopic extirpation of lesion of stomach NOS"
       },
       "subject": {
-        "reference": "Patient/00000000-0000-0000-0000-000000000002"
+        "reference": "Patient/00000000-0000-0000-0000-000000000003"
       },
       "context": {
         "reference": "Encounter/C07745C6-ADAC-11E2-883C-B639E5B05B1F"
       },
       "effectiveDateTime": "2000-03-31",
-      "issued": "2017-05-18T08:12:07.000+00:00",
+      "issued": "2000-03-31T00:00:00.000+00:00",
       "performer": [ {
         "reference": "Practitioner/298F8D0B-C3B9-0598-4D0E-3ADB6F7B1DEF"
       } ],
@@ -4797,13 +4797,13 @@
         "text": "Therap fibr endos operations on upper gastrointestinal tract"
       },
       "subject": {
-        "reference": "Patient/00000000-0000-0000-0000-000000000002"
+        "reference": "Patient/00000000-0000-0000-0000-000000000003"
       },
       "context": {
         "reference": "Encounter/C07745C6-ADAC-11E2-883C-B639E5B05B1F"
       },
       "effectiveDateTime": "2000-03-31",
-      "issued": "2017-05-18T08:12:07.000+00:00",
+      "issued": "2000-03-31T00:00:00.000+00:00",
       "performer": [ {
         "reference": "Practitioner/298F8D0B-C3B9-0598-4D0E-3ADB6F7B1DEF"
       } ],
@@ -4841,13 +4841,13 @@
         "text": "Fibr endos endoluminal plication gastro-oesophageal junction"
       },
       "subject": {
-        "reference": "Patient/00000000-0000-0000-0000-000000000002"
+        "reference": "Patient/00000000-0000-0000-0000-000000000003"
       },
       "context": {
         "reference": "Encounter/C07745C6-ADAC-11E2-883C-B639E5B05B1F"
       },
       "effectiveDateTime": "2000-03-31",
-      "issued": "2017-05-18T08:12:07.000+00:00",
+      "issued": "2000-03-31T00:00:00.000+00:00",
       "performer": [ {
         "reference": "Practitioner/298F8D0B-C3B9-0598-4D0E-3ADB6F7B1DEF"
       } ],
@@ -4885,13 +4885,13 @@
         "text": "OS ther fibr endoscopic ops on upper gastrointestinal tract"
       },
       "subject": {
-        "reference": "Patient/00000000-0000-0000-0000-000000000002"
+        "reference": "Patient/00000000-0000-0000-0000-000000000003"
       },
       "context": {
         "reference": "Encounter/C07745C6-ADAC-11E2-883C-B639E5B05B1F"
       },
       "effectiveDateTime": "2000-03-31",
-      "issued": "2017-05-18T08:12:07.000+00:00",
+      "issued": "2000-03-31T00:00:00.000+00:00",
       "performer": [ {
         "reference": "Practitioner/298F8D0B-C3B9-0598-4D0E-3ADB6F7B1DEF"
       } ],
@@ -4929,13 +4929,13 @@
         "text": "Ther fibr endoscopic ops on upper gastrointestinal tract NOS"
       },
       "subject": {
-        "reference": "Patient/00000000-0000-0000-0000-000000000002"
+        "reference": "Patient/00000000-0000-0000-0000-000000000003"
       },
       "context": {
         "reference": "Encounter/C07745C6-ADAC-11E2-883C-B639E5B05B1F"
       },
       "effectiveDateTime": "2000-03-31",
-      "issued": "2017-05-18T08:12:07.000+00:00",
+      "issued": "2000-03-31T00:00:00.000+00:00",
       "performer": [ {
         "reference": "Practitioner/298F8D0B-C3B9-0598-4D0E-3ADB6F7B1DEF"
       } ],
@@ -4973,13 +4973,13 @@
         "text": "Other fibre endos extirp lesion upper gastrointestinal tract"
       },
       "subject": {
-        "reference": "Patient/00000000-0000-0000-0000-000000000002"
+        "reference": "Patient/00000000-0000-0000-0000-000000000003"
       },
       "context": {
         "reference": "Encounter/C07745C6-ADAC-11E2-883C-B639E5B05B1F"
       },
       "effectiveDateTime": "2000-03-31",
-      "issued": "2017-05-18T08:12:07.000+00:00",
+      "issued": "2000-03-31T00:00:00.000+00:00",
       "performer": [ {
         "reference": "Practitioner/298F8D0B-C3B9-0598-4D0E-3ADB6F7B1DEF"
       } ],
@@ -5017,13 +5017,13 @@
         "text": "Fibr end submucosal resect les upper gastrointestinal tract"
       },
       "subject": {
-        "reference": "Patient/00000000-0000-0000-0000-000000000002"
+        "reference": "Patient/00000000-0000-0000-0000-000000000003"
       },
       "context": {
         "reference": "Encounter/C07745C6-ADAC-11E2-883C-B639E5B05B1F"
       },
       "effectiveDateTime": "2000-03-31",
-      "issued": "2017-05-18T08:12:07.000+00:00",
+      "issued": "2000-03-31T00:00:00.000+00:00",
       "performer": [ {
         "reference": "Practitioner/298F8D0B-C3B9-0598-4D0E-3ADB6F7B1DEF"
       } ],
@@ -5061,13 +5061,13 @@
         "text": "Fibr end photodynamic thera les upper gastrointestinal tract"
       },
       "subject": {
-        "reference": "Patient/00000000-0000-0000-0000-000000000002"
+        "reference": "Patient/00000000-0000-0000-0000-000000000003"
       },
       "context": {
         "reference": "Encounter/C07745C6-ADAC-11E2-883C-B639E5B05B1F"
       },
       "effectiveDateTime": "2000-03-31",
-      "issued": "2017-05-18T08:12:07.000+00:00",
+      "issued": "2000-03-31T00:00:00.000+00:00",
       "performer": [ {
         "reference": "Practitioner/298F8D0B-C3B9-0598-4D0E-3ADB6F7B1DEF"
       } ],
@@ -5105,13 +5105,13 @@
         "text": "OS other fibre endos extirp les upper gastrointestinal tract"
       },
       "subject": {
-        "reference": "Patient/00000000-0000-0000-0000-000000000002"
+        "reference": "Patient/00000000-0000-0000-0000-000000000003"
       },
       "context": {
         "reference": "Encounter/C07745C6-ADAC-11E2-883C-B639E5B05B1F"
       },
       "effectiveDateTime": "2000-03-31",
-      "issued": "2017-05-18T08:12:07.000+00:00",
+      "issued": "2000-03-31T00:00:00.000+00:00",
       "performer": [ {
         "reference": "Practitioner/298F8D0B-C3B9-0598-4D0E-3ADB6F7B1DEF"
       } ],
@@ -5149,13 +5149,13 @@
         "text": "Oth fib endos extirp lesion upper gastrointestinal tract NOS"
       },
       "subject": {
-        "reference": "Patient/00000000-0000-0000-0000-000000000002"
+        "reference": "Patient/00000000-0000-0000-0000-000000000003"
       },
       "context": {
         "reference": "Encounter/C07745C6-ADAC-11E2-883C-B639E5B05B1F"
       },
       "effectiveDateTime": "2000-03-31",
-      "issued": "2017-05-18T08:12:07.000+00:00",
+      "issued": "2000-03-31T00:00:00.000+00:00",
       "performer": [ {
         "reference": "Practitioner/298F8D0B-C3B9-0598-4D0E-3ADB6F7B1DEF"
       } ],
@@ -5193,13 +5193,13 @@
         "text": "Other specified operations on stomach or pylorus"
       },
       "subject": {
-        "reference": "Patient/00000000-0000-0000-0000-000000000002"
+        "reference": "Patient/00000000-0000-0000-0000-000000000003"
       },
       "context": {
         "reference": "Encounter/C07745C6-ADAC-11E2-883C-B639E5B05B1F"
       },
       "effectiveDateTime": "2000-03-31",
-      "issued": "2017-05-18T08:12:07.000+00:00",
+      "issued": "2000-03-31T00:00:00.000+00:00",
       "performer": [ {
         "reference": "Practitioner/298F8D0B-C3B9-0598-4D0E-3ADB6F7B1DEF"
       } ],
@@ -5237,13 +5237,13 @@
         "text": "Stomach and pylorus operations NOS"
       },
       "subject": {
-        "reference": "Patient/00000000-0000-0000-0000-000000000002"
+        "reference": "Patient/00000000-0000-0000-0000-000000000003"
       },
       "context": {
         "reference": "Encounter/C07745C6-ADAC-11E2-883C-B639E5B05B1F"
       },
       "effectiveDateTime": "2000-03-31",
-      "issued": "2017-05-18T08:12:07.000+00:00",
+      "issued": "2000-03-31T00:00:00.000+00:00",
       "performer": [ {
         "reference": "Practitioner/298F8D0B-C3B9-0598-4D0E-3ADB6F7B1DEF"
       } ],
@@ -5281,13 +5281,13 @@
         "text": "Duodenum operations"
       },
       "subject": {
-        "reference": "Patient/00000000-0000-0000-0000-000000000002"
+        "reference": "Patient/00000000-0000-0000-0000-000000000003"
       },
       "context": {
         "reference": "Encounter/C07745C6-ADAC-11E2-883C-B639E5B05B1F"
       },
       "effectiveDateTime": "2000-03-31",
-      "issued": "2017-05-18T08:12:07.000+00:00",
+      "issued": "2000-03-31T00:00:00.000+00:00",
       "performer": [ {
         "reference": "Practitioner/298F8D0B-C3B9-0598-4D0E-3ADB6F7B1DEF"
       } ],
@@ -5328,13 +5328,13 @@
         "text": "Duodenectomy"
       },
       "subject": {
-        "reference": "Patient/00000000-0000-0000-0000-000000000002"
+        "reference": "Patient/00000000-0000-0000-0000-000000000003"
       },
       "context": {
         "reference": "Encounter/C07745C6-ADAC-11E2-883C-B639E5B05B1F"
       },
       "effectiveDateTime": "2000-03-31",
-      "issued": "2017-05-18T08:12:07.000+00:00",
+      "issued": "2000-03-31T00:00:00.000+00:00",
       "performer": [ {
         "reference": "Practitioner/298F8D0B-C3B9-0598-4D0E-3ADB6F7B1DEF"
       } ],
@@ -5372,13 +5372,13 @@
         "text": "Excision of duodenum"
       },
       "subject": {
-        "reference": "Patient/00000000-0000-0000-0000-000000000002"
+        "reference": "Patient/00000000-0000-0000-0000-000000000003"
       },
       "context": {
         "reference": "Encounter/C07745C6-ADAC-11E2-883C-B639E5B05B1F"
       },
       "effectiveDateTime": "2000-03-31",
-      "issued": "2017-05-18T08:12:07.000+00:00",
+      "issued": "2000-03-31T00:00:00.000+00:00",
       "performer": [ {
         "reference": "Practitioner/298F8D0B-C3B9-0598-4D0E-3ADB6F7B1DEF"
       } ],
@@ -5419,13 +5419,13 @@
         "text": "Gastroduodenectomy"
       },
       "subject": {
-        "reference": "Patient/00000000-0000-0000-0000-000000000002"
+        "reference": "Patient/00000000-0000-0000-0000-000000000003"
       },
       "context": {
         "reference": "Encounter/C07745C6-ADAC-11E2-883C-B639E5B05B1F"
       },
       "effectiveDateTime": "2000-03-31",
-      "issued": "2017-05-18T08:12:07.000+00:00",
+      "issued": "2000-03-31T00:00:00.000+00:00",
       "performer": [ {
         "reference": "Practitioner/298F8D0B-C3B9-0598-4D0E-3ADB6F7B1DEF"
       } ],
@@ -5466,13 +5466,13 @@
         "text": "Total excision of duodenum"
       },
       "subject": {
-        "reference": "Patient/00000000-0000-0000-0000-000000000002"
+        "reference": "Patient/00000000-0000-0000-0000-000000000003"
       },
       "context": {
         "reference": "Encounter/C07745C6-ADAC-11E2-883C-B639E5B05B1F"
       },
       "effectiveDateTime": "2000-03-31",
-      "issued": "2017-05-18T08:12:07.000+00:00",
+      "issued": "2000-03-31T00:00:00.000+00:00",
       "performer": [ {
         "reference": "Practitioner/298F8D0B-C3B9-0598-4D0E-3ADB6F7B1DEF"
       } ],
@@ -5513,13 +5513,13 @@
         "text": "Partial excision of duodenum"
       },
       "subject": {
-        "reference": "Patient/00000000-0000-0000-0000-000000000002"
+        "reference": "Patient/00000000-0000-0000-0000-000000000003"
       },
       "context": {
         "reference": "Encounter/C07745C6-ADAC-11E2-883C-B639E5B05B1F"
       },
       "effectiveDateTime": "2000-03-31",
-      "issued": "2017-05-18T08:12:07.000+00:00",
+      "issued": "2000-03-31T00:00:00.000+00:00",
       "performer": [ {
         "reference": "Practitioner/298F8D0B-C3B9-0598-4D0E-3ADB6F7B1DEF"
       } ],
@@ -5557,13 +5557,13 @@
         "text": "Other specified excision of duodenum"
       },
       "subject": {
-        "reference": "Patient/00000000-0000-0000-0000-000000000002"
+        "reference": "Patient/00000000-0000-0000-0000-000000000003"
       },
       "context": {
         "reference": "Encounter/C07745C6-ADAC-11E2-883C-B639E5B05B1F"
       },
       "effectiveDateTime": "2000-03-31",
-      "issued": "2017-05-18T08:12:07.000+00:00",
+      "issued": "2000-03-31T00:00:00.000+00:00",
       "performer": [ {
         "reference": "Practitioner/298F8D0B-C3B9-0598-4D0E-3ADB6F7B1DEF"
       } ],
@@ -5601,13 +5601,13 @@
         "text": "Duodenectomy NEC"
       },
       "subject": {
-        "reference": "Patient/00000000-0000-0000-0000-000000000002"
+        "reference": "Patient/00000000-0000-0000-0000-000000000003"
       },
       "context": {
         "reference": "Encounter/C07745C6-ADAC-11E2-883C-B639E5B05B1F"
       },
       "effectiveDateTime": "2000-03-31",
-      "issued": "2017-05-18T08:12:07.000+00:00",
+      "issued": "2000-03-31T00:00:00.000+00:00",
       "performer": [ {
         "reference": "Practitioner/298F8D0B-C3B9-0598-4D0E-3ADB6F7B1DEF"
       } ],
@@ -5645,13 +5645,13 @@
         "text": "Excision of duodenum NOS"
       },
       "subject": {
-        "reference": "Patient/00000000-0000-0000-0000-000000000002"
+        "reference": "Patient/00000000-0000-0000-0000-000000000003"
       },
       "context": {
         "reference": "Encounter/C07745C6-ADAC-11E2-883C-B639E5B05B1F"
       },
       "effectiveDateTime": "2000-03-31",
-      "issued": "2017-05-18T08:12:07.000+00:00",
+      "issued": "2000-03-31T00:00:00.000+00:00",
       "performer": [ {
         "reference": "Practitioner/298F8D0B-C3B9-0598-4D0E-3ADB6F7B1DEF"
       } ],
@@ -5692,13 +5692,13 @@
         "text": "Open extirpation of lesion of duodenum"
       },
       "subject": {
-        "reference": "Patient/00000000-0000-0000-0000-000000000002"
+        "reference": "Patient/00000000-0000-0000-0000-000000000003"
       },
       "context": {
         "reference": "Encounter/C07745C6-ADAC-11E2-883C-B639E5B05B1F"
       },
       "effectiveDateTime": "2000-03-31",
-      "issued": "2017-05-18T08:12:07.000+00:00",
+      "issued": "2000-03-31T00:00:00.000+00:00",
       "performer": [ {
         "reference": "Practitioner/298F8D0B-C3B9-0598-4D0E-3ADB6F7B1DEF"
       } ],
@@ -5739,13 +5739,13 @@
         "text": "Excision of lesion of duodenum"
       },
       "subject": {
-        "reference": "Patient/00000000-0000-0000-0000-000000000002"
+        "reference": "Patient/00000000-0000-0000-0000-000000000003"
       },
       "context": {
         "reference": "Encounter/C07745C6-ADAC-11E2-883C-B639E5B05B1F"
       },
       "effectiveDateTime": "2000-03-31",
-      "issued": "2017-05-18T08:12:07.000+00:00",
+      "issued": "2000-03-31T00:00:00.000+00:00",
       "performer": [ {
         "reference": "Practitioner/298F8D0B-C3B9-0598-4D0E-3ADB6F7B1DEF"
       } ],
@@ -5786,13 +5786,13 @@
         "text": "Open destruction of lesion of duodenum"
       },
       "subject": {
-        "reference": "Patient/00000000-0000-0000-0000-000000000002"
+        "reference": "Patient/00000000-0000-0000-0000-000000000003"
       },
       "context": {
         "reference": "Encounter/C07745C6-ADAC-11E2-883C-B639E5B05B1F"
       },
       "effectiveDateTime": "2000-03-31",
-      "issued": "2017-05-18T08:12:07.000+00:00",
+      "issued": "2000-03-31T00:00:00.000+00:00",
       "performer": [ {
         "reference": "Practitioner/298F8D0B-C3B9-0598-4D0E-3ADB6F7B1DEF"
       } ],
@@ -5830,13 +5830,13 @@
         "text": "Other specified open extirpation of lesion of duodenum"
       },
       "subject": {
-        "reference": "Patient/00000000-0000-0000-0000-000000000002"
+        "reference": "Patient/00000000-0000-0000-0000-000000000003"
       },
       "context": {
         "reference": "Encounter/C07745C6-ADAC-11E2-883C-B639E5B05B1F"
       },
       "effectiveDateTime": "2000-03-31",
-      "issued": "2017-05-18T08:12:07.000+00:00",
+      "issued": "2000-03-31T00:00:00.000+00:00",
       "performer": [ {
         "reference": "Practitioner/298F8D0B-C3B9-0598-4D0E-3ADB6F7B1DEF"
       } ],
@@ -5874,13 +5874,13 @@
         "text": "Open extirpation of lesion of duodenum NOS"
       },
       "subject": {
-        "reference": "Patient/00000000-0000-0000-0000-000000000002"
+        "reference": "Patient/00000000-0000-0000-0000-000000000003"
       },
       "context": {
         "reference": "Encounter/C07745C6-ADAC-11E2-883C-B639E5B05B1F"
       },
       "effectiveDateTime": "2000-03-31",
-      "issued": "2017-05-18T08:12:07.000+00:00",
+      "issued": "2000-03-31T00:00:00.000+00:00",
       "performer": [ {
         "reference": "Practitioner/298F8D0B-C3B9-0598-4D0E-3ADB6F7B1DEF"
       } ],
@@ -5921,13 +5921,13 @@
         "text": "Bypass of duodenum"
       },
       "subject": {
-        "reference": "Patient/00000000-0000-0000-0000-000000000002"
+        "reference": "Patient/00000000-0000-0000-0000-000000000003"
       },
       "context": {
         "reference": "Encounter/C07745C6-ADAC-11E2-883C-B639E5B05B1F"
       },
       "effectiveDateTime": "2000-03-31",
-      "issued": "2017-05-18T08:12:07.000+00:00",
+      "issued": "2000-03-31T00:00:00.000+00:00",
       "performer": [ {
         "reference": "Practitioner/298F8D0B-C3B9-0598-4D0E-3ADB6F7B1DEF"
       } ],
@@ -5968,13 +5968,13 @@
         "text": "Bypass of duodenum by anastomosis of stomach to jejunum"
       },
       "subject": {
-        "reference": "Patient/00000000-0000-0000-0000-000000000002"
+        "reference": "Patient/00000000-0000-0000-0000-000000000003"
       },
       "context": {
         "reference": "Encounter/C07745C6-ADAC-11E2-883C-B639E5B05B1F"
       },
       "effectiveDateTime": "2000-03-31",
-      "issued": "2017-05-18T08:12:07.000+00:00",
+      "issued": "2000-03-31T00:00:00.000+00:00",
       "performer": [ {
         "reference": "Practitioner/298F8D0B-C3B9-0598-4D0E-3ADB6F7B1DEF"
       } ],
@@ -6015,13 +6015,13 @@
         "text": "Bypass of duodenum by anastomosis of duodenum to duodenum"
       },
       "subject": {
-        "reference": "Patient/00000000-0000-0000-0000-000000000002"
+        "reference": "Patient/00000000-0000-0000-0000-000000000003"
       },
       "context": {
         "reference": "Encounter/C07745C6-ADAC-11E2-883C-B639E5B05B1F"
       },
       "effectiveDateTime": "2000-03-31",
-      "issued": "2017-05-18T08:12:07.000+00:00",
+      "issued": "2000-03-31T00:00:00.000+00:00",
       "performer": [ {
         "reference": "Practitioner/298F8D0B-C3B9-0598-4D0E-3ADB6F7B1DEF"
       } ],
@@ -6059,13 +6059,13 @@
         "text": "Focused ultrasound to lesion of uterus"
       },
       "subject": {
-        "reference": "Patient/00000000-0000-0000-0000-000000000002"
+        "reference": "Patient/00000000-0000-0000-0000-000000000003"
       },
       "context": {
         "reference": "Encounter/C11B5062-ADAC-11E2-9964-B639E5B05B1F"
       },
       "effectiveDateTime": "2000-03-31",
-      "issued": "2017-05-18T08:12:07.000+00:00",
+      "issued": "2000-03-31T00:00:00.000+00:00",
       "performer": [ {
         "reference": "Practitioner/298F8D0B-C3B9-0598-4D0E-3ADB6F7B1DEF"
       } ],
@@ -6103,13 +6103,13 @@
         "text": "Other specified operation on uterus"
       },
       "subject": {
-        "reference": "Patient/00000000-0000-0000-0000-000000000002"
+        "reference": "Patient/00000000-0000-0000-0000-000000000003"
       },
       "context": {
         "reference": "Encounter/C11B5062-ADAC-11E2-9964-B639E5B05B1F"
       },
       "effectiveDateTime": "2000-03-31",
-      "issued": "2017-05-18T08:12:07.000+00:00",
+      "issued": "2000-03-31T00:00:00.000+00:00",
       "performer": [ {
         "reference": "Practitioner/298F8D0B-C3B9-0598-4D0E-3ADB6F7B1DEF"
       } ],
@@ -6147,13 +6147,13 @@
         "text": "Operation on uterus NOS"
       },
       "subject": {
-        "reference": "Patient/00000000-0000-0000-0000-000000000002"
+        "reference": "Patient/00000000-0000-0000-0000-000000000003"
       },
       "context": {
         "reference": "Encounter/C11B5062-ADAC-11E2-9964-B639E5B05B1F"
       },
       "effectiveDateTime": "2000-03-31",
-      "issued": "2017-05-18T08:12:07.000+00:00",
+      "issued": "2000-03-31T00:00:00.000+00:00",
       "performer": [ {
         "reference": "Practitioner/298F8D0B-C3B9-0598-4D0E-3ADB6F7B1DEF"
       } ],
@@ -6191,13 +6191,13 @@
         "text": "Other vaginal operations on uterus"
       },
       "subject": {
-        "reference": "Patient/00000000-0000-0000-0000-000000000002"
+        "reference": "Patient/00000000-0000-0000-0000-000000000003"
       },
       "context": {
         "reference": "Encounter/C11B5062-ADAC-11E2-9964-B639E5B05B1F"
       },
       "effectiveDateTime": "2000-03-31",
-      "issued": "2017-05-18T08:12:07.000+00:00",
+      "issued": "2000-03-31T00:00:00.000+00:00",
       "performer": [ {
         "reference": "Practitioner/298F8D0B-C3B9-0598-4D0E-3ADB6F7B1DEF"
       } ],
@@ -6238,13 +6238,13 @@
         "text": "Vaginal excision of lesion of uterus"
       },
       "subject": {
-        "reference": "Patient/00000000-0000-0000-0000-000000000002"
+        "reference": "Patient/00000000-0000-0000-0000-000000000003"
       },
       "context": {
         "reference": "Encounter/C11B5062-ADAC-11E2-9964-B639E5B05B1F"
       },
       "effectiveDateTime": "2000-03-31",
-      "issued": "2017-05-18T08:12:07.000+00:00",
+      "issued": "2000-03-31T00:00:00.000+00:00",
       "performer": [ {
         "reference": "Practitioner/298F8D0B-C3B9-0598-4D0E-3ADB6F7B1DEF"
       } ],
@@ -6285,13 +6285,13 @@
         "text": "Endometrial balloon ablation"
       },
       "subject": {
-        "reference": "Patient/00000000-0000-0000-0000-000000000002"
+        "reference": "Patient/00000000-0000-0000-0000-000000000003"
       },
       "context": {
         "reference": "Encounter/C11B5062-ADAC-11E2-9964-B639E5B05B1F"
       },
       "effectiveDateTime": "2000-03-31",
-      "issued": "2017-05-18T08:12:07.000+00:00",
+      "issued": "2000-03-31T00:00:00.000+00:00",
       "performer": [ {
         "reference": "Practitioner/298F8D0B-C3B9-0598-4D0E-3ADB6F7B1DEF"
       } ],
@@ -6329,13 +6329,13 @@
         "text": "Microwave ablation of endometrium NEC"
       },
       "subject": {
-        "reference": "Patient/00000000-0000-0000-0000-000000000002"
+        "reference": "Patient/00000000-0000-0000-0000-000000000003"
       },
       "context": {
         "reference": "Encounter/C11B5062-ADAC-11E2-9964-B639E5B05B1F"
       },
       "effectiveDateTime": "2000-03-31",
-      "issued": "2017-05-18T08:12:07.000+00:00",
+      "issued": "2000-03-31T00:00:00.000+00:00",
       "performer": [ {
         "reference": "Practitioner/298F8D0B-C3B9-0598-4D0E-3ADB6F7B1DEF"
       } ],
@@ -6376,13 +6376,13 @@
         "text": "Free circulating saline ablation of endometrium"
       },
       "subject": {
-        "reference": "Patient/00000000-0000-0000-0000-000000000002"
+        "reference": "Patient/00000000-0000-0000-0000-000000000003"
       },
       "context": {
         "reference": "Encounter/C11B5062-ADAC-11E2-9964-B639E5B05B1F"
       },
       "effectiveDateTime": "2000-03-31",
-      "issued": "2017-05-18T08:12:07.000+00:00",
+      "issued": "2000-03-31T00:00:00.000+00:00",
       "performer": [ {
         "reference": "Practitioner/298F8D0B-C3B9-0598-4D0E-3ADB6F7B1DEF"
       } ],
@@ -6423,13 +6423,13 @@
         "text": "Radiofrequency endometrial ablation"
       },
       "subject": {
-        "reference": "Patient/00000000-0000-0000-0000-000000000002"
+        "reference": "Patient/00000000-0000-0000-0000-000000000003"
       },
       "context": {
         "reference": "Encounter/C11B5062-ADAC-11E2-9964-B639E5B05B1F"
       },
       "effectiveDateTime": "2000-03-31",
-      "issued": "2017-05-18T08:12:07.000+00:00",
+      "issued": "2000-03-31T00:00:00.000+00:00",
       "performer": [ {
         "reference": "Practitioner/298F8D0B-C3B9-0598-4D0E-3ADB6F7B1DEF"
       } ],
@@ -6470,13 +6470,13 @@
         "text": "Photodynamic ablation of endometrium"
       },
       "subject": {
-        "reference": "Patient/00000000-0000-0000-0000-000000000002"
+        "reference": "Patient/00000000-0000-0000-0000-000000000003"
       },
       "context": {
         "reference": "Encounter/C11B5062-ADAC-11E2-9964-B639E5B05B1F"
       },
       "effectiveDateTime": "2000-03-31",
-      "issued": "2017-05-18T08:12:07.000+00:00",
+      "issued": "2000-03-31T00:00:00.000+00:00",
       "performer": [ {
         "reference": "Practitioner/298F8D0B-C3B9-0598-4D0E-3ADB6F7B1DEF"
       } ],
@@ -6514,13 +6514,13 @@
         "text": "Other specified other vaginal operation on uterus"
       },
       "subject": {
-        "reference": "Patient/00000000-0000-0000-0000-000000000002"
+        "reference": "Patient/00000000-0000-0000-0000-000000000003"
       },
       "context": {
         "reference": "Encounter/C11B5062-ADAC-11E2-9964-B639E5B05B1F"
       },
       "effectiveDateTime": "2000-03-31",
-      "issued": "2017-05-18T08:12:07.000+00:00",
+      "issued": "2000-03-31T00:00:00.000+00:00",
       "performer": [ {
         "reference": "Practitioner/298F8D0B-C3B9-0598-4D0E-3ADB6F7B1DEF"
       } ],
@@ -6558,13 +6558,13 @@
         "text": "Other vaginal operation on uterus NOS"
       },
       "subject": {
-        "reference": "Patient/00000000-0000-0000-0000-000000000002"
+        "reference": "Patient/00000000-0000-0000-0000-000000000003"
       },
       "context": {
         "reference": "Encounter/C11B5062-ADAC-11E2-9964-B639E5B05B1F"
       },
       "effectiveDateTime": "2000-03-31",
-      "issued": "2017-05-18T08:12:07.000+00:00",
+      "issued": "2000-03-31T00:00:00.000+00:00",
       "performer": [ {
         "reference": "Practitioner/298F8D0B-C3B9-0598-4D0E-3ADB6F7B1DEF"
       } ],
@@ -6602,13 +6602,13 @@
         "text": "Plastic operations on uterus"
       },
       "subject": {
-        "reference": "Patient/00000000-0000-0000-0000-000000000002"
+        "reference": "Patient/00000000-0000-0000-0000-000000000003"
       },
       "context": {
         "reference": "Encounter/C11B5062-ADAC-11E2-9964-B639E5B05B1F"
       },
       "effectiveDateTime": "2000-03-31",
-      "issued": "2017-05-18T08:12:07.000+00:00",
+      "issued": "2000-03-31T00:00:00.000+00:00",
       "performer": [ {
         "reference": "Practitioner/298F8D0B-C3B9-0598-4D0E-3ADB6F7B1DEF"
       } ],
@@ -6649,13 +6649,13 @@
         "text": "Connection of uterus to vagina"
       },
       "subject": {
-        "reference": "Patient/00000000-0000-0000-0000-000000000002"
+        "reference": "Patient/00000000-0000-0000-0000-000000000003"
       },
       "context": {
         "reference": "Encounter/C11B5062-ADAC-11E2-9964-B639E5B05B1F"
       },
       "effectiveDateTime": "2000-03-31",
-      "issued": "2017-05-18T08:12:07.000+00:00",
+      "issued": "2000-03-31T00:00:00.000+00:00",
       "performer": [ {
         "reference": "Practitioner/298F8D0B-C3B9-0598-4D0E-3ADB6F7B1DEF"
       } ],
@@ -6693,13 +6693,13 @@
         "text": "Other specified plastic operations on uterus"
       },
       "subject": {
-        "reference": "Patient/00000000-0000-0000-0000-000000000002"
+        "reference": "Patient/00000000-0000-0000-0000-000000000003"
       },
       "context": {
         "reference": "Encounter/C11B5062-ADAC-11E2-9964-B639E5B05B1F"
       },
       "effectiveDateTime": "2000-03-31",
-      "issued": "2017-05-18T08:12:07.000+00:00",
+      "issued": "2000-03-31T00:00:00.000+00:00",
       "performer": [ {
         "reference": "Practitioner/298F8D0B-C3B9-0598-4D0E-3ADB6F7B1DEF"
       } ],
@@ -6737,13 +6737,13 @@
         "text": "Plastic operations on uterus NOS"
       },
       "subject": {
-        "reference": "Patient/00000000-0000-0000-0000-000000000002"
+        "reference": "Patient/00000000-0000-0000-0000-000000000003"
       },
       "context": {
         "reference": "Encounter/C11B5062-ADAC-11E2-9964-B639E5B05B1F"
       },
       "effectiveDateTime": "2000-03-31",
-      "issued": "2017-05-18T08:12:07.000+00:00",
+      "issued": "2000-03-31T00:00:00.000+00:00",
       "performer": [ {
         "reference": "Practitioner/298F8D0B-C3B9-0598-4D0E-3ADB6F7B1DEF"
       } ],
@@ -6781,13 +6781,13 @@
         "text": "Other introduction of gamete into uterine cavity"
       },
       "subject": {
-        "reference": "Patient/00000000-0000-0000-0000-000000000002"
+        "reference": "Patient/00000000-0000-0000-0000-000000000003"
       },
       "context": {
         "reference": "Encounter/C11B5062-ADAC-11E2-9964-B639E5B05B1F"
       },
       "effectiveDateTime": "2000-03-31",
-      "issued": "2017-05-18T08:12:07.000+00:00",
+      "issued": "2000-03-31T00:00:00.000+00:00",
       "performer": [ {
         "reference": "Practitioner/298F8D0B-C3B9-0598-4D0E-3ADB6F7B1DEF"
       } ],
@@ -6828,13 +6828,13 @@
         "text": "Transmyometrial transfer of embryo to uterus"
       },
       "subject": {
-        "reference": "Patient/00000000-0000-0000-0000-000000000002"
+        "reference": "Patient/00000000-0000-0000-0000-000000000003"
       },
       "context": {
         "reference": "Encounter/C11B5062-ADAC-11E2-9964-B639E5B05B1F"
       },
       "effectiveDateTime": "2000-03-31",
-      "issued": "2017-05-18T08:12:07.000+00:00",
+      "issued": "2000-03-31T00:00:00.000+00:00",
       "performer": [ {
         "reference": "Practitioner/298F8D0B-C3B9-0598-4D0E-3ADB6F7B1DEF"
       } ],
@@ -6872,13 +6872,13 @@
         "text": "Other specified operations on uterus"
       },
       "subject": {
-        "reference": "Patient/00000000-0000-0000-0000-000000000002"
+        "reference": "Patient/00000000-0000-0000-0000-000000000003"
       },
       "context": {
         "reference": "Encounter/C11B5062-ADAC-11E2-9964-B639E5B05B1F"
       },
       "effectiveDateTime": "2000-03-31",
-      "issued": "2017-05-18T08:12:07.000+00:00",
+      "issued": "2000-03-31T00:00:00.000+00:00",
       "performer": [ {
         "reference": "Practitioner/298F8D0B-C3B9-0598-4D0E-3ADB6F7B1DEF"
       } ],
@@ -6916,13 +6916,13 @@
         "text": "Uterus operations NOS"
       },
       "subject": {
-        "reference": "Patient/00000000-0000-0000-0000-000000000002"
+        "reference": "Patient/00000000-0000-0000-0000-000000000003"
       },
       "context": {
         "reference": "Encounter/C11B5062-ADAC-11E2-9964-B639E5B05B1F"
       },
       "effectiveDateTime": "2000-03-31",
-      "issued": "2017-05-18T08:12:07.000+00:00",
+      "issued": "2000-03-31T00:00:00.000+00:00",
       "performer": [ {
         "reference": "Practitioner/298F8D0B-C3B9-0598-4D0E-3ADB6F7B1DEF"
       } ],
@@ -6963,13 +6963,13 @@
         "text": "Fallopian tube operations"
       },
       "subject": {
-        "reference": "Patient/00000000-0000-0000-0000-000000000002"
+        "reference": "Patient/00000000-0000-0000-0000-000000000003"
       },
       "context": {
         "reference": "Encounter/C11B5062-ADAC-11E2-9964-B639E5B05B1F"
       },
       "effectiveDateTime": "2000-03-31",
-      "issued": "2017-05-18T08:12:07.000+00:00",
+      "issued": "2000-03-31T00:00:00.000+00:00",
       "performer": [ {
         "reference": "Practitioner/298F8D0B-C3B9-0598-4D0E-3ADB6F7B1DEF"
       } ],
@@ -7010,13 +7010,13 @@
         "text": "Tubal operations - fallopian"
       },
       "subject": {
-        "reference": "Patient/00000000-0000-0000-0000-000000000002"
+        "reference": "Patient/00000000-0000-0000-0000-000000000003"
       },
       "context": {
         "reference": "Encounter/C11B5062-ADAC-11E2-9964-B639E5B05B1F"
       },
       "effectiveDateTime": "2000-03-31",
-      "issued": "2017-05-18T08:12:07.000+00:00",
+      "issued": "2000-03-31T00:00:00.000+00:00",
       "performer": [ {
         "reference": "Practitioner/298F8D0B-C3B9-0598-4D0E-3ADB6F7B1DEF"
       } ],
@@ -7057,13 +7057,13 @@
         "text": "Bilateral excision of adnexa of uterus"
       },
       "subject": {
-        "reference": "Patient/00000000-0000-0000-0000-000000000002"
+        "reference": "Patient/00000000-0000-0000-0000-000000000003"
       },
       "context": {
         "reference": "Encounter/C11B5062-ADAC-11E2-9964-B639E5B05B1F"
       },
       "effectiveDateTime": "2000-03-31",
-      "issued": "2017-05-18T08:12:07.000+00:00",
+      "issued": "2000-03-31T00:00:00.000+00:00",
       "performer": [ {
         "reference": "Practitioner/298F8D0B-C3B9-0598-4D0E-3ADB6F7B1DEF"
       } ],
@@ -7101,13 +7101,13 @@
         "text": "Bilateral salpingoophorectomy"
       },
       "subject": {
-        "reference": "Patient/00000000-0000-0000-0000-000000000002"
+        "reference": "Patient/00000000-0000-0000-0000-000000000003"
       },
       "context": {
         "reference": "Encounter/C11B5062-ADAC-11E2-9964-B639E5B05B1F"
       },
       "effectiveDateTime": "2000-03-31",
-      "issued": "2017-05-18T08:12:07.000+00:00",
+      "issued": "2000-03-31T00:00:00.000+00:00",
       "performer": [ {
         "reference": "Practitioner/298F8D0B-C3B9-0598-4D0E-3ADB6F7B1DEF"
       } ],
@@ -7145,13 +7145,13 @@
         "text": "Bilateral salpingectomy NEC"
       },
       "subject": {
-        "reference": "Patient/00000000-0000-0000-0000-000000000002"
+        "reference": "Patient/00000000-0000-0000-0000-000000000003"
       },
       "context": {
         "reference": "Encounter/C11B5062-ADAC-11E2-9964-B639E5B05B1F"
       },
       "effectiveDateTime": "2000-03-31",
-      "issued": "2017-05-18T08:12:07.000+00:00",
+      "issued": "2000-03-31T00:00:00.000+00:00",
       "performer": [ {
         "reference": "Practitioner/298F8D0B-C3B9-0598-4D0E-3ADB6F7B1DEF"
       } ],
@@ -7189,13 +7189,13 @@
         "text": "Bilateral oophorectomy NEC"
       },
       "subject": {
-        "reference": "Patient/00000000-0000-0000-0000-000000000002"
+        "reference": "Patient/00000000-0000-0000-0000-000000000003"
       },
       "context": {
         "reference": "Encounter/C11B5062-ADAC-11E2-9964-B639E5B05B1F"
       },
       "effectiveDateTime": "2000-03-31",
-      "issued": "2017-05-18T08:12:07.000+00:00",
+      "issued": "2000-03-31T00:00:00.000+00:00",
       "performer": [ {
         "reference": "Practitioner/298F8D0B-C3B9-0598-4D0E-3ADB6F7B1DEF"
       } ],
@@ -7233,13 +7233,13 @@
         "text": "Other specified bilateral excision of adnexa of uterus"
       },
       "subject": {
-        "reference": "Patient/00000000-0000-0000-0000-000000000002"
+        "reference": "Patient/00000000-0000-0000-0000-000000000003"
       },
       "context": {
         "reference": "Encounter/C11B5062-ADAC-11E2-9964-B639E5B05B1F"
       },
       "effectiveDateTime": "2000-03-31",
-      "issued": "2017-05-18T08:12:07.000+00:00",
+      "issued": "2000-03-31T00:00:00.000+00:00",
       "performer": [ {
         "reference": "Practitioner/298F8D0B-C3B9-0598-4D0E-3ADB6F7B1DEF"
       } ],
@@ -7277,13 +7277,13 @@
         "text": "Bilateral excision of adnexa of uterus NOS"
       },
       "subject": {
-        "reference": "Patient/00000000-0000-0000-0000-000000000002"
+        "reference": "Patient/00000000-0000-0000-0000-000000000003"
       },
       "context": {
         "reference": "Encounter/C11B5062-ADAC-11E2-9964-B639E5B05B1F"
       },
       "effectiveDateTime": "2000-03-31",
-      "issued": "2017-05-18T08:12:07.000+00:00",
+      "issued": "2000-03-31T00:00:00.000+00:00",
       "performer": [ {
         "reference": "Practitioner/298F8D0B-C3B9-0598-4D0E-3ADB6F7B1DEF"
       } ],
@@ -7324,13 +7324,13 @@
         "text": "Unilateral excision of adnexa of uterus"
       },
       "subject": {
-        "reference": "Patient/00000000-0000-0000-0000-000000000002"
+        "reference": "Patient/00000000-0000-0000-0000-000000000003"
       },
       "context": {
         "reference": "Encounter/C11B5062-ADAC-11E2-9964-B639E5B05B1F"
       },
       "effectiveDateTime": "2000-03-31",
-      "issued": "2017-05-18T08:12:07.000+00:00",
+      "issued": "2000-03-31T00:00:00.000+00:00",
       "performer": [ {
         "reference": "Practitioner/298F8D0B-C3B9-0598-4D0E-3ADB6F7B1DEF"
       } ],
@@ -7368,13 +7368,13 @@
         "text": "Unilateral salpingoophorectomy NEC"
       },
       "subject": {
-        "reference": "Patient/00000000-0000-0000-0000-000000000002"
+        "reference": "Patient/00000000-0000-0000-0000-000000000003"
       },
       "context": {
         "reference": "Encounter/C11B5062-ADAC-11E2-9964-B639E5B05B1F"
       },
       "effectiveDateTime": "2000-03-31",
-      "issued": "2017-05-18T08:12:07.000+00:00",
+      "issued": "2000-03-31T00:00:00.000+00:00",
       "performer": [ {
         "reference": "Practitioner/298F8D0B-C3B9-0598-4D0E-3ADB6F7B1DEF"
       } ],
@@ -7412,13 +7412,13 @@
         "text": "Salpingoophorectomy remaining solitary fallop tube and ovary"
       },
       "subject": {
-        "reference": "Patient/00000000-0000-0000-0000-000000000002"
+        "reference": "Patient/00000000-0000-0000-0000-000000000003"
       },
       "context": {
         "reference": "Encounter/C11B5062-ADAC-11E2-9964-B639E5B05B1F"
       },
       "effectiveDateTime": "2000-03-31",
-      "issued": "2017-05-18T08:12:07.000+00:00",
+      "issued": "2000-03-31T00:00:00.000+00:00",
       "performer": [ {
         "reference": "Practitioner/298F8D0B-C3B9-0598-4D0E-3ADB6F7B1DEF"
       } ],
@@ -7456,13 +7456,13 @@
         "text": "Unilateral salpingectomy NEC"
       },
       "subject": {
-        "reference": "Patient/00000000-0000-0000-0000-000000000002"
+        "reference": "Patient/00000000-0000-0000-0000-000000000003"
       },
       "context": {
         "reference": "Encounter/C11B5062-ADAC-11E2-9964-B639E5B05B1F"
       },
       "effectiveDateTime": "2000-03-31",
-      "issued": "2017-05-18T08:12:07.000+00:00",
+      "issued": "2000-03-31T00:00:00.000+00:00",
       "performer": [ {
         "reference": "Practitioner/298F8D0B-C3B9-0598-4D0E-3ADB6F7B1DEF"
       } ],
@@ -7500,13 +7500,13 @@
         "text": "Salpingectomy of remaining solitary fallopian tube NEC"
       },
       "subject": {
-        "reference": "Patient/00000000-0000-0000-0000-000000000002"
+        "reference": "Patient/00000000-0000-0000-0000-000000000003"
       },
       "context": {
         "reference": "Encounter/C11B5062-ADAC-11E2-9964-B639E5B05B1F"
       },
       "effectiveDateTime": "2000-03-31",
-      "issued": "2017-05-18T08:12:07.000+00:00",
+      "issued": "2000-03-31T00:00:00.000+00:00",
       "performer": [ {
         "reference": "Practitioner/298F8D0B-C3B9-0598-4D0E-3ADB6F7B1DEF"
       } ],
@@ -7544,13 +7544,13 @@
         "text": "Unilateral oophorectomy NEC"
       },
       "subject": {
-        "reference": "Patient/00000000-0000-0000-0000-000000000002"
+        "reference": "Patient/00000000-0000-0000-0000-000000000003"
       },
       "context": {
         "reference": "Encounter/C11B5062-ADAC-11E2-9964-B639E5B05B1F"
       },
       "effectiveDateTime": "2000-03-31",
-      "issued": "2017-05-18T08:12:07.000+00:00",
+      "issued": "2000-03-31T00:00:00.000+00:00",
       "performer": [ {
         "reference": "Practitioner/298F8D0B-C3B9-0598-4D0E-3ADB6F7B1DEF"
       } ],
@@ -7588,13 +7588,13 @@
         "text": "Oophorectomy of remaining solitary ovary NEC"
       },
       "subject": {
-        "reference": "Patient/00000000-0000-0000-0000-000000000002"
+        "reference": "Patient/00000000-0000-0000-0000-000000000003"
       },
       "context": {
         "reference": "Encounter/C11B5062-ADAC-11E2-9964-B639E5B05B1F"
       },
       "effectiveDateTime": "2000-03-31",
-      "issued": "2017-05-18T08:12:07.000+00:00",
+      "issued": "2000-03-31T00:00:00.000+00:00",
       "performer": [ {
         "reference": "Practitioner/298F8D0B-C3B9-0598-4D0E-3ADB6F7B1DEF"
       } ],
@@ -7632,13 +7632,13 @@
         "text": "Right salpingoophorectomy"
       },
       "subject": {
-        "reference": "Patient/00000000-0000-0000-0000-000000000002"
+        "reference": "Patient/00000000-0000-0000-0000-000000000003"
       },
       "context": {
         "reference": "Encounter/C11B5062-ADAC-11E2-9964-B639E5B05B1F"
       },
       "effectiveDateTime": "2000-03-31",
-      "issued": "2017-05-18T08:12:07.000+00:00",
+      "issued": "2000-03-31T00:00:00.000+00:00",
       "performer": [ {
         "reference": "Practitioner/298F8D0B-C3B9-0598-4D0E-3ADB6F7B1DEF"
       } ],
@@ -7676,13 +7676,13 @@
         "text": "Left salpingoophorectomy"
       },
       "subject": {
-        "reference": "Patient/00000000-0000-0000-0000-000000000002"
+        "reference": "Patient/00000000-0000-0000-0000-000000000003"
       },
       "context": {
         "reference": "Encounter/C11B5062-ADAC-11E2-9964-B639E5B05B1F"
       },
       "effectiveDateTime": "2000-03-31",
-      "issued": "2017-05-18T08:12:07.000+00:00",
+      "issued": "2000-03-31T00:00:00.000+00:00",
       "performer": [ {
         "reference": "Practitioner/298F8D0B-C3B9-0598-4D0E-3ADB6F7B1DEF"
       } ],
@@ -7723,13 +7723,13 @@
         "text": "Right salpingectomy"
       },
       "subject": {
-        "reference": "Patient/00000000-0000-0000-0000-000000000002"
+        "reference": "Patient/00000000-0000-0000-0000-000000000003"
       },
       "context": {
         "reference": "Encounter/C11B5062-ADAC-11E2-9964-B639E5B05B1F"
       },
       "effectiveDateTime": "2000-03-31",
-      "issued": "2017-05-18T08:12:07.000+00:00",
+      "issued": "2000-03-31T00:00:00.000+00:00",
       "performer": [ {
         "reference": "Practitioner/298F8D0B-C3B9-0598-4D0E-3ADB6F7B1DEF"
       } ],
@@ -7770,13 +7770,13 @@
         "text": "Left salpingectomy"
       },
       "subject": {
-        "reference": "Patient/00000000-0000-0000-0000-000000000002"
+        "reference": "Patient/00000000-0000-0000-0000-000000000003"
       },
       "context": {
         "reference": "Encounter/C11B5062-ADAC-11E2-9964-B639E5B05B1F"
       },
       "effectiveDateTime": "2000-03-31",
-      "issued": "2017-05-18T08:12:07.000+00:00",
+      "issued": "2000-03-31T00:00:00.000+00:00",
       "performer": [ {
         "reference": "Practitioner/298F8D0B-C3B9-0598-4D0E-3ADB6F7B1DEF"
       } ],
@@ -7814,13 +7814,13 @@
         "text": "Other specified unilateral excision of adnexa of uterus"
       },
       "subject": {
-        "reference": "Patient/00000000-0000-0000-0000-000000000002"
+        "reference": "Patient/00000000-0000-0000-0000-000000000003"
       },
       "context": {
         "reference": "Encounter/C11B5062-ADAC-11E2-9964-B639E5B05B1F"
       },
       "effectiveDateTime": "2000-03-31",
-      "issued": "2017-05-18T08:12:07.000+00:00",
+      "issued": "2000-03-31T00:00:00.000+00:00",
       "performer": [ {
         "reference": "Practitioner/298F8D0B-C3B9-0598-4D0E-3ADB6F7B1DEF"
       } ],
@@ -7858,13 +7858,13 @@
         "text": "Unilateral excision of adnexa of uterus NOS"
       },
       "subject": {
-        "reference": "Patient/00000000-0000-0000-0000-000000000002"
+        "reference": "Patient/00000000-0000-0000-0000-000000000003"
       },
       "context": {
         "reference": "Encounter/C11B5062-ADAC-11E2-9964-B639E5B05B1F"
       },
       "effectiveDateTime": "2000-03-31",
-      "issued": "2017-05-18T08:12:07.000+00:00",
+      "issued": "2000-03-31T00:00:00.000+00:00",
       "performer": [ {
         "reference": "Practitioner/298F8D0B-C3B9-0598-4D0E-3ADB6F7B1DEF"
       } ],
@@ -7902,13 +7902,13 @@
         "text": "Other excision of adnexa of uterus"
       },
       "subject": {
-        "reference": "Patient/00000000-0000-0000-0000-000000000002"
+        "reference": "Patient/00000000-0000-0000-0000-000000000003"
       },
       "context": {
         "reference": "Encounter/C11B5062-ADAC-11E2-9964-B639E5B05B1F"
       },
       "effectiveDateTime": "2000-03-31",
-      "issued": "2017-05-18T08:12:07.000+00:00",
+      "issued": "2000-03-31T00:00:00.000+00:00",
       "performer": [ {
         "reference": "Practitioner/298F8D0B-C3B9-0598-4D0E-3ADB6F7B1DEF"
       } ],
@@ -7946,13 +7946,13 @@
         "text": "Salpingoophorectomy NEC"
       },
       "subject": {
-        "reference": "Patient/00000000-0000-0000-0000-000000000002"
+        "reference": "Patient/00000000-0000-0000-0000-000000000003"
       },
       "context": {
         "reference": "Encounter/C11B5062-ADAC-11E2-9964-B639E5B05B1F"
       },
       "effectiveDateTime": "2000-03-31",
-      "issued": "2017-05-18T08:12:07.000+00:00",
+      "issued": "2000-03-31T00:00:00.000+00:00",
       "performer": [ {
         "reference": "Practitioner/298F8D0B-C3B9-0598-4D0E-3ADB6F7B1DEF"
       } ],
@@ -7990,13 +7990,13 @@
         "text": "Salpingectomy NEC"
       },
       "subject": {
-        "reference": "Patient/00000000-0000-0000-0000-000000000002"
+        "reference": "Patient/00000000-0000-0000-0000-000000000003"
       },
       "context": {
         "reference": "Encounter/C11B5062-ADAC-11E2-9964-B639E5B05B1F"
       },
       "effectiveDateTime": "2000-03-31",
-      "issued": "2017-05-18T08:12:07.000+00:00",
+      "issued": "2000-03-31T00:00:00.000+00:00",
       "performer": [ {
         "reference": "Practitioner/298F8D0B-C3B9-0598-4D0E-3ADB6F7B1DEF"
       } ],
@@ -8034,13 +8034,13 @@
         "text": "Oophorectomy NEC"
       },
       "subject": {
-        "reference": "Patient/00000000-0000-0000-0000-000000000002"
+        "reference": "Patient/00000000-0000-0000-0000-000000000003"
       },
       "context": {
         "reference": "Encounter/C11B5062-ADAC-11E2-9964-B639E5B05B1F"
       },
       "effectiveDateTime": "2000-03-31",
-      "issued": "2017-05-18T08:12:07.000+00:00",
+      "issued": "2000-03-31T00:00:00.000+00:00",
       "performer": [ {
         "reference": "Practitioner/298F8D0B-C3B9-0598-4D0E-3ADB6F7B1DEF"
       } ],
@@ -8078,13 +8078,13 @@
         "text": "Right oophorectomy NEC"
       },
       "subject": {
-        "reference": "Patient/00000000-0000-0000-0000-000000000002"
+        "reference": "Patient/00000000-0000-0000-0000-000000000003"
       },
       "context": {
         "reference": "Encounter/C11B5062-ADAC-11E2-9964-B639E5B05B1F"
       },
       "effectiveDateTime": "2000-03-31",
-      "issued": "2017-05-18T08:12:07.000+00:00",
+      "issued": "2000-03-31T00:00:00.000+00:00",
       "performer": [ {
         "reference": "Practitioner/298F8D0B-C3B9-0598-4D0E-3ADB6F7B1DEF"
       } ],
@@ -8122,13 +8122,13 @@
         "text": "Left oophorectomy NEC"
       },
       "subject": {
-        "reference": "Patient/00000000-0000-0000-0000-000000000002"
+        "reference": "Patient/00000000-0000-0000-0000-000000000003"
       },
       "context": {
         "reference": "Encounter/C11B5062-ADAC-11E2-9964-B639E5B05B1F"
       },
       "effectiveDateTime": "2000-03-31",
-      "issued": "2017-05-18T08:12:07.000+00:00",
+      "issued": "2000-03-31T00:00:00.000+00:00",
       "performer": [ {
         "reference": "Practitioner/298F8D0B-C3B9-0598-4D0E-3ADB6F7B1DEF"
       } ],
@@ -8166,13 +8166,13 @@
         "text": "Other specified other excision of adnexa of uterus"
       },
       "subject": {
-        "reference": "Patient/00000000-0000-0000-0000-000000000002"
+        "reference": "Patient/00000000-0000-0000-0000-000000000003"
       },
       "context": {
         "reference": "Encounter/C11B5062-ADAC-11E2-9964-B639E5B05B1F"
       },
       "effectiveDateTime": "2000-03-31",
-      "issued": "2017-05-18T08:12:07.000+00:00",
+      "issued": "2000-03-31T00:00:00.000+00:00",
       "performer": [ {
         "reference": "Practitioner/298F8D0B-C3B9-0598-4D0E-3ADB6F7B1DEF"
       } ],
@@ -8210,13 +8210,13 @@
         "text": "Other excision of adnexa of uterus NOS"
       },
       "subject": {
-        "reference": "Patient/00000000-0000-0000-0000-000000000002"
+        "reference": "Patient/00000000-0000-0000-0000-000000000003"
       },
       "context": {
         "reference": "Encounter/C11B5062-ADAC-11E2-9964-B639E5B05B1F"
       },
       "effectiveDateTime": "2000-03-31",
-      "issued": "2017-05-18T08:12:07.000+00:00",
+      "issued": "2000-03-31T00:00:00.000+00:00",
       "performer": [ {
         "reference": "Practitioner/298F8D0B-C3B9-0598-4D0E-3ADB6F7B1DEF"
       } ],
@@ -8257,13 +8257,13 @@
         "text": "Partial excision of fallopian tube"
       },
       "subject": {
-        "reference": "Patient/00000000-0000-0000-0000-000000000002"
+        "reference": "Patient/00000000-0000-0000-0000-000000000003"
       },
       "context": {
         "reference": "Encounter/C11B5062-ADAC-11E2-9964-B639E5B05B1F"
       },
       "effectiveDateTime": "2000-03-31",
-      "issued": "2017-05-18T08:12:07.000+00:00",
+      "issued": "2000-03-31T00:00:00.000+00:00",
       "performer": [ {
         "reference": "Practitioner/298F8D0B-C3B9-0598-4D0E-3ADB6F7B1DEF"
       } ],
@@ -8304,13 +8304,13 @@
         "text": "Excision of lesion of fallopian tube"
       },
       "subject": {
-        "reference": "Patient/00000000-0000-0000-0000-000000000002"
+        "reference": "Patient/00000000-0000-0000-0000-000000000003"
       },
       "context": {
         "reference": "Encounter/C11B5062-ADAC-11E2-9964-B639E5B05B1F"
       },
       "effectiveDateTime": "2000-03-31",
-      "issued": "2017-05-18T08:12:07.000+00:00",
+      "issued": "2000-03-31T00:00:00.000+00:00",
       "performer": [ {
         "reference": "Practitioner/298F8D0B-C3B9-0598-4D0E-3ADB6F7B1DEF"
       } ],
@@ -8351,13 +8351,13 @@
         "text": "Excision of ectopic ovarian pregnancy"
       },
       "subject": {
-        "reference": "Patient/00000000-0000-0000-0000-000000000002"
+        "reference": "Patient/00000000-0000-0000-0000-000000000003"
       },
       "context": {
         "reference": "Encounter/C11B5062-ADAC-11E2-9964-B639E5B05B1F"
       },
       "effectiveDateTime": "2000-03-31",
-      "issued": "2017-05-18T08:12:07.000+00:00",
+      "issued": "2000-03-31T00:00:00.000+00:00",
       "performer": [ {
         "reference": "Practitioner/298F8D0B-C3B9-0598-4D0E-3ADB6F7B1DEF"
       } ],
@@ -8398,13 +8398,13 @@
         "text": "Excision of ruptured ectopic tubal pregnancy"
       },
       "subject": {
-        "reference": "Patient/00000000-0000-0000-0000-000000000002"
+        "reference": "Patient/00000000-0000-0000-0000-000000000003"
       },
       "context": {
         "reference": "Encounter/C11B5062-ADAC-11E2-9964-B639E5B05B1F"
       },
       "effectiveDateTime": "2000-03-31",
-      "issued": "2017-05-18T08:12:07.000+00:00",
+      "issued": "2000-03-31T00:00:00.000+00:00",
       "performer": [ {
         "reference": "Practitioner/298F8D0B-C3B9-0598-4D0E-3ADB6F7B1DEF"
       } ],
@@ -8442,13 +8442,13 @@
         "text": "Other specified partial excision of fallopian tube"
       },
       "subject": {
-        "reference": "Patient/00000000-0000-0000-0000-000000000002"
+        "reference": "Patient/00000000-0000-0000-0000-000000000003"
       },
       "context": {
         "reference": "Encounter/C11B5062-ADAC-11E2-9964-B639E5B05B1F"
       },
       "effectiveDateTime": "2000-03-31",
-      "issued": "2017-05-18T08:12:07.000+00:00",
+      "issued": "2000-03-31T00:00:00.000+00:00",
       "performer": [ {
         "reference": "Practitioner/298F8D0B-C3B9-0598-4D0E-3ADB6F7B1DEF"
       } ],
@@ -8486,13 +8486,13 @@
         "text": "Partial salpingectomy NEC"
       },
       "subject": {
-        "reference": "Patient/00000000-0000-0000-0000-000000000002"
+        "reference": "Patient/00000000-0000-0000-0000-000000000003"
       },
       "context": {
         "reference": "Encounter/C11B5062-ADAC-11E2-9964-B639E5B05B1F"
       },
       "effectiveDateTime": "2000-03-31",
-      "issued": "2017-05-18T08:12:07.000+00:00",
+      "issued": "2000-03-31T00:00:00.000+00:00",
       "performer": [ {
         "reference": "Practitioner/298F8D0B-C3B9-0598-4D0E-3ADB6F7B1DEF"
       } ],
@@ -8530,13 +8530,13 @@
         "text": "Partial excision of fallopian tube NOS"
       },
       "subject": {
-        "reference": "Patient/00000000-0000-0000-0000-000000000002"
+        "reference": "Patient/00000000-0000-0000-0000-000000000003"
       },
       "context": {
         "reference": "Encounter/C11B5062-ADAC-11E2-9964-B639E5B05B1F"
       },
       "effectiveDateTime": "2000-03-31",
-      "issued": "2017-05-18T08:12:07.000+00:00",
+      "issued": "2000-03-31T00:00:00.000+00:00",
       "performer": [ {
         "reference": "Practitioner/298F8D0B-C3B9-0598-4D0E-3ADB6F7B1DEF"
       } ],
@@ -8574,13 +8574,13 @@
         "text": "Placement of prosthesis in fallopian tube"
       },
       "subject": {
-        "reference": "Patient/00000000-0000-0000-0000-000000000002"
+        "reference": "Patient/00000000-0000-0000-0000-000000000003"
       },
       "context": {
         "reference": "Encounter/C11B5062-ADAC-11E2-9964-B639E5B05B1F"
       },
       "effectiveDateTime": "2000-03-31",
-      "issued": "2017-05-18T08:12:07.000+00:00",
+      "issued": "2000-03-31T00:00:00.000+00:00",
       "performer": [ {
         "reference": "Practitioner/298F8D0B-C3B9-0598-4D0E-3ADB6F7B1DEF"
       } ],
@@ -8618,13 +8618,13 @@
         "text": "Insertion of tubal prosthesis into fallopian tube"
       },
       "subject": {
-        "reference": "Patient/00000000-0000-0000-0000-000000000002"
+        "reference": "Patient/00000000-0000-0000-0000-000000000003"
       },
       "context": {
         "reference": "Encounter/C11B5062-ADAC-11E2-9964-B639E5B05B1F"
       },
       "effectiveDateTime": "2000-03-31",
-      "issued": "2017-05-18T08:12:07.000+00:00",
+      "issued": "2000-03-31T00:00:00.000+00:00",
       "performer": [ {
         "reference": "Practitioner/298F8D0B-C3B9-0598-4D0E-3ADB6F7B1DEF"
       } ],
@@ -8662,13 +8662,13 @@
         "text": "Revision of tubal prosthesis in fallopian tube"
       },
       "subject": {
-        "reference": "Patient/00000000-0000-0000-0000-000000000002"
+        "reference": "Patient/00000000-0000-0000-0000-000000000003"
       },
       "context": {
         "reference": "Encounter/C11B5062-ADAC-11E2-9964-B639E5B05B1F"
       },
       "effectiveDateTime": "2000-03-31",
-      "issued": "2017-05-18T08:12:07.000+00:00",
+      "issued": "2000-03-31T00:00:00.000+00:00",
       "performer": [ {
         "reference": "Practitioner/298F8D0B-C3B9-0598-4D0E-3ADB6F7B1DEF"
       } ],
@@ -8706,13 +8706,13 @@
         "text": "Removal of tubal prosthesis from fallopian tube"
       },
       "subject": {
-        "reference": "Patient/00000000-0000-0000-0000-000000000002"
+        "reference": "Patient/00000000-0000-0000-0000-000000000003"
       },
       "context": {
         "reference": "Encounter/C11B5062-ADAC-11E2-9964-B639E5B05B1F"
       },
       "effectiveDateTime": "2000-03-31",
-      "issued": "2017-05-18T08:12:07.000+00:00",
+      "issued": "2000-03-31T00:00:00.000+00:00",
       "performer": [ {
         "reference": "Practitioner/298F8D0B-C3B9-0598-4D0E-3ADB6F7B1DEF"
       } ],
@@ -8750,13 +8750,13 @@
         "text": "Other specified placement of prosthesis in fallopian tube"
       },
       "subject": {
-        "reference": "Patient/00000000-0000-0000-0000-000000000002"
+        "reference": "Patient/00000000-0000-0000-0000-000000000003"
       },
       "context": {
         "reference": "Encounter/C11B5062-ADAC-11E2-9964-B639E5B05B1F"
       },
       "effectiveDateTime": "2000-03-31",
-      "issued": "2017-05-18T08:12:07.000+00:00",
+      "issued": "2000-03-31T00:00:00.000+00:00",
       "performer": [ {
         "reference": "Practitioner/298F8D0B-C3B9-0598-4D0E-3ADB6F7B1DEF"
       } ],
@@ -8794,13 +8794,13 @@
         "text": "Placement of prosthesis in fallopian tube NOS"
       },
       "subject": {
-        "reference": "Patient/00000000-0000-0000-0000-000000000002"
+        "reference": "Patient/00000000-0000-0000-0000-000000000003"
       },
       "context": {
         "reference": "Encounter/C11B5062-ADAC-11E2-9964-B639E5B05B1F"
       },
       "effectiveDateTime": "2000-03-31",
-      "issued": "2017-05-18T08:12:07.000+00:00",
+      "issued": "2000-03-31T00:00:00.000+00:00",
       "performer": [ {
         "reference": "Practitioner/298F8D0B-C3B9-0598-4D0E-3ADB6F7B1DEF"
       } ],
@@ -8841,13 +8841,13 @@
         "text": "Open bilateral occlusion of fallopian tubes"
       },
       "subject": {
-        "reference": "Patient/00000000-0000-0000-0000-000000000002"
+        "reference": "Patient/00000000-0000-0000-0000-000000000003"
       },
       "context": {
         "reference": "Encounter/C11B5062-ADAC-11E2-9964-B639E5B05B1F"
       },
       "effectiveDateTime": "2000-03-31",
-      "issued": "2017-05-18T08:12:07.000+00:00",
+      "issued": "2000-03-31T00:00:00.000+00:00",
       "performer": [ {
         "reference": "Practitioner/298F8D0B-C3B9-0598-4D0E-3ADB6F7B1DEF"
       } ],
@@ -8888,13 +8888,13 @@
         "text": "Open bilateral female sterilisation"
       },
       "subject": {
-        "reference": "Patient/00000000-0000-0000-0000-000000000002"
+        "reference": "Patient/00000000-0000-0000-0000-000000000003"
       },
       "context": {
         "reference": "Encounter/C11B5062-ADAC-11E2-9964-B639E5B05B1F"
       },
       "effectiveDateTime": "2000-03-31",
-      "issued": "2017-05-18T08:12:07.000+00:00",
+      "issued": "2000-03-31T00:00:00.000+00:00",
       "performer": [ {
         "reference": "Practitioner/298F8D0B-C3B9-0598-4D0E-3ADB6F7B1DEF"
       } ],
@@ -8935,13 +8935,13 @@
         "text": "Open bilateral ligation of fallopian tubes"
       },
       "subject": {
-        "reference": "Patient/00000000-0000-0000-0000-000000000002"
+        "reference": "Patient/00000000-0000-0000-0000-000000000003"
       },
       "context": {
         "reference": "Encounter/C11B5062-ADAC-11E2-9964-B639E5B05B1F"
       },
       "effectiveDateTime": "2000-03-31",
-      "issued": "2017-05-18T08:12:07.000+00:00",
+      "issued": "2000-03-31T00:00:00.000+00:00",
       "performer": [ {
         "reference": "Practitioner/298F8D0B-C3B9-0598-4D0E-3ADB6F7B1DEF"
       } ],
@@ -8982,13 +8982,13 @@
         "text": "Pomeroy open bilateral ligation of fallopian tubes"
       },
       "subject": {
-        "reference": "Patient/00000000-0000-0000-0000-000000000002"
+        "reference": "Patient/00000000-0000-0000-0000-000000000003"
       },
       "context": {
         "reference": "Encounter/C11B5062-ADAC-11E2-9964-B639E5B05B1F"
       },
       "effectiveDateTime": "2000-03-31",
-      "issued": "2017-05-18T08:12:07.000+00:00",
+      "issued": "2000-03-31T00:00:00.000+00:00",
       "performer": [ {
         "reference": "Practitioner/298F8D0B-C3B9-0598-4D0E-3ADB6F7B1DEF"
       } ],
@@ -9029,13 +9029,13 @@
         "text": "Open bilateral clipping of fallopian tubes"
       },
       "subject": {
-        "reference": "Patient/00000000-0000-0000-0000-000000000002"
+        "reference": "Patient/00000000-0000-0000-0000-000000000003"
       },
       "context": {
         "reference": "Encounter/C11B5062-ADAC-11E2-9964-B639E5B05B1F"
       },
       "effectiveDateTime": "2000-03-31",
-      "issued": "2017-05-18T08:12:07.000+00:00",
+      "issued": "2000-03-31T00:00:00.000+00:00",
       "performer": [ {
         "reference": "Practitioner/298F8D0B-C3B9-0598-4D0E-3ADB6F7B1DEF"
       } ],
@@ -9076,13 +9076,13 @@
         "text": "Open bilateral ringing of fallopian tubes"
       },
       "subject": {
-        "reference": "Patient/00000000-0000-0000-0000-000000000002"
+        "reference": "Patient/00000000-0000-0000-0000-000000000003"
       },
       "context": {
         "reference": "Encounter/C11B5062-ADAC-11E2-9964-B639E5B05B1F"
       },
       "effectiveDateTime": "2000-03-31",
-      "issued": "2017-05-18T08:12:07.000+00:00",
+      "issued": "2000-03-31T00:00:00.000+00:00",
       "performer": [ {
         "reference": "Practitioner/298F8D0B-C3B9-0598-4D0E-3ADB6F7B1DEF"
       } ],
@@ -9120,13 +9120,13 @@
         "text": "Other specified open bilateral occlusion of fallopian tubes"
       },
       "subject": {
-        "reference": "Patient/00000000-0000-0000-0000-000000000002"
+        "reference": "Patient/00000000-0000-0000-0000-000000000003"
       },
       "context": {
         "reference": "Encounter/C11B5062-ADAC-11E2-9964-B639E5B05B1F"
       },
       "effectiveDateTime": "2000-03-31",
-      "issued": "2017-05-18T08:12:07.000+00:00",
+      "issued": "2000-03-31T00:00:00.000+00:00",
       "performer": [ {
         "reference": "Practitioner/298F8D0B-C3B9-0598-4D0E-3ADB6F7B1DEF"
       } ],
@@ -9164,13 +9164,13 @@
         "text": "Open bilateral occlusion of fallopian tubes NOS"
       },
       "subject": {
-        "reference": "Patient/00000000-0000-0000-0000-000000000002"
+        "reference": "Patient/00000000-0000-0000-0000-000000000003"
       },
       "context": {
         "reference": "Encounter/C11B5062-ADAC-11E2-9964-B639E5B05B1F"
       },
       "effectiveDateTime": "2000-03-31",
-      "issued": "2017-05-18T08:12:07.000+00:00",
+      "issued": "2000-03-31T00:00:00.000+00:00",
       "performer": [ {
         "reference": "Practitioner/298F8D0B-C3B9-0598-4D0E-3ADB6F7B1DEF"
       } ],
@@ -9208,13 +9208,13 @@
         "text": "Other open occlusion of fallopian tube"
       },
       "subject": {
-        "reference": "Patient/00000000-0000-0000-0000-000000000002"
+        "reference": "Patient/00000000-0000-0000-0000-000000000003"
       },
       "context": {
         "reference": "Encounter/C11B5062-ADAC-11E2-9964-B639E5B05B1F"
       },
       "effectiveDateTime": "2000-03-31",
-      "issued": "2017-05-18T08:12:07.000+00:00",
+      "issued": "2000-03-31T00:00:00.000+00:00",
       "performer": [ {
         "reference": "Practitioner/298F8D0B-C3B9-0598-4D0E-3ADB6F7B1DEF"
       } ],
@@ -9252,13 +9252,13 @@
         "text": "Other open female sterilisation"
       },
       "subject": {
-        "reference": "Patient/00000000-0000-0000-0000-000000000002"
+        "reference": "Patient/00000000-0000-0000-0000-000000000003"
       },
       "context": {
         "reference": "Encounter/C11B5062-ADAC-11E2-9964-B639E5B05B1F"
       },
       "effectiveDateTime": "2000-03-31",
-      "issued": "2017-05-18T08:12:07.000+00:00",
+      "issued": "2000-03-31T00:00:00.000+00:00",
       "performer": [ {
         "reference": "Practitioner/298F8D0B-C3B9-0598-4D0E-3ADB6F7B1DEF"
       } ],
@@ -9299,13 +9299,13 @@
         "text": "Unilateral occlusion of fallopian tube"
       },
       "subject": {
-        "reference": "Patient/00000000-0000-0000-0000-000000000002"
+        "reference": "Patient/00000000-0000-0000-0000-000000000003"
       },
       "context": {
         "reference": "Encounter/C11B5062-ADAC-11E2-9964-B639E5B05B1F"
       },
       "effectiveDateTime": "2000-03-31",
-      "issued": "2017-05-18T08:12:07.000+00:00",
+      "issued": "2000-03-31T00:00:00.000+00:00",
       "performer": [ {
         "reference": "Practitioner/298F8D0B-C3B9-0598-4D0E-3ADB6F7B1DEF"
       } ],
@@ -9346,13 +9346,13 @@
         "text": "Open ligation of remaining solitary fallopian tube"
       },
       "subject": {
-        "reference": "Patient/00000000-0000-0000-0000-000000000002"
+        "reference": "Patient/00000000-0000-0000-0000-000000000003"
       },
       "context": {
         "reference": "Encounter/C11B5062-ADAC-11E2-9964-B639E5B05B1F"
       },
       "effectiveDateTime": "2000-03-31",
-      "issued": "2017-05-18T08:12:07.000+00:00",
+      "issued": "2000-03-31T00:00:00.000+00:00",
       "performer": [ {
         "reference": "Practitioner/298F8D0B-C3B9-0598-4D0E-3ADB6F7B1DEF"
       } ],
@@ -9390,13 +9390,13 @@
         "text": "Open ligation of fallopian tube NEC"
       },
       "subject": {
-        "reference": "Patient/00000000-0000-0000-0000-000000000002"
+        "reference": "Patient/00000000-0000-0000-0000-000000000003"
       },
       "context": {
         "reference": "Encounter/C11B5062-ADAC-11E2-9964-B639E5B05B1F"
       },
       "effectiveDateTime": "2000-03-31",
-      "issued": "2017-05-18T08:12:07.000+00:00",
+      "issued": "2000-03-31T00:00:00.000+00:00",
       "performer": [ {
         "reference": "Practitioner/298F8D0B-C3B9-0598-4D0E-3ADB6F7B1DEF"
       } ],
@@ -9437,13 +9437,13 @@
         "text": "Open clipping of remaining solitary fallopian tube"
       },
       "subject": {
-        "reference": "Patient/00000000-0000-0000-0000-000000000002"
+        "reference": "Patient/00000000-0000-0000-0000-000000000003"
       },
       "context": {
         "reference": "Encounter/C11B5062-ADAC-11E2-9964-B639E5B05B1F"
       },
       "effectiveDateTime": "2000-03-31",
-      "issued": "2017-05-18T08:12:07.000+00:00",
+      "issued": "2000-03-31T00:00:00.000+00:00",
       "performer": [ {
         "reference": "Practitioner/298F8D0B-C3B9-0598-4D0E-3ADB6F7B1DEF"
       } ],
@@ -9484,13 +9484,13 @@
         "text": "Open clipping of residual solitary fallopian tube"
       },
       "subject": {
-        "reference": "Patient/00000000-0000-0000-0000-000000000002"
+        "reference": "Patient/00000000-0000-0000-0000-000000000003"
       },
       "context": {
         "reference": "Encounter/C11B5062-ADAC-11E2-9964-B639E5B05B1F"
       },
       "effectiveDateTime": "2000-03-31",
-      "issued": "2017-05-18T08:12:07.000+00:00",
+      "issued": "2000-03-31T00:00:00.000+00:00",
       "performer": [ {
         "reference": "Practitioner/298F8D0B-C3B9-0598-4D0E-3ADB6F7B1DEF"
       } ],
@@ -9531,13 +9531,13 @@
         "text": "Open ringing of remaining solitary fallopian tube"
       },
       "subject": {
-        "reference": "Patient/00000000-0000-0000-0000-000000000002"
+        "reference": "Patient/00000000-0000-0000-0000-000000000003"
       },
       "context": {
         "reference": "Encounter/C11B5062-ADAC-11E2-9964-B639E5B05B1F"
       },
       "effectiveDateTime": "2000-03-31",
-      "issued": "2017-05-18T08:12:07.000+00:00",
+      "issued": "2000-03-31T00:00:00.000+00:00",
       "performer": [ {
         "reference": "Practitioner/298F8D0B-C3B9-0598-4D0E-3ADB6F7B1DEF"
       } ],
@@ -9575,13 +9575,13 @@
         "text": "Open clipping of fallopian tube NEC"
       },
       "subject": {
-        "reference": "Patient/00000000-0000-0000-0000-000000000002"
+        "reference": "Patient/00000000-0000-0000-0000-000000000003"
       },
       "context": {
         "reference": "Encounter/C11B5062-ADAC-11E2-9964-B639E5B05B1F"
       },
       "effectiveDateTime": "2000-03-31",
-      "issued": "2017-05-18T08:12:07.000+00:00",
+      "issued": "2000-03-31T00:00:00.000+00:00",
       "performer": [ {
         "reference": "Practitioner/298F8D0B-C3B9-0598-4D0E-3ADB6F7B1DEF"
       } ],
@@ -9619,13 +9619,13 @@
         "text": "Open ringing of fallopian tube NEC"
       },
       "subject": {
-        "reference": "Patient/00000000-0000-0000-0000-000000000002"
+        "reference": "Patient/00000000-0000-0000-0000-000000000003"
       },
       "context": {
         "reference": "Encounter/C11B5062-ADAC-11E2-9964-B639E5B05B1F"
       },
       "effectiveDateTime": "2000-03-31",
-      "issued": "2017-05-18T08:12:07.000+00:00",
+      "issued": "2000-03-31T00:00:00.000+00:00",
       "performer": [ {
         "reference": "Practitioner/298F8D0B-C3B9-0598-4D0E-3ADB6F7B1DEF"
       } ],
@@ -9666,13 +9666,13 @@
         "text": "Open clipping of right fallopian tube"
       },
       "subject": {
-        "reference": "Patient/00000000-0000-0000-0000-000000000002"
+        "reference": "Patient/00000000-0000-0000-0000-000000000003"
       },
       "context": {
         "reference": "Encounter/C11B5062-ADAC-11E2-9964-B639E5B05B1F"
       },
       "effectiveDateTime": "2000-03-31",
-      "issued": "2017-05-18T08:12:07.000+00:00",
+      "issued": "2000-03-31T00:00:00.000+00:00",
       "performer": [ {
         "reference": "Practitioner/298F8D0B-C3B9-0598-4D0E-3ADB6F7B1DEF"
       } ],
@@ -9713,13 +9713,13 @@
         "text": "Open ringing of right fallopian tube"
       },
       "subject": {
-        "reference": "Patient/00000000-0000-0000-0000-000000000002"
+        "reference": "Patient/00000000-0000-0000-0000-000000000003"
       },
       "context": {
         "reference": "Encounter/C11B5062-ADAC-11E2-9964-B639E5B05B1F"
       },
       "effectiveDateTime": "2000-03-31",
-      "issued": "2017-05-18T08:12:07.000+00:00",
+      "issued": "2000-03-31T00:00:00.000+00:00",
       "performer": [ {
         "reference": "Practitioner/298F8D0B-C3B9-0598-4D0E-3ADB6F7B1DEF"
       } ],
@@ -9760,13 +9760,13 @@
         "text": "Open clipping of left fallopian tube"
       },
       "subject": {
-        "reference": "Patient/00000000-0000-0000-0000-000000000002"
+        "reference": "Patient/00000000-0000-0000-0000-000000000003"
       },
       "context": {
         "reference": "Encounter/C11B5062-ADAC-11E2-9964-B639E5B05B1F"
       },
       "effectiveDateTime": "2000-03-31",
-      "issued": "2017-05-18T08:12:07.000+00:00",
+      "issued": "2000-03-31T00:00:00.000+00:00",
       "performer": [ {
         "reference": "Practitioner/298F8D0B-C3B9-0598-4D0E-3ADB6F7B1DEF"
       } ],
@@ -9807,13 +9807,13 @@
         "text": "Open ringing of left fallopian tube"
       },
       "subject": {
-        "reference": "Patient/00000000-0000-0000-0000-000000000002"
+        "reference": "Patient/00000000-0000-0000-0000-000000000003"
       },
       "context": {
         "reference": "Encounter/C11B5062-ADAC-11E2-9964-B639E5B05B1F"
       },
       "effectiveDateTime": "2000-03-31",
-      "issued": "2017-05-18T08:12:07.000+00:00",
+      "issued": "2000-03-31T00:00:00.000+00:00",
       "performer": [ {
         "reference": "Practitioner/298F8D0B-C3B9-0598-4D0E-3ADB6F7B1DEF"
       } ],
@@ -9854,13 +9854,13 @@
         "text": "Open ligation of right fallopian tube"
       },
       "subject": {
-        "reference": "Patient/00000000-0000-0000-0000-000000000002"
+        "reference": "Patient/00000000-0000-0000-0000-000000000003"
       },
       "context": {
         "reference": "Encounter/C11B5062-ADAC-11E2-9964-B639E5B05B1F"
       },
       "effectiveDateTime": "2000-03-31",
-      "issued": "2017-05-18T08:12:07.000+00:00",
+      "issued": "2000-03-31T00:00:00.000+00:00",
       "performer": [ {
         "reference": "Practitioner/298F8D0B-C3B9-0598-4D0E-3ADB6F7B1DEF"
       } ],
@@ -9901,13 +9901,13 @@
         "text": "Open ligation of left fallopian tube"
       },
       "subject": {
-        "reference": "Patient/00000000-0000-0000-0000-000000000002"
+        "reference": "Patient/00000000-0000-0000-0000-000000000003"
       },
       "context": {
         "reference": "Encounter/C11B5062-ADAC-11E2-9964-B639E5B05B1F"
       },
       "effectiveDateTime": "2000-03-31",
-      "issued": "2017-05-18T08:12:07.000+00:00",
+      "issued": "2000-03-31T00:00:00.000+00:00",
       "performer": [ {
         "reference": "Practitioner/298F8D0B-C3B9-0598-4D0E-3ADB6F7B1DEF"
       } ],
@@ -9945,13 +9945,13 @@
         "text": "Other specified other open occlusion of fallopian tube"
       },
       "subject": {
-        "reference": "Patient/00000000-0000-0000-0000-000000000002"
+        "reference": "Patient/00000000-0000-0000-0000-000000000003"
       },
       "context": {
         "reference": "Encounter/C11B5062-ADAC-11E2-9964-B639E5B05B1F"
       },
       "effectiveDateTime": "2000-03-31",
-      "issued": "2017-05-18T08:12:07.000+00:00",
+      "issued": "2000-03-31T00:00:00.000+00:00",
       "performer": [ {
         "reference": "Practitioner/298F8D0B-C3B9-0598-4D0E-3ADB6F7B1DEF"
       } ],
@@ -9989,13 +9989,13 @@
         "text": "Other open occlusion of fallopian tube NOS"
       },
       "subject": {
-        "reference": "Patient/00000000-0000-0000-0000-000000000002"
+        "reference": "Patient/00000000-0000-0000-0000-000000000003"
       },
       "context": {
         "reference": "Encounter/C11B5062-ADAC-11E2-9964-B639E5B05B1F"
       },
       "effectiveDateTime": "2000-03-31",
-      "issued": "2017-05-18T08:12:07.000+00:00",
+      "issued": "2000-03-31T00:00:00.000+00:00",
       "performer": [ {
         "reference": "Practitioner/298F8D0B-C3B9-0598-4D0E-3ADB6F7B1DEF"
       } ],
@@ -10036,13 +10036,13 @@
         "text": "Open reversal of female sterilisation"
       },
       "subject": {
-        "reference": "Patient/00000000-0000-0000-0000-000000000002"
+        "reference": "Patient/00000000-0000-0000-0000-000000000003"
       },
       "context": {
         "reference": "Encounter/C11B5062-ADAC-11E2-9964-B639E5B05B1F"
       },
       "effectiveDateTime": "2000-03-31",
-      "issued": "2017-05-18T08:12:07.000+00:00",
+      "issued": "2000-03-31T00:00:00.000+00:00",
       "performer": [ {
         "reference": "Practitioner/298F8D0B-C3B9-0598-4D0E-3ADB6F7B1DEF"
       } ],
@@ -10083,13 +10083,13 @@
         "text": "Open reversal of female sterilisation"
       },
       "subject": {
-        "reference": "Patient/00000000-0000-0000-0000-000000000002"
+        "reference": "Patient/00000000-0000-0000-0000-000000000003"
       },
       "context": {
         "reference": "Encounter/C11B5062-ADAC-11E2-9964-B639E5B05B1F"
       },
       "effectiveDateTime": "2000-03-31",
-      "issued": "2017-05-18T08:12:07.000+00:00",
+      "issued": "2000-03-31T00:00:00.000+00:00",
       "performer": [ {
         "reference": "Practitioner/298F8D0B-C3B9-0598-4D0E-3ADB6F7B1DEF"
       } ],
@@ -10130,13 +10130,13 @@
         "text": "Open reversal of tubal ligation"
       },
       "subject": {
-        "reference": "Patient/00000000-0000-0000-0000-000000000002"
+        "reference": "Patient/00000000-0000-0000-0000-000000000003"
       },
       "context": {
         "reference": "Encounter/C11B5062-ADAC-11E2-9964-B639E5B05B1F"
       },
       "effectiveDateTime": "2000-03-31",
-      "issued": "2017-05-18T08:12:07.000+00:00",
+      "issued": "2000-03-31T00:00:00.000+00:00",
       "performer": [ {
         "reference": "Practitioner/298F8D0B-C3B9-0598-4D0E-3ADB6F7B1DEF"
       } ],
@@ -10174,13 +10174,13 @@
         "text": "Reanastomosis of fallopian tube NEC"
       },
       "subject": {
-        "reference": "Patient/00000000-0000-0000-0000-000000000002"
+        "reference": "Patient/00000000-0000-0000-0000-000000000003"
       },
       "context": {
         "reference": "Encounter/C11B5062-ADAC-11E2-9964-B639E5B05B1F"
       },
       "effectiveDateTime": "2000-03-31",
-      "issued": "2017-05-18T08:12:07.000+00:00",
+      "issued": "2000-03-31T00:00:00.000+00:00",
       "performer": [ {
         "reference": "Practitioner/298F8D0B-C3B9-0598-4D0E-3ADB6F7B1DEF"
       } ],
@@ -10218,13 +10218,13 @@
         "text": "Open removal of clip from fallopian tube NEC"
       },
       "subject": {
-        "reference": "Patient/00000000-0000-0000-0000-000000000002"
+        "reference": "Patient/00000000-0000-0000-0000-000000000003"
       },
       "context": {
         "reference": "Encounter/C11B5062-ADAC-11E2-9964-B639E5B05B1F"
       },
       "effectiveDateTime": "2000-03-31",
-      "issued": "2017-05-18T08:12:07.000+00:00",
+      "issued": "2000-03-31T00:00:00.000+00:00",
       "performer": [ {
         "reference": "Practitioner/298F8D0B-C3B9-0598-4D0E-3ADB6F7B1DEF"
       } ],
@@ -10262,13 +10262,13 @@
         "text": "Open removal of ring from fallopian tube NEC"
       },
       "subject": {
-        "reference": "Patient/00000000-0000-0000-0000-000000000002"
+        "reference": "Patient/00000000-0000-0000-0000-000000000003"
       },
       "context": {
         "reference": "Encounter/C11B5062-ADAC-11E2-9964-B639E5B05B1F"
       },
       "effectiveDateTime": "2000-03-31",
-      "issued": "2017-05-18T08:12:07.000+00:00",
+      "issued": "2000-03-31T00:00:00.000+00:00",
       "performer": [ {
         "reference": "Practitioner/298F8D0B-C3B9-0598-4D0E-3ADB6F7B1DEF"
       } ],
@@ -10306,13 +10306,13 @@
         "text": "Other specified open reversal of female sterilisation"
       },
       "subject": {
-        "reference": "Patient/00000000-0000-0000-0000-000000000002"
+        "reference": "Patient/00000000-0000-0000-0000-000000000003"
       },
       "context": {
         "reference": "Encounter/C11B5062-ADAC-11E2-9964-B639E5B05B1F"
       },
       "effectiveDateTime": "2000-03-31",
-      "issued": "2017-05-18T08:12:07.000+00:00",
+      "issued": "2000-03-31T00:00:00.000+00:00",
       "performer": [ {
         "reference": "Practitioner/298F8D0B-C3B9-0598-4D0E-3ADB6F7B1DEF"
       } ],
@@ -10350,13 +10350,13 @@
         "text": "Open reversal of female sterilisation NOS"
       },
       "subject": {
-        "reference": "Patient/00000000-0000-0000-0000-000000000002"
+        "reference": "Patient/00000000-0000-0000-0000-000000000003"
       },
       "context": {
         "reference": "Encounter/C11B5062-ADAC-11E2-9964-B639E5B05B1F"
       },
       "effectiveDateTime": "2000-03-31",
-      "issued": "2017-05-18T08:12:07.000+00:00",
+      "issued": "2000-03-31T00:00:00.000+00:00",
       "performer": [ {
         "reference": "Practitioner/298F8D0B-C3B9-0598-4D0E-3ADB6F7B1DEF"
       } ],
@@ -10394,13 +10394,13 @@
         "text": "Other repair of fallopian tube"
       },
       "subject": {
-        "reference": "Patient/00000000-0000-0000-0000-000000000002"
+        "reference": "Patient/00000000-0000-0000-0000-000000000003"
       },
       "context": {
         "reference": "Encounter/C11B5062-ADAC-11E2-9964-B639E5B05B1F"
       },
       "effectiveDateTime": "2000-03-31",
-      "issued": "2017-05-18T08:12:07.000+00:00",
+      "issued": "2000-03-31T00:00:00.000+00:00",
       "performer": [ {
         "reference": "Practitioner/298F8D0B-C3B9-0598-4D0E-3ADB6F7B1DEF"
       } ],
@@ -10441,13 +10441,13 @@
         "text": "Reconstruction of fallopian tube"
       },
       "subject": {
-        "reference": "Patient/00000000-0000-0000-0000-000000000002"
+        "reference": "Patient/00000000-0000-0000-0000-000000000003"
       },
       "context": {
         "reference": "Encounter/C11B5062-ADAC-11E2-9964-B639E5B05B1F"
       },
       "effectiveDateTime": "2000-03-31",
-      "issued": "2017-05-18T08:12:07.000+00:00",
+      "issued": "2000-03-31T00:00:00.000+00:00",
       "performer": [ {
         "reference": "Practitioner/298F8D0B-C3B9-0598-4D0E-3ADB6F7B1DEF"
       } ],
@@ -10485,13 +10485,13 @@
         "text": "Replantation of fallopian tube"
       },
       "subject": {
-        "reference": "Patient/00000000-0000-0000-0000-000000000002"
+        "reference": "Patient/00000000-0000-0000-0000-000000000003"
       },
       "context": {
         "reference": "Encounter/C11B5062-ADAC-11E2-9964-B639E5B05B1F"
       },
       "effectiveDateTime": "2000-03-31",
-      "issued": "2017-05-18T08:12:07.000+00:00",
+      "issued": "2000-03-31T00:00:00.000+00:00",
       "performer": [ {
         "reference": "Practitioner/298F8D0B-C3B9-0598-4D0E-3ADB6F7B1DEF"
       } ],
@@ -10529,13 +10529,13 @@
         "text": "Anastomosis of fallopian tube NEC"
       },
       "subject": {
-        "reference": "Patient/00000000-0000-0000-0000-000000000002"
+        "reference": "Patient/00000000-0000-0000-0000-000000000003"
       },
       "context": {
         "reference": "Encounter/C11B5062-ADAC-11E2-9964-B639E5B05B1F"
       },
       "effectiveDateTime": "2000-03-31",
-      "issued": "2017-05-18T08:12:07.000+00:00",
+      "issued": "2000-03-31T00:00:00.000+00:00",
       "performer": [ {
         "reference": "Practitioner/298F8D0B-C3B9-0598-4D0E-3ADB6F7B1DEF"
       } ],

--- a/gp2gp-translator/src/integrationTest/resources/json/LargeMessage/expectedBundleScenario6.json
+++ b/gp2gp-translator/src/integrationTest/resources/json/LargeMessage/expectedBundleScenario6.json
@@ -15,7 +15,7 @@
       },
       "identifier": [ {
         "system": "https://fhir.nhs.uk/Id/nhs-number",
-        "value": "8024037631"
+        "value": "2856448805"
       } ],
       "managingOrganization": {
         "reference": "Organization/0B98DC27-535D-4BC1-A99F-AA5880A446E1"
@@ -387,7 +387,7 @@
         "reference": "Encounter/3B96CB3A-14C2-4FB3-823E-04A7D86BC123"
       },
       "effectiveDateTime": "2018-06-12",
-      "issued": "2018-06-12T08:24:07.000+00:00",
+      "issued": "2018-06-12T00:00:00.000+00:00",
       "performer": [ {
         "reference": "Practitioner/FC4889C6-50CD-4DC1-9FE2-961BAA81DBBC"
       } ],
@@ -444,7 +444,7 @@
         "reference": "Encounter/3B96CB3A-14C2-4FB3-823E-04A7D86BC123"
       },
       "effectiveDateTime": "2018-06-12",
-      "issued": "2018-06-12T08:24:07.000+00:00",
+      "issued": "2018-06-12T00:00:00.000+00:00",
       "performer": [ {
         "reference": "Practitioner/FC4889C6-50CD-4DC1-9FE2-961BAA81DBBC"
       } ],
@@ -501,7 +501,7 @@
         "reference": "Encounter/3B96CB3A-14C2-4FB3-823E-04A7D86BC123"
       },
       "effectiveDateTime": "2018-06-12",
-      "issued": "2018-06-12T08:24:07.000+00:00",
+      "issued": "2018-06-12T00:00:00.000+00:00",
       "performer": [ {
         "reference": "Practitioner/FC4889C6-50CD-4DC1-9FE2-961BAA81DBBC"
       } ],
@@ -563,7 +563,7 @@
         "reference": "Encounter/3B96CB3A-14C2-4FB3-823E-04A7D86BC123"
       },
       "effectiveDateTime": "2018-01-01",
-      "issued": "2018-06-12T08:24:07.000+00:00",
+      "issued": "2018-06-12T00:00:00.000+00:00",
       "performer": [ {
         "reference": "Practitioner/FC4889C6-50CD-4DC1-9FE2-961BAA81DBBC"
       } ],
@@ -619,7 +619,7 @@
         "reference": "Encounter/3B96CB3A-14C2-4FB3-823E-04A7D86BC123"
       },
       "effectiveDateTime": "2018-06-12T08:20:00+00:00",
-      "issued": "2018-06-12T08:24:07.000+00:00",
+      "issued": "2018-06-12T08:20:00.000+00:00",
       "performer": [ {
         "reference": "Practitioner/FC4889C6-50CD-4DC1-9FE2-961BAA81DBBC"
       } ],
@@ -681,7 +681,7 @@
         "reference": "Encounter/3B96CB3A-14C2-4FB3-823E-04A7D86BC123"
       },
       "effectiveDateTime": "2018-06-12T08:20:00+00:00",
-      "issued": "2018-06-12T08:24:07.000+00:00",
+      "issued": "2018-06-12T08:20:00.000+00:00",
       "performer": [ {
         "reference": "Practitioner/FC4889C6-50CD-4DC1-9FE2-961BAA81DBBC"
       } ],
@@ -750,7 +750,7 @@
       "content": [ {
         "attachment": {
           "contentType": "image/tiff",
-          "url": "9206CA42-1F4A-47DA-8C5F-2F197AEAD0F1_588210BB-401D-41F9-84D2-978697CEEFE5_00011000.tif",
+          "url": "D30A00D7-E93A-4071-AB04-B04B6A4E0E00_588210BB-401D-41F9-84D2-978697CEEFE5_00011000.tif",
           "size": 36504
         }
       } ],

--- a/gp2gp-translator/src/integrationTest/resources/json/expectedBundle.json
+++ b/gp2gp-translator/src/integrationTest/resources/json/expectedBundle.json
@@ -15,7 +15,7 @@
       },
       "identifier": [ {
         "system": "https://fhir.nhs.uk/Id/nhs-number",
-        "value": "9194544435"
+        "value": "{{nhsNumber}}"
       } ],
       "managingOrganization": {
         "reference": "Organization/94F00D99-0601-4A8E-AD1D-1B564307B0A6-ORG"
@@ -22071,7 +22071,7 @@
         "reference": "Encounter/CDFC5DF7-2D1B-4EBB-BE5C-6BD2E19405FF"
       },
       "effectiveDateTime": "2010-01-14",
-      "issued": "2010-01-14T10:34:30.000+00:00",
+      "issued": "2010-01-14T00:00:00.000+00:00",
       "performer": [ {
         "reference": "Practitioner/2D70F602-6BB1-47E0-B2EC-39912A59787D"
       } ]
@@ -22113,7 +22113,7 @@
         "reference": "Encounter/3BFD78DE-03BF-44FD-96BC-CDF3DB2CC039"
       },
       "effectiveDateTime": "2010-01-15",
-      "issued": "2010-01-15T10:06:46.000+00:00",
+      "issued": "2010-01-15T00:00:00.000+00:00",
       "performer": [ {
         "reference": "Practitioner/2D70F602-6BB1-47E0-B2EC-39912A59787D"
       } ]
@@ -22151,7 +22151,7 @@
         "reference": "Encounter/8F2D066F-E3DB-4D1A-A39F-E19F55A5D6D3"
       },
       "effectiveDateTime": "2010-03-23T15:36:00+00:00",
-      "issued": "2010-03-23T15:51:27.000+00:00",
+      "issued": "2010-03-23T15:36:00.000+00:00",
       "performer": [ {
         "reference": "Practitioner/2D70F602-6BB1-47E0-B2EC-39912A59787D"
       } ],
@@ -22190,7 +22190,7 @@
         "reference": "Encounter/9326C01E-488B-4EDF-B9C9-529E69EE0361"
       },
       "effectiveDateTime": "2010-03-23T15:39:00+00:00",
-      "issued": "2010-03-23T15:59:35.000+00:00",
+      "issued": "2010-03-23T15:39:00.000+00:00",
       "performer": [ {
         "reference": "Practitioner/2D70F602-6BB1-47E0-B2EC-39912A59787D"
       } ],
@@ -22229,7 +22229,7 @@
         "reference": "Encounter/797F53B7-4D96-4BBE-84CC-3110DB040D90"
       },
       "effectiveDateTime": "2011-11-15T14:54:00+00:00",
-      "issued": "2011-11-15T14:59:10.000+00:00",
+      "issued": "2011-11-15T14:54:00.000+00:00",
       "performer": [ {
         "reference": "Practitioner/884E7627-796C-4C70-870A-D61B88AD2E57"
       } ],
@@ -22272,7 +22272,7 @@
         "reference": "Encounter/2485BC20-90B4-11EC-B1E5-0800200C9A66"
       },
       "effectiveDateTime": "2006-04-25T15:30:00+00:00",
-      "issued": "2010-01-13T15:13:32.000+00:00",
+      "issued": "2006-04-25T15:30:00.000+00:00",
       "performer": [ {
         "reference": "Practitioner/3707E1F0-9011-11EC-B1E5-0800200C9A66"
       } ],
@@ -22343,7 +22343,7 @@
         "reference": "Encounter/2485BC20-90B4-11EC-B1E5-0800200C9A66"
       },
       "effectiveDateTime": "2006-04-25T15:30:00+00:00",
-      "issued": "2010-01-13T15:13:32.000+00:00",
+      "issued": "2006-04-25T15:30:00.000+00:00",
       "performer": [ {
         "reference": "Practitioner/3707E1F0-9011-11EC-B1E5-0800200C9A66"
       } ],
@@ -22411,7 +22411,7 @@
         "reference": "Encounter/2485BC20-90B4-11EC-B1E5-0800200C9A66"
       },
       "effectiveDateTime": "2019-07-08T13:35:00+00:00",
-      "issued": "2010-01-13T15:13:32.000+00:00",
+      "issued": "2019-07-08T13:35:00.000+00:00",
       "performer": [ {
         "reference": "Practitioner/1230F602-6BB1-47E0-B2EC-39912A59787D"
       } ],
@@ -22522,7 +22522,7 @@
         "reference": "Encounter/2485BC20-90B4-11EC-B1E5-0800200C9A66"
       },
       "effectiveDateTime": "2011-01-11T15:33:00+00:00",
-      "issued": "2010-01-13T15:13:32.000+00:00",
+      "issued": "2011-01-11T15:33:00.000+00:00",
       "performer": [ {
         "reference": "Practitioner/3707E1F0-9011-11EC-B1E5-0800200C9A66"
       } ],
@@ -22647,7 +22647,7 @@
         "reference": "Patient/00000000-0000-0000-0000-000000000009"
       },
       "effectiveDateTime": "2010-02-23T00:00:00+00:00",
-      "issued": "2020-01-01T01:01:01.000+00:00",
+      "issued": "2010-02-25T15:41:00.000+00:00",
       "performer": [ {
         "reference": "Practitioner/2D70F602-6BB1-47E0-B2EC-39912A59787D"
       } ],
@@ -22701,7 +22701,7 @@
         "reference": "Patient/00000000-0000-0000-0000-000000000009"
       },
       "effectiveDateTime": "2010-02-23T00:00:00+00:00",
-      "issued": "2020-01-01T01:01:01.000+00:00",
+      "issued": "2010-02-25T15:41:00.000+00:00",
       "performer": [ {
         "reference": "Practitioner/2D70F602-6BB1-47E0-B2EC-39912A59787D"
       } ],
@@ -22762,7 +22762,7 @@
         "reference": "Patient/00000000-0000-0000-0000-000000000009"
       },
       "effectiveDateTime": "2010-02-23T00:00:00+00:00",
-      "issued": "2020-01-01T01:01:01.000+00:00",
+      "issued": "2010-02-25T15:41:00.000+00:00",
       "performer": [ {
         "reference": "Practitioner/2D70F602-6BB1-47E0-B2EC-39912A59787D"
       } ],
@@ -22802,7 +22802,7 @@
         "reference": "Encounter/9FB8560B-A7FF-4F04-9E0B-CFBB4D0AF4E9"
       },
       "effectiveDateTime": "2019-07-08T13:35:00+00:00",
-      "issued": "2010-01-13T15:13:32.000+00:00",
+      "issued": "2019-07-08T13:35:00.000+00:00",
       "performer": [ {
         "reference": "Practitioner/1230F602-6BB1-47E0-B2EC-39912A59787D"
       } ],
@@ -22926,7 +22926,7 @@
         "reference": "Encounter/9FB8560B-A7FF-4F04-9E0B-CFBB4D0AF4E9"
       },
       "effectiveDateTime": "2010-02-23T00:00:00+00:00",
-      "issued": "2010-01-13T15:13:32.000+00:00",
+      "issued": "2010-02-25T15:41:00.000+00:00",
       "performer": [ {
         "reference": "Practitioner/70555A33-0550-405D-BB67-E9805440B38C"
       } ],
@@ -22994,7 +22994,7 @@
         "reference": "Encounter/9FB8560B-A7FF-4F04-9E0B-CFBB4D0AF4E9"
       },
       "effectiveDateTime": "2010-02-23T00:00:00+00:00",
-      "issued": "2010-01-13T15:13:32.000+00:00",
+      "issued": "2010-02-25T15:41:00.000+00:00",
       "performer": [ {
         "reference": "Practitioner/70555A33-0550-405D-BB67-E9805440B38C"
       } ],
@@ -23050,7 +23050,7 @@
         "reference": "Encounter/9FB8560B-A7FF-4F04-9E0B-CFBB4D0AF4E9"
       },
       "effectiveDateTime": "2011-01-11T15:33:00+00:00",
-      "issued": "2010-01-13T15:13:32.000+00:00",
+      "issued": "2011-01-11T15:33:00.000+00:00",
       "performer": [ {
         "reference": "Practitioner/70555A33-0550-405D-BB67-E9805440B38C"
       } ],

--- a/gp2gp-translator/src/main/java/uk/nhs/adaptors/pss/translator/mapper/ObservationMapper.java
+++ b/gp2gp-translator/src/main/java/uk/nhs/adaptors/pss/translator/mapper/ObservationMapper.java
@@ -8,6 +8,7 @@ import org.apache.commons.lang3.StringUtils;
 import org.hl7.fhir.dstu3.model.CodeableConcept;
 import org.hl7.fhir.dstu3.model.DateTimeType;
 import org.hl7.fhir.dstu3.model.Encounter;
+import org.hl7.fhir.dstu3.model.InstantType;
 import org.hl7.fhir.dstu3.model.Observation;
 import org.hl7.fhir.dstu3.model.Patient;
 import org.hl7.fhir.dstu3.model.Period;
@@ -24,10 +25,12 @@ import org.hl7.v3.RCMRMT030101UKObservationStatement;
 import org.hl7.v3.RCMRMT030101UKPertinentInformation02;
 import org.hl7.v3.RCMRMT030101UKRequestStatement;
 import org.hl7.v3.RCMRMT030101UKSubject;
+import org.hl7.v3.TS;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 import uk.nhs.adaptors.pss.translator.util.DatabaseImmunizationChecker;
 import uk.nhs.adaptors.pss.translator.util.DegradedCodeableConcepts;
+import uk.nhs.adaptors.pss.translator.util.ObservationUtil;
 
 import java.math.BigInteger;
 import java.util.ArrayList;
@@ -43,9 +46,9 @@ import static org.hl7.fhir.dstu3.model.Observation.ObservationStatus.FINAL;
 
 import static uk.nhs.adaptors.pss.translator.util.CompoundStatementResourceExtractors.extractAllObservationStatementsWithoutAllergiesAndBloodPressures;
 import static uk.nhs.adaptors.pss.translator.util.CompoundStatementResourceExtractors.extractAllRequestStatements;
+import static uk.nhs.adaptors.pss.translator.util.DateFormatUtil.parseToInstantType;
 import static uk.nhs.adaptors.pss.translator.util.ObservationUtil.getEffective;
 import static uk.nhs.adaptors.pss.translator.util.ObservationUtil.getInterpretation;
-import static uk.nhs.adaptors.pss.translator.util.ObservationUtil.getIssued;
 import static uk.nhs.adaptors.pss.translator.util.ObservationUtil.getReferenceRange;
 import static uk.nhs.adaptors.pss.translator.util.ObservationUtil.getValueQuantity;
 import static uk.nhs.adaptors.pss.translator.util.ParticipantReferenceUtil.getParticipantReference;
@@ -102,7 +105,7 @@ public class ObservationMapper extends AbstractMapper<Observation> {
             .setStatus(FINAL)
             .addIdentifier(buildIdentifier(id, practiseCode))
             .setCode(getCode(observationStatement.getCode()))
-            .setIssuedElement(getIssued(ehrComposition))
+            .setIssuedElement(getIssued(observationStatement, ehrComposition))
             .addPerformer(getParticipantReference(observationStatement.getParticipant(), ehrComposition))
             .setInterpretation(getInterpretation(observationStatement.getInterpretationCode()))
             .setComment(getComment(
@@ -127,6 +130,35 @@ public class ObservationMapper extends AbstractMapper<Observation> {
         return observation;
     }
 
+    private static InstantType getIssued(
+        RCMRMT030101UKObservationStatement observationStatement,
+        RCMRMT030101UKEhrComposition matchingEhrComposition) {
+
+        if (observationStatement.hasAvailabilityTime()
+            && availabilityTimeHasValue(observationStatement.getAvailabilityTime())
+        ) {
+            return parseToInstantType(observationStatement.getAvailabilityTime().getValue());
+        }
+
+        return ObservationUtil.getIssued(matchingEhrComposition);
+    }
+
+    private static InstantType getIssued(
+        RCMRMT030101UKRequestStatement requestStatement,
+        RCMRMT030101UKEhrComposition matchingEhrComposition) {
+        if (requestStatement != null
+            && availabilityTimeHasValue(requestStatement.getAvailabilityTime())
+        ) {
+            return parseToInstantType(requestStatement.getAvailabilityTime().getValue());
+        }
+
+        return ObservationUtil.getIssued(matchingEhrComposition);
+    }
+
+    private static boolean availabilityTimeHasValue(TS availabilityTime) {
+        return availabilityTime != null && availabilityTime.hasValue() && !availabilityTime.hasNullFlavor();
+    }
+
     private Observation mapObservationFromRequestStatement(RCMRMT030101UKEhrComposition ehrComposition,
                                                            RCMRMT030101UKRequestStatement requestStatement, Patient patient,
                                                            List<Encounter> encounters, String practiseCode) {
@@ -137,7 +169,7 @@ public class ObservationMapper extends AbstractMapper<Observation> {
                 .setStatus(FINAL)
                 .addIdentifier(buildIdentifier(id, practiseCode))
                 .setCode(getCode(requestStatement.getCode()))
-                .setIssuedElement(getIssued(ehrComposition))
+                .setIssuedElement(getIssued(requestStatement, ehrComposition))
                 .addPerformer(getParticipantReference(requestStatement.getParticipant(), ehrComposition))
                 .setComment(SELF_REFERRAL)
                 .setSubject(new Reference(patient))

--- a/gp2gp-translator/src/test/java/uk/nhs/adaptors/pss/translator/mapper/ObservationMapperTest.java
+++ b/gp2gp-translator/src/test/java/uk/nhs/adaptors/pss/translator/mapper/ObservationMapperTest.java
@@ -6,6 +6,7 @@ import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.when;
 import static org.springframework.util.ResourceUtils.getFile;
 
+import static uk.nhs.adaptors.pss.translator.util.DateFormatUtil.parseToInstantType;
 import static uk.nhs.adaptors.pss.translator.util.XmlUnmarshallUtil.unmarshallFile;
 
 import java.math.BigDecimal;
@@ -34,9 +35,22 @@ import uk.nhs.adaptors.pss.translator.util.DatabaseImmunizationChecker;
 import uk.nhs.adaptors.pss.translator.util.DegradedCodeableConcepts;
 
 import static uk.nhs.adaptors.common.util.CodeableConceptUtils.createCodeableConcept;
+import static uk.nhs.adaptors.pss.translator.util.XmlUnmarshallUtil.unmarshallString;
 
 @ExtendWith(MockitoExtension.class)
 public class ObservationMapperTest {
+
+    private static final String EHR_EXTRACT_WRAPPER = """
+        <EhrExtract xmlns="urn:hl7-org:v3" classCode="EXTRACT" moodCode="EVN">
+            <component typeCode="COMP">
+                <ehrFolder classCode="FOLDER" moodCode="EVN">
+                    <component typeCode="COMP">
+                        {{ehrComposition}}
+                    </component>
+                </ehrFolder>
+            </component>
+        </EhrExtract>
+        """;
 
     private static final String XML_RESOURCES_BASE = "xml/Observation/";
     private static final String EXAMPLE_ID = "263B2A9F-0B1D-4697-943A-328F70E068DE";
@@ -45,8 +59,6 @@ public class ObservationMapperTest {
     private static final String IDENTIFIER_SYSTEM = "https://PSSAdaptor/TESTPRACTISECODE";
     private static final String INTERPRETATION_SYSTEM = "http://hl7.org/fhir/v2/0078";
     private static final String CODING_DISPLAY_MOCK = "Test Display";
-    private static final String QUANTITY_SYSTEM = "http://unitsofmeasure.org";
-    private static final String ISSUED_EHR_COMPOSITION_EXAMPLE = "2020-01-01T01:01:01.000+00:00";
     private static final String PPRF_PARTICIPANT_ID = "Practitioner/1230F602-6BB1-47E0-B2EC-39912A59787D";
     private static final String NEGATIVE_VALUE = "Negative";
     private static final String TEST_DISPLAY_VALUE = "Test display name";
@@ -89,7 +101,6 @@ public class ObservationMapperTest {
         assertThat(observation.getId()).isEqualTo(EXAMPLE_ID);
         assertThat(observation.getEffective() instanceof DateTimeType).isTrue();
         assertThat(observation.getEffectiveDateTimeType().getValue()).isEqualTo("2019-07-08T13:35:00+00:00");
-        assertThat(observation.getIssuedElement().asStringValue()).isEqualTo(ISSUED_EHR_COMPOSITION_EXAMPLE);
         assertThat(observation.getPerformer().get(0).getReference()).isEqualTo(PPRF_PARTICIPANT_ID);
         assertThat(observation.getValue() instanceof Quantity).isTrue();
         assertQuantity(observation.getValueQuantity(), QUANTITY_VALUE, "kilogram per square meter", "kg/m2");
@@ -153,14 +164,11 @@ public class ObservationMapperTest {
 
     @Test
     public void mapObservationWithNoOptionalData() {
-        //when(codeableConceptMapper.mapToCodeableConcept(any())).thenReturn(CODEABLE_CONCEPT);
         var ehrExtract = unmarshallEhrExtractElement("no_optional_data_observation_example.xml");
         var observation = observationMapper.mapResources(ehrExtract, patient, ENCOUNTER_LIST, PRACTISE_CODE).get(0);
 
         assertFixedValues(observation);
         assertThat(observation.getId()).isEqualTo(EXAMPLE_ID);
-        //assertThat(observation.getCode().getCodingFirstRep().getDisplay()).isEqualTo(CODING_DISPLAY_MOCK);
-        assertThat(observation.getIssuedElement().asStringValue()).isEqualTo(ISSUED_EHR_COMPOSITION_EXAMPLE);
         assertThat(observation.getPerformer().get(0).getReference()).isEqualTo(PPRF_PARTICIPANT_ID);
         assertThat(observation.getEffective()).isNull();
         assertThat(observation.getValue()).isNull();
@@ -342,6 +350,125 @@ public class ObservationMapperTest {
             .isEqualTo(CODING_DISPLAY_MOCK);
         assertThat(observation.getCode().getCodingFirstRep().getSystem())
             .isEqualTo(SNOMED_SYSTEM);
+    }
+
+    @Test
+    public void When_MappingObservationFromObservationStatementWithAvailabilityTime_Expect_IssuedUsesThisValue() {
+        final var ehrCompositionXml = """
+            <ehrComposition classCode="COMPOSITION" moodCode="EVN">
+                <id root="CA4AD477-C33B-4FE7-8417-A242BB3D23AF"/>
+                <author typeCode="AUT" contextControlCode="OP">
+                    <time value="20200101010101"/>
+                </author>
+                <component typeCode="COMP">
+                    <ObservationStatement classCode="OBS" moodCode="EVN">
+                        <id root="263B2A9F-0B1D-4697-943A-328F70E068DE"/>
+                        <availabilityTime value="20200716"/>
+                    </ObservationStatement>
+                </component>
+            </ehrComposition>
+            """;
+        var ehrExtract = unmarshallEhrExtractFromEhrCompositionXml(ehrCompositionXml);
+
+        var observations = observationMapper.mapResources(ehrExtract, patient, ENCOUNTER_LIST, PRACTISE_CODE);
+        var observation = observations.get(0);
+
+        assertThat(observation.getIssuedElement().asStringValue()).
+            isEqualTo(parseToInstantType("20200716").asStringValue());
+    }
+
+    @Test
+    public void When_MappingObservationFromObservationStatementWithoutAvailabilityTime_Expect_IssuedUsesAuthorTime() {
+        final var ehrCompositionXml = """
+            <ehrComposition classCode="COMPOSITION" moodCode="EVN">
+                <id root="CA4AD477-C33B-4FE7-8417-A242BB3D23AF"/>
+                <author typeCode="AUT" contextControlCode="OP">
+                    <time value="20200101010101"/>
+                </author>
+                <component typeCode="COMP">
+                    <ObservationStatement classCode="OBS" moodCode="EVN">
+                        <id root="263B2A9F-0B1D-4697-943A-328F70E068DE"/>
+                    </ObservationStatement>
+                </component>
+            </ehrComposition>
+            """;
+        var ehrExtract = unmarshallEhrExtractFromEhrCompositionXml(ehrCompositionXml);
+
+        var observations = observationMapper.mapResources(ehrExtract, patient, ENCOUNTER_LIST, PRACTISE_CODE);
+        var observation = observations.get(0);
+
+        assertThat(observation.getIssuedElement().asStringValue()).
+            isEqualTo(parseToInstantType("20200101010101").asStringValue());
+    }
+
+    @Test
+    public void When_MappingObservationFromRequestStatementWithAvailabilityTime_Expect_IssuedUsesThisValue() {
+        final var ehrCompositionXml = """
+            <ehrComposition classCode="COMPOSITION" moodCode="EVN">
+                <id root="CA4AD477-C33B-4FE7-8417-A242BB3D23AF"/>
+                <component contextConductionInd="true" typeCode="COMP">
+                    <RequestStatement classCode="OBS" moodCode="RQO">
+                        <id root="8D61D723-D51D-44FB-B814-0EB69DB1D6F4"/>
+                        <code code="8H62.00" codeSystem="2.16.840.1.113883.2.1.6.2" displayName="Referral to G.P.">
+                            <qualifier codeSystem="2.16.840.1.113883.2.1.6.3" inverted="false">
+                                <name code="RequestType" displayName="RequestType"/>
+                                <value code="SelfReferral" displayName="SelfReferral"/>
+                            </qualifier>
+                        </code>
+                        <availabilityTime value="20100119"/>
+                        <priorityCode code="394848005" codeSystem="2.16.840.1.113883.2.1.3.2.4.15" displayName="Normal">
+                            <originalText>Routine</originalText>
+                        </priorityCode>
+                    </RequestStatement>
+                </component>
+            </ehrComposition>
+            """;
+        var ehrExtract = unmarshallEhrExtractFromEhrCompositionXml(ehrCompositionXml);
+
+        var observations = observationMapper.mapResources(ehrExtract, patient, ENCOUNTER_LIST, PRACTISE_CODE);
+        var observation = observations.get(0);
+
+        assertThat(observation.getIssuedElement().asStringValue()).
+            isEqualTo(parseToInstantType("20100119").asStringValue());
+    }
+
+    @Test
+    public void When_MappingObservationFromRequestStatementWithoutAvailabilityTime_Expect_IssuedUsesAuthorTime() {
+        final var ehrCompositionXml = """
+            <ehrComposition classCode="COMPOSITION" moodCode="EVN">
+                <id root="CA4AD477-C33B-4FE7-8417-A242BB3D23AF"/>
+                <author typeCode="AUT" contextControlCode="OP">
+                    <time value="20200101010101"/>
+                </author>
+                <component contextConductionInd="true" typeCode="COMP">
+                    <RequestStatement classCode="OBS" moodCode="RQO">
+                        <id root="8D61D723-D51D-44FB-B814-0EB69DB1D6F4"/>
+                        <code code="8H62.00" codeSystem="2.16.840.1.113883.2.1.6.2" displayName="Referral to G.P.">
+                            <qualifier codeSystem="2.16.840.1.113883.2.1.6.3" inverted="false">
+                                <name code="RequestType" displayName="RequestType"/>
+                                <value code="SelfReferral" displayName="SelfReferral"/>
+                            </qualifier>
+                        </code>
+                        <priorityCode code="394848005" codeSystem="2.16.840.1.113883.2.1.3.2.4.15" displayName="Normal">
+                            <originalText>Routine</originalText>
+                        </priorityCode>
+                    </RequestStatement>
+                </component>
+            </ehrComposition>
+            """;
+        var ehrExtract = unmarshallEhrExtractFromEhrCompositionXml(ehrCompositionXml);
+
+        var observations = observationMapper.mapResources(ehrExtract, patient, ENCOUNTER_LIST, PRACTISE_CODE);
+        var observation = observations.get(0);
+
+        assertThat(observation.getIssuedElement().asStringValue()).
+            isEqualTo(parseToInstantType("20200101010101").asStringValue());
+    }
+
+    @SneakyThrows
+    private RCMRMT030101UK04EhrExtract unmarshallEhrExtractFromEhrCompositionXml(String ehrCompositionXml) {
+        var ehrExtractXml = EHR_EXTRACT_WRAPPER.replace("{{ehrComposition}}", ehrCompositionXml);
+        return unmarshallString(ehrExtractXml, RCMRMT030101UK04EhrExtract.class);
     }
 
     private void assertFixedValues(Observation observation) {


### PR DESCRIPTION
## What

Update ObservationMapper to ensure that the availabilityTime is used when available, when mapping ObservationStatements and ObservationRequests.
Add Unit tests to ObservationMapperTest for this updated functionality.

## Why

GP Connect specifies that the issued date on ObservationStatement should use the following to determine its value:

`The audit trail timestamp representing when the data was recorded.`

It has been reported under NIAD-2911 that it has been identified that the date & time associated with Investigation Results is incorrect.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have updated the [Changelog](/CHANGELOG.md) with details of my change in the UNRELEASED section if this change will affect end users