### PR TITLE
Improve the wording of the developer guidance

### DIFF
--- a/developer-information.md
+++ b/developer-information.md
@@ -23,12 +23,9 @@
 ### How to start local environment
 1. Go to `docker` directory
 2. Create a copy of `example.vars.sh`, name it `vars.sh`
-3. Fill in the passwords inside `vars.sh` file:
-    - `SNOMED_CT_TERMINOLOGY_FILE`: Path to where your SNOMED ZIP file is downloaded to.
-
-    For the description and purpose of other environment variables, refer to the [end user OPERATING guidance](OPERATING.md#environment-variables).
-
-
+3. Fill in the `SNOMED_CT_TERMINOLOGY_FILE` variable inside `vars.sh` file with the path to where your SNOMED ZIP file
+   is downloaded to. For the description and purpose of other environment variables, refer to the
+   [end user OPERATING guidance](OPERATING.md#environment-variables).
 3. Run `start-local-environment.sh` script:
    ```shell script
     ./start-local-environment.sh


### PR DESCRIPTION
## Why

Remove reference to passwords, which don't need populating anymore.

## Type of change

Internal change (non-breaking change with no effect on the functionality affecting end users)

## Checklist:

- [x] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I have updated the [Changelog](/CHANGELOG.md) with details of my change in the UNRELEASED section if this change will affect end users
- [ ] A corresponding change has been made to the [Mapping Documentation repository][mapping-docs]

[mapping-docs]: https://github.com/NHSDigital/patient-switching-adaptors-mapping-documentation