### PR TITLE
NIAD-3054: Also ignore discontinuation reason where the originalText is prefix of pertinentInformation

### DIFF
--- a/gp2gp-translator/src/main/java/uk/nhs/adaptors/pss/translator/mapper/medication/MedicationRequestPlanMapper.java
+++ b/gp2gp-translator/src/main/java/uk/nhs/adaptors/pss/translator/mapper/medication/MedicationRequestPlanMapper.java
@@ -172,12 +172,6 @@ public class MedicationRequestPlanMapper {
     }
 
     private String extractTermText(RCMRMT030101UKDiscontinue discontinue) {
-        String originalText = "";
-        if (discontinue.hasCode() && discontinue.getCode().hasOriginalText()) {
-            originalText = discontinue.getCode().getOriginalText();
-        }
-
-
         var pertinentInfo = discontinue.getPertinentInformation()
                 .stream()
                 .map(RCMRMT030101UKPertinentInformation2::getPertinentSupplyAnnotation)
@@ -187,11 +181,15 @@ public class MedicationRequestPlanMapper {
 
         var stringBuilder = new StringBuilder();
 
-        if (StringUtils.isNotEmpty(originalText) && !pertinentInfo.contains(originalText)) {
-            stringBuilder
-                .append('(')
-                .append(originalText)
-                .append(") ");
+        if (discontinue.hasCode() && discontinue.getCode().hasOriginalText()) {
+            final var originalText = discontinue.getCode().getOriginalText();
+
+            final boolean hasIncumbentSystemDuplicatedOriginalTextWithinPertinentInfo = pertinentInfo.stream().anyMatch(
+                annotation -> annotation.regionMatches(0, originalText, 0, originalText.length())
+            );
+            if (!hasIncumbentSystemDuplicatedOriginalTextWithinPertinentInfo) {
+                stringBuilder.append('(').append(originalText).append(") ");
+            }
         }
 
         stringBuilder.append(


### PR DESCRIPTION
## Why

Incumbent can also include additional comments after the original reason, let's make sure we remove the duplication in that case too.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [x] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] I have updated the [Changelog](/CHANGELOG.md) with details of my change in the UNRELEASED section if this change will affect end users
- [ ] A corresponding change has been made to the [Mapping Documentation repository][mapping-docs]

[mapping-docs]: https://github.com/NHSDigital/patient-switching-adaptors-mapping-documentation