### PR TITLE
NIAD-2991: Use the NarrativeStatement/availabilityTime for filing comment ObservationStatement.issued

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 ### Added
 * Retry mechanism has been added for MHS Runtime exceptions 
 
+### Fixed
+* Mapping of `issued` for Test Group Headers, Test Results, Filing Comment and has been updated to use time value from
+  the GP2GP `ObservationStatement / availabilityTime` field and use `EhrComposition / author / time` if not available.
+
 ## [2.1.1] - 2024-06-19
 
 ### Changed

--- a/gp2gp-translator/src/integrationTest/resources/e2e-mapping/output-json/PWTP10-output.json
+++ b/gp2gp-translator/src/integrationTest/resources/e2e-mapping/output-json/PWTP10-output.json
@@ -3719,7 +3719,7 @@
         "reference": "Encounter/0D68809F-354F-44BF-84AC-F69995369638"
       },
       "effectiveDateTime": "2009-09-30T07:45:00+00:00",
-      "issued": "2010-02-04T08:41:13.000+00:00",
+      "issued": "2009-09-30T07:45:00.000+00:00",
       "performer": [ {
         "reference": "Practitioner/1E473786-E7FA-785E-C911-A8D38FB56F20"
       } ],
@@ -3751,7 +3751,7 @@
         "reference": "Encounter/B6C42958-A107-4188-9A9B-6D58AB25A657"
       },
       "effectiveDateTime": "2010-01-04T12:54:00+00:00",
-      "issued": "2010-02-06T12:48:37.000+00:00",
+      "issued": "2010-01-04T12:54:00.000+00:00",
       "performer": [ {
         "reference": "Practitioner/C5DEFBF3-0174-BC6F-182C-B777B9C6FF43"
       } ],
@@ -3783,7 +3783,7 @@
         "reference": "Encounter/58488EEB-78EA-47F4-9A73-8D6836E09AAB"
       },
       "effectiveDateTime": "2010-02-04T08:47:00+00:00",
-      "issued": "2010-02-04T08:41:39.000+00:00",
+      "issued": "2010-02-04T08:47:00.000+00:00",
       "performer": [ {
         "reference": "Practitioner/C5DEFBF3-0174-BC6F-182C-B777B9C6FF43"
       } ],
@@ -3815,7 +3815,7 @@
         "reference": "Encounter/81A3B881-FE23-4346-A7ED-48ED539E9054"
       },
       "effectiveDateTime": "2010-02-06T12:41:00+00:00",
-      "issued": "2010-02-06T12:44:53.000+00:00",
+      "issued": "2010-02-06T12:41:00.000+00:00",
       "performer": [ {
         "reference": "Practitioner/C5DEFBF3-0174-BC6F-182C-B777B9C6FF43"
       } ],
@@ -3847,7 +3847,7 @@
         "reference": "Encounter/81A3B881-FE23-4346-A7ED-48ED539E9054"
       },
       "effectiveDateTime": "2010-02-06T12:41:00+00:00",
-      "issued": "2010-02-06T12:44:53.000+00:00",
+      "issued": "2010-02-06T12:41:00.000+00:00",
       "performer": [ {
         "reference": "Practitioner/C5DEFBF3-0174-BC6F-182C-B777B9C6FF43"
       } ],
@@ -3879,7 +3879,7 @@
         "reference": "Encounter/81A3B881-FE23-4346-A7ED-48ED539E9054"
       },
       "effectiveDateTime": "2010-02-06T12:41:00+00:00",
-      "issued": "2010-02-06T12:44:53.000+00:00",
+      "issued": "2010-02-06T12:41:00.000+00:00",
       "performer": [ {
         "reference": "Practitioner/C5DEFBF3-0174-BC6F-182C-B777B9C6FF43"
       } ],
@@ -3911,7 +3911,7 @@
         "reference": "Encounter/3995C975-2435-4AEC-AA26-7FF40D751E48"
       },
       "effectiveDateTime": "2010-02-06T12:52:00+00:00",
-      "issued": "2010-02-06T12:47:59.000+00:00",
+      "issued": "2010-02-06T12:52:00.000+00:00",
       "performer": [ {
         "reference": "Practitioner/1E473786-E7FA-785E-C911-A8D38FB56F20"
       } ],
@@ -3943,7 +3943,7 @@
         "reference": "Encounter/0D27AD4C-6CC6-4743-965A-B0F2A020C2FD"
       },
       "effectiveDateTime": "2010-02-06T12:53:00+00:00",
-      "issued": "2010-02-06T12:48:12.000+00:00",
+      "issued": "2010-02-06T12:53:00.000+00:00",
       "performer": [ {
         "reference": "Practitioner/C5DEFBF3-0174-BC6F-182C-B777B9C6FF43"
       } ],
@@ -3975,7 +3975,7 @@
         "reference": "Encounter/20F49BAF-8E7B-49C3-8E64-91AC5810389B"
       },
       "effectiveDateTime": "2010-02-06T12:56:00+00:00",
-      "issued": "2010-02-06T12:51:45.000+00:00",
+      "issued": "2010-02-06T12:56:00.000+00:00",
       "performer": [ {
         "reference": "Practitioner/1E473786-E7FA-785E-C911-A8D38FB56F20"
       } ],

--- a/gp2gp-translator/src/integrationTest/resources/e2e-mapping/output-json/PWTP11-output.json
+++ b/gp2gp-translator/src/integrationTest/resources/e2e-mapping/output-json/PWTP11-output.json
@@ -5003,7 +5003,7 @@
         "reference": "Encounter/76102D2A-8898-4EE3-B0C5-72FC95F93BB0"
       },
       "effectiveDateTime": "2010-03-23T07:59:00+00:00",
-      "issued": "2010-03-24T09:00:00.000+00:00",
+      "issued": "2010-03-23T07:59:00.000+00:00",
       "performer": [ {
         "reference": "Practitioner/1E473786-E7FA-785E-C911-A8D38FB56F20"
       } ],
@@ -5035,7 +5035,7 @@
         "reference": "Encounter/22A00924-FCA4-4B32-9588-5BBC1145AAB0"
       },
       "effectiveDateTime": "2010-03-23T13:46:00+00:00",
-      "issued": "2010-03-23T15:02:28.000+00:00",
+      "issued": "2010-03-23T13:46:00.000+00:00",
       "performer": [ {
         "reference": "Practitioner/1E473786-E7FA-785E-C911-A8D38FB56F20"
       } ],
@@ -5067,7 +5067,7 @@
         "reference": "Encounter/6B023A7D-ABD9-494B-A133-D77E6A4B0D2C"
       },
       "effectiveDateTime": "2010-03-24",
-      "issued": "2010-03-24T09:04:07.000+00:00",
+      "issued": "2010-03-24T00:00:00.000+00:00",
       "performer": [ {
         "reference": "Practitioner/1E473786-E7FA-785E-C911-A8D38FB56F20"
       } ],

--- a/gp2gp-translator/src/integrationTest/resources/e2e-mapping/output-json/PWTP2-output.json
+++ b/gp2gp-translator/src/integrationTest/resources/e2e-mapping/output-json/PWTP2-output.json
@@ -9200,7 +9200,7 @@
         "reference": "Encounter/9B69EBA5-F541-4119-9142-0AA0F87E3758"
       },
       "effectiveDateTime": "2009-11-02",
-      "issued": "2010-01-13T15:13:32.000+00:00",
+      "issued": "2009-11-02T00:00:00.000+00:00",
       "performer": [ {
         "reference": "Practitioner/C5DEFBF3-0174-BC6F-182C-B777B9C6FF43"
       } ],
@@ -9232,7 +9232,7 @@
         "reference": "Encounter/B618332C-F6FC-4A79-B193-580FD098B95C"
       },
       "effectiveDateTime": "2010-01-13T11:44:00+00:00",
-      "issued": "2010-01-13T11:37:33.000+00:00",
+      "issued": "2010-01-13T11:44:00.000+00:00",
       "performer": [ {
         "reference": "Practitioner/1E473786-E7FA-785E-C911-A8D38FB56F20"
       } ],
@@ -9264,7 +9264,7 @@
         "reference": "Encounter/F9ADFA5F-A4D0-469D-B22F-2F1787DD7F05"
       },
       "effectiveDateTime": "2010-01-13T11:48:00+00:00",
-      "issued": "2010-01-13T11:42:01.000+00:00",
+      "issued": "2010-01-13T11:48:00.000+00:00",
       "performer": [ {
         "reference": "Practitioner/1E473786-E7FA-785E-C911-A8D38FB56F20"
       } ],
@@ -9296,7 +9296,7 @@
         "reference": "Encounter/F550CC56-EF65-4934-A7B1-3DC2E02243C3"
       },
       "effectiveDateTime": "2010-01-13T15:20:00+00:00",
-      "issued": "2010-01-13T15:29:50.000+00:00",
+      "issued": "2010-01-13T15:20:00.000+00:00",
       "performer": [ {
         "reference": "Practitioner/1E473786-E7FA-785E-C911-A8D38FB56F20"
       } ],
@@ -9328,7 +9328,7 @@
         "reference": "Encounter/9B69F6AE-F991-49EE-9FFD-028E39B38BFE"
       },
       "effectiveDateTime": "2010-01-23T13:48:00+00:00",
-      "issued": "2010-01-23T14:03:54.000+00:00",
+      "issued": "2010-01-23T13:48:00.000+00:00",
       "performer": [ {
         "reference": "Practitioner/1E473786-E7FA-785E-C911-A8D38FB56F20"
       } ],
@@ -9360,7 +9360,7 @@
         "reference": "Encounter/D81C5E8F-CB3A-4A78-92EA-51EC3665648E"
       },
       "effectiveDateTime": "2010-06-09",
-      "issued": "2010-06-09T16:51:21.000+00:00",
+      "issued": "2010-06-09T00:00:00.000+00:00",
       "performer": [ {
         "reference": "Practitioner/1E473786-E7FA-785E-C911-A8D38FB56F20"
       } ],
@@ -9392,7 +9392,7 @@
         "reference": "Encounter/8FEB11AA-5785-43D3-99A9-E9D49EAF2161"
       },
       "effectiveDateTime": "2010-06-10T07:22:00+00:00",
-      "issued": "2010-06-10T07:19:25.000+00:00",
+      "issued": "2010-06-10T07:22:00.000+00:00",
       "performer": [ {
         "reference": "Practitioner/1E473786-E7FA-785E-C911-A8D38FB56F20"
       } ],
@@ -9424,7 +9424,7 @@
         "reference": "Encounter/4088F3A1-CE58-4374-AABA-763C31738281"
       },
       "effectiveDateTime": "2010-07-14T16:55:00+00:00",
-      "issued": "2010-07-14T15:28:13.000+00:00",
+      "issued": "2010-07-14T16:55:00.000+00:00",
       "performer": [ {
         "reference": "Practitioner/1E473786-E7FA-785E-C911-A8D38FB56F20"
       } ],
@@ -9453,7 +9453,7 @@
         "reference": "Patient/00000000-0000-0000-0000-000000000010"
       },
       "effectiveDateTime": "2010-07-14",
-      "issued": "2010-07-14T15:27:49.000+00:00",
+      "issued": "2010-07-14T00:00:00.000+00:00",
       "performer": [ {
         "reference": "Practitioner/1E473786-E7FA-785E-C911-A8D38FB56F20"
       } ],

--- a/gp2gp-translator/src/integrationTest/resources/e2e-mapping/output-json/PWTP4-output.json
+++ b/gp2gp-translator/src/integrationTest/resources/e2e-mapping/output-json/PWTP4-output.json
@@ -18820,7 +18820,7 @@
         "reference": "Encounter/825B1B60-525E-4D0A-B813-F3AE3E18EB5D"
       },
       "effectiveDateTime": "2010-03-23T15:42:00+00:00",
-      "issued": "2010-03-23T16:07:49.000+00:00",
+      "issued": "2010-03-23T15:42:00.000+00:00",
       "performer": [ {
         "reference": "Practitioner/1E473786-E7FA-785E-C911-A8D38FB56F20"
       } ],
@@ -18852,7 +18852,7 @@
         "reference": "Encounter/18ADB528-260B-41D8-ACA5-77529A4A4F59"
       },
       "effectiveDateTime": "2010-08-10T12:17:00+00:00",
-      "issued": "2010-08-10T12:22:33.000+00:00",
+      "issued": "2010-08-10T12:17:00.000+00:00",
       "performer": [ {
         "reference": "Practitioner/C5DEFBF3-0174-BC6F-182C-B777B9C6FF43"
       } ],

--- a/gp2gp-translator/src/integrationTest/resources/e2e-mapping/output-json/PWTP5-output.json
+++ b/gp2gp-translator/src/integrationTest/resources/e2e-mapping/output-json/PWTP5-output.json
@@ -3470,7 +3470,7 @@
         "reference": "Encounter/4C04E966-8CDD-4BED-92CE-220ED82F9ABE"
       },
       "effectiveDateTime": "2010-01-18T09:39:00+00:00",
-      "issued": "2010-01-18T09:33:31.000+00:00",
+      "issued": "2010-01-18T09:39:00.000+00:00",
       "performer": [ {
         "reference": "Practitioner/1E473786-E7FA-785E-C911-A8D38FB56F20"
       } ],
@@ -3502,7 +3502,7 @@
         "reference": "Encounter/B60F6338-CC2A-4DF6-870D-AB2A51DA4AA4"
       },
       "effectiveDateTime": "2010-01-18T09:41:00+00:00",
-      "issued": "2010-01-18T09:36:54.000+00:00",
+      "issued": "2010-01-18T09:41:00.000+00:00",
       "performer": [ {
         "reference": "Practitioner/1E473786-E7FA-785E-C911-A8D38FB56F20"
       } ],
@@ -3534,7 +3534,7 @@
         "reference": "Encounter/F55AB99F-E327-420E-8D0B-4348C61778FF"
       },
       "effectiveDateTime": "2010-01-18T09:42:00+00:00",
-      "issued": "2010-01-18T09:45:24.000+00:00",
+      "issued": "2010-01-18T09:42:00.000+00:00",
       "performer": [ {
         "reference": "Practitioner/1E473786-E7FA-785E-C911-A8D38FB56F20"
       } ],
@@ -3566,7 +3566,7 @@
         "reference": "Encounter/A1C8AD7F-99E6-4EED-B102-362D3961D2AF"
       },
       "effectiveDateTime": "2010-01-18T09:42:00+00:00",
-      "issued": "2010-01-18T11:02:28.000+00:00",
+      "issued": "2010-01-18T09:42:00.000+00:00",
       "performer": [ {
         "reference": "Practitioner/1E473786-E7FA-785E-C911-A8D38FB56F20"
       } ],
@@ -3598,7 +3598,7 @@
         "reference": "Encounter/389A5279-93AD-4AAA-9FE7-95883FCE91B6"
       },
       "effectiveDateTime": "2010-01-18T09:42:00+00:00",
-      "issued": "2010-01-18T11:06:58.000+00:00",
+      "issued": "2010-01-18T09:42:00.000+00:00",
       "performer": [ {
         "reference": "Practitioner/1E473786-E7FA-785E-C911-A8D38FB56F20"
       } ],
@@ -3630,7 +3630,7 @@
         "reference": "Encounter/D09EBBDF-1FD3-4546-986C-6203A09D3C6D"
       },
       "effectiveDateTime": "2010-01-18T09:42:00+00:00",
-      "issued": "2010-01-18T11:27:20.000+00:00",
+      "issued": "2010-01-18T09:42:00.000+00:00",
       "performer": [ {
         "reference": "Practitioner/1E473786-E7FA-785E-C911-A8D38FB56F20"
       } ],
@@ -3662,7 +3662,7 @@
         "reference": "Encounter/D09EBBDF-1FD3-4546-986C-6203A09D3C6D"
       },
       "effectiveDateTime": "2010-01-18T09:42:00+00:00",
-      "issued": "2010-01-18T11:27:20.000+00:00",
+      "issued": "2010-01-18T09:42:00.000+00:00",
       "performer": [ {
         "reference": "Practitioner/1E473786-E7FA-785E-C911-A8D38FB56F20"
       } ],
@@ -3694,7 +3694,7 @@
         "reference": "Encounter/D09EBBDF-1FD3-4546-986C-6203A09D3C6D"
       },
       "effectiveDateTime": "2010-01-18T09:42:00+00:00",
-      "issued": "2010-01-18T11:27:20.000+00:00",
+      "issued": "2010-01-18T09:42:00.000+00:00",
       "performer": [ {
         "reference": "Practitioner/1E473786-E7FA-785E-C911-A8D38FB56F20"
       } ],
@@ -3726,7 +3726,7 @@
         "reference": "Encounter/D09EBBDF-1FD3-4546-986C-6203A09D3C6D"
       },
       "effectiveDateTime": "2010-01-18T09:42:00+00:00",
-      "issued": "2010-01-18T11:27:20.000+00:00",
+      "issued": "2010-01-18T09:42:00.000+00:00",
       "performer": [ {
         "reference": "Practitioner/1E473786-E7FA-785E-C911-A8D38FB56F20"
       } ],
@@ -3758,7 +3758,7 @@
         "reference": "Encounter/D09EBBDF-1FD3-4546-986C-6203A09D3C6D"
       },
       "effectiveDateTime": "2010-01-18T09:42:00+00:00",
-      "issued": "2010-01-18T11:27:20.000+00:00",
+      "issued": "2010-01-18T09:42:00.000+00:00",
       "performer": [ {
         "reference": "Practitioner/1E473786-E7FA-785E-C911-A8D38FB56F20"
       } ],
@@ -3790,7 +3790,7 @@
         "reference": "Encounter/D09EBBDF-1FD3-4546-986C-6203A09D3C6D"
       },
       "effectiveDateTime": "2010-01-18T09:42:00+00:00",
-      "issued": "2010-01-18T11:27:20.000+00:00",
+      "issued": "2010-01-18T09:42:00.000+00:00",
       "performer": [ {
         "reference": "Practitioner/1E473786-E7FA-785E-C911-A8D38FB56F20"
       } ],
@@ -3822,7 +3822,7 @@
         "reference": "Encounter/6CE8318F-2230-47CE-86CC-5210130A00F5"
       },
       "effectiveDateTime": "2010-06-30T04:59:00+00:00",
-      "issued": "2010-06-30T04:48:04.000+00:00",
+      "issued": "2010-06-30T04:59:00.000+00:00",
       "performer": [ {
         "reference": "Practitioner/1E473786-E7FA-785E-C911-A8D38FB56F20"
       } ],
@@ -3854,7 +3854,7 @@
         "reference": "Encounter/CF355E94-C4BB-44A8-A346-785A993F37F0"
       },
       "effectiveDateTime": "2011-02-11T13:46:00+00:00",
-      "issued": "2011-02-11T13:51:36.000+00:00",
+      "issued": "2011-02-11T13:46:00.000+00:00",
       "performer": [ {
         "reference": "Practitioner/1E473786-E7FA-785E-C911-A8D38FB56F20"
       } ],
@@ -3886,7 +3886,7 @@
         "reference": "Encounter/55315F2E-55D0-4737-B2BC-4E816F04770E"
       },
       "effectiveDateTime": "2011-02-11T13:53:00+00:00",
-      "issued": "2011-02-11T14:02:43.000+00:00",
+      "issued": "2011-02-11T13:53:00.000+00:00",
       "performer": [ {
         "reference": "Practitioner/1E473786-E7FA-785E-C911-A8D38FB56F20"
       } ],
@@ -3918,7 +3918,7 @@
         "reference": "Encounter/55315F2E-55D0-4737-B2BC-4E816F04770E"
       },
       "effectiveDateTime": "2010-12-04",
-      "issued": "2011-02-11T14:02:43.000+00:00",
+      "issued": "2010-12-04T00:00:00.000+00:00",
       "performer": [ {
         "reference": "Practitioner/1E473786-E7FA-785E-C911-A8D38FB56F20"
       } ],
@@ -3950,7 +3950,7 @@
         "reference": "Encounter/55315F2E-55D0-4737-B2BC-4E816F04770E"
       },
       "effectiveDateTime": "2011-02-11T13:53:00+00:00",
-      "issued": "2011-02-11T14:02:43.000+00:00",
+      "issued": "2011-02-11T13:53:00.000+00:00",
       "performer": [ {
         "reference": "Practitioner/1E473786-E7FA-785E-C911-A8D38FB56F20"
       } ],

--- a/gp2gp-translator/src/integrationTest/resources/e2e-mapping/output-json/PWTP6-output.json
+++ b/gp2gp-translator/src/integrationTest/resources/e2e-mapping/output-json/PWTP6-output.json
@@ -6365,7 +6365,7 @@
         "reference": "Encounter/9F891565-9B5E-487F-9155-6131382DBED8"
       },
       "effectiveDateTime": "2010-01-18T11:41:00+00:00",
-      "issued": "2010-01-18T11:39:45.000+00:00",
+      "issued": "2010-01-18T11:41:00.000+00:00",
       "performer": [ {
         "reference": "Practitioner/1E473786-E7FA-785E-C911-A8D38FB56F20"
       } ],
@@ -6397,7 +6397,7 @@
         "reference": "Encounter/9F891565-9B5E-487F-9155-6131382DBED8"
       },
       "effectiveDateTime": "2010-01-18T11:41:00+00:00",
-      "issued": "2010-01-18T11:39:45.000+00:00",
+      "issued": "2010-01-18T11:41:00.000+00:00",
       "performer": [ {
         "reference": "Practitioner/1E473786-E7FA-785E-C911-A8D38FB56F20"
       } ],
@@ -6429,7 +6429,7 @@
         "reference": "Encounter/9F891565-9B5E-487F-9155-6131382DBED8"
       },
       "effectiveDateTime": "2010-01-18T11:41:00+00:00",
-      "issued": "2010-01-18T11:39:45.000+00:00",
+      "issued": "2010-01-18T11:41:00.000+00:00",
       "performer": [ {
         "reference": "Practitioner/1E473786-E7FA-785E-C911-A8D38FB56F20"
       } ],
@@ -6461,7 +6461,7 @@
         "reference": "Encounter/9F891565-9B5E-487F-9155-6131382DBED8"
       },
       "effectiveDateTime": "2010-01-18T11:41:00+00:00",
-      "issued": "2010-01-18T11:39:45.000+00:00",
+      "issued": "2010-01-18T11:41:00.000+00:00",
       "performer": [ {
         "reference": "Practitioner/1E473786-E7FA-785E-C911-A8D38FB56F20"
       } ],
@@ -6493,7 +6493,7 @@
         "reference": "Encounter/9F891565-9B5E-487F-9155-6131382DBED8"
       },
       "effectiveDateTime": "2010-01-18T11:41:00+00:00",
-      "issued": "2010-01-18T11:39:45.000+00:00",
+      "issued": "2010-01-18T11:41:00.000+00:00",
       "performer": [ {
         "reference": "Practitioner/1E473786-E7FA-785E-C911-A8D38FB56F20"
       } ],
@@ -6525,7 +6525,7 @@
         "reference": "Encounter/9F891565-9B5E-487F-9155-6131382DBED8"
       },
       "effectiveDateTime": "2010-01-18T11:41:00+00:00",
-      "issued": "2010-01-18T11:39:45.000+00:00",
+      "issued": "2010-01-18T11:41:00.000+00:00",
       "performer": [ {
         "reference": "Practitioner/1E473786-E7FA-785E-C911-A8D38FB56F20"
       } ],
@@ -6557,7 +6557,7 @@
         "reference": "Encounter/9F891565-9B5E-487F-9155-6131382DBED8"
       },
       "effectiveDateTime": "2010-01-18T11:41:00+00:00",
-      "issued": "2010-01-18T11:39:45.000+00:00",
+      "issued": "2010-01-18T11:41:00.000+00:00",
       "performer": [ {
         "reference": "Practitioner/1E473786-E7FA-785E-C911-A8D38FB56F20"
       } ],
@@ -6589,7 +6589,7 @@
         "reference": "Encounter/9F891565-9B5E-487F-9155-6131382DBED8"
       },
       "effectiveDateTime": "2010-01-18T11:41:00+00:00",
-      "issued": "2010-01-18T11:39:45.000+00:00",
+      "issued": "2010-01-18T11:41:00.000+00:00",
       "performer": [ {
         "reference": "Practitioner/1E473786-E7FA-785E-C911-A8D38FB56F20"
       } ],
@@ -6621,7 +6621,7 @@
         "reference": "Encounter/62B17FF3-AC74-4118-A567-B34D09798DCA"
       },
       "effectiveDateTime": "2010-01-18T11:47:00+00:00",
-      "issued": "2010-01-18T11:47:10.000+00:00",
+      "issued": "2010-01-18T11:47:00.000+00:00",
       "performer": [ {
         "reference": "Practitioner/1E473786-E7FA-785E-C911-A8D38FB56F20"
       } ],
@@ -6653,7 +6653,7 @@
         "reference": "Encounter/62B17FF3-AC74-4118-A567-B34D09798DCA"
       },
       "effectiveDateTime": "2010-01-18T11:47:00+00:00",
-      "issued": "2010-01-18T11:47:10.000+00:00",
+      "issued": "2010-01-18T11:47:00.000+00:00",
       "performer": [ {
         "reference": "Practitioner/1E473786-E7FA-785E-C911-A8D38FB56F20"
       } ],
@@ -6685,7 +6685,7 @@
         "reference": "Encounter/B7A64FCC-6F01-489E-8A2E-6D5080EFB36C"
       },
       "effectiveDateTime": "2011-01-11T15:33:00+00:00",
-      "issued": "2011-01-11T15:39:27.000+00:00",
+      "issued": "2011-01-11T15:33:00.000+00:00",
       "performer": [ {
         "reference": "Practitioner/1E473786-E7FA-785E-C911-A8D38FB56F20"
       } ],
@@ -6717,7 +6717,7 @@
         "reference": "Encounter/B7A64FCC-6F01-489E-8A2E-6D5080EFB36C"
       },
       "effectiveDateTime": "2011-01-11T15:33:00+00:00",
-      "issued": "2011-01-11T15:39:27.000+00:00",
+      "issued": "2011-01-11T15:33:00.000+00:00",
       "performer": [ {
         "reference": "Practitioner/1E473786-E7FA-785E-C911-A8D38FB56F20"
       } ],
@@ -6749,7 +6749,7 @@
         "reference": "Encounter/B7A64FCC-6F01-489E-8A2E-6D5080EFB36C"
       },
       "effectiveDateTime": "2011-01-11T15:33:00+00:00",
-      "issued": "2011-01-11T15:39:27.000+00:00",
+      "issued": "2011-01-11T15:33:00.000+00:00",
       "performer": [ {
         "reference": "Practitioner/1E473786-E7FA-785E-C911-A8D38FB56F20"
       } ],
@@ -6781,7 +6781,7 @@
         "reference": "Encounter/B7A64FCC-6F01-489E-8A2E-6D5080EFB36C"
       },
       "effectiveDateTime": "2011-01-11T15:33:00+00:00",
-      "issued": "2011-01-11T15:39:27.000+00:00",
+      "issued": "2011-01-11T15:33:00.000+00:00",
       "performer": [ {
         "reference": "Practitioner/1E473786-E7FA-785E-C911-A8D38FB56F20"
       } ],

--- a/gp2gp-translator/src/integrationTest/resources/e2e-mapping/output-json/PWTP9-output.json
+++ b/gp2gp-translator/src/integrationTest/resources/e2e-mapping/output-json/PWTP9-output.json
@@ -15339,7 +15339,7 @@
         "reference": "Encounter/9A47C85C-7A97-4656-8CAF-572B29B3A591"
       },
       "effectiveDateTime": "2010-01-20T16:27:19+00:00",
-      "issued": "2010-03-26T13:52:58.000+00:00",
+      "issued": "2010-01-20T16:27:19.000+00:00",
       "performer": [ {
         "reference": "Practitioner/C5DEFBF3-0174-BC6F-182C-B777B9C6FF43"
       } ],
@@ -15417,7 +15417,7 @@
         "reference": "Encounter/B2410617-E36D-4B94-8DAF-24449E3A0297"
       },
       "effectiveDateTime": "2010-01-20T16:27:20+00:00",
-      "issued": "2010-03-26T13:53:28.000+00:00",
+      "issued": "2010-01-20T16:27:20.000+00:00",
       "performer": [ {
         "reference": "Practitioner/C5DEFBF3-0174-BC6F-182C-B777B9C6FF43"
       } ],
@@ -15495,7 +15495,7 @@
         "reference": "Encounter/DD64A383-7DC5-4E15-A0FF-20F2C4D195A5"
       },
       "effectiveDateTime": "2010-01-20T16:27:23+00:00",
-      "issued": "2010-03-26T14:04:43.000+00:00",
+      "issued": "2010-01-20T16:27:23.000+00:00",
       "performer": [ {
         "reference": "Practitioner/C5DEFBF3-0174-BC6F-182C-B777B9C6FF43"
       } ],
@@ -15578,7 +15578,7 @@
         "reference": "Encounter/6ACDA770-F676-4ECB-AE41-3BECCE24D02C"
       },
       "effectiveDateTime": "2010-01-20T10:46:22+00:00",
-      "issued": "2010-03-26T13:49:25.000+00:00",
+      "issued": "2010-01-20T10:46:22.000+00:00",
       "performer": [ {
         "reference": "Practitioner/1E473786-E7FA-785E-C911-A8D38FB56F20"
       } ],
@@ -15647,7 +15647,7 @@
         "reference": "Encounter/6ACDA770-F676-4ECB-AE41-3BECCE24D02C"
       },
       "effectiveDateTime": "2010-01-20T10:46:22+00:00",
-      "issued": "2010-03-26T13:49:25.000+00:00",
+      "issued": "2010-01-20T10:46:22.000+00:00",
       "performer": [ {
         "reference": "Practitioner/1E473786-E7FA-785E-C911-A8D38FB56F20"
       } ],
@@ -15721,7 +15721,7 @@
         "reference": "Encounter/6ACDA770-F676-4ECB-AE41-3BECCE24D02C"
       },
       "effectiveDateTime": "2010-01-20T10:46:22+00:00",
-      "issued": "2010-03-26T13:49:25.000+00:00",
+      "issued": "2010-01-20T10:46:22.000+00:00",
       "performer": [ {
         "reference": "Practitioner/1E473786-E7FA-785E-C911-A8D38FB56F20"
       } ],
@@ -15838,7 +15838,7 @@
         "reference": "Encounter/9096889B-4D56-4668-86F7-1E1C63011A46"
       },
       "effectiveDateTime": "2010-01-20T10:46:22+00:00",
-      "issued": "2010-03-26T13:45:44.000+00:00",
+      "issued": "2010-01-20T10:46:22.000+00:00",
       "performer": [ {
         "reference": "Practitioner/1E473786-E7FA-785E-C911-A8D38FB56F20"
       } ],
@@ -15930,7 +15930,7 @@
         "reference": "Encounter/9096889B-4D56-4668-86F7-1E1C63011A46"
       },
       "effectiveDateTime": "2010-01-20T10:46:22+00:00",
-      "issued": "2010-03-26T13:45:44.000+00:00",
+      "issued": "2010-01-20T10:46:22.000+00:00",
       "performer": [ {
         "reference": "Practitioner/1E473786-E7FA-785E-C911-A8D38FB56F20"
       } ],
@@ -16012,7 +16012,7 @@
         "reference": "Encounter/730C507B-32CE-4270-80BA-42F4B62BA064"
       },
       "effectiveDateTime": "2010-01-20T10:46:22+00:00",
-      "issued": "2010-02-09T12:21:06.000+00:00",
+      "issued": "2010-01-20T10:46:22.000+00:00",
       "performer": [ {
         "reference": "Practitioner/1E473786-E7FA-785E-C911-A8D38FB56F20"
       } ],
@@ -16085,7 +16085,7 @@
         "reference": "Encounter/B0696913-F11D-4EAA-8BB7-41350B296F3F"
       },
       "effectiveDateTime": "2010-01-20T16:27:23+00:00",
-      "issued": "2010-02-01T09:33:13.000+00:00",
+      "issued": "2010-01-20T16:27:23.000+00:00",
       "performer": [ {
         "reference": "Practitioner/1E473786-E7FA-785E-C911-A8D38FB56F20"
       } ],
@@ -16222,7 +16222,7 @@
         "reference": "Encounter/6AF1549E-55BC-481D-A498-19B213312DB7"
       },
       "effectiveDateTime": "2010-01-20T10:46:22+00:00",
-      "issued": "2010-02-09T12:08:18.000+00:00",
+      "issued": "2010-01-20T10:46:22.000+00:00",
       "performer": [ {
         "reference": "Practitioner/C5DEFBF3-0174-BC6F-182C-B777B9C6FF43"
       } ],
@@ -16290,7 +16290,7 @@
         "reference": "Encounter/1449860E-3953-4D71-A867-3E1E79D2E11B"
       },
       "effectiveDateTime": "2010-01-20T10:46:22+00:00",
-      "issued": "2010-03-26T13:49:48.000+00:00",
+      "issued": "2010-01-20T10:46:22.000+00:00",
       "performer": [ {
         "reference": "Practitioner/1E473786-E7FA-785E-C911-A8D38FB56F20"
       } ],
@@ -16353,7 +16353,7 @@
         "reference": "Encounter/1449860E-3953-4D71-A867-3E1E79D2E11B"
       },
       "effectiveDateTime": "2010-01-20T10:46:22+00:00",
-      "issued": "2010-03-26T13:49:48.000+00:00",
+      "issued": "2010-01-20T10:46:22.000+00:00",
       "performer": [ {
         "reference": "Practitioner/1E473786-E7FA-785E-C911-A8D38FB56F20"
       } ],

--- a/gp2gp-translator/src/integrationTest/resources/e2e-mapping/output-json/PWTP9-output.json
+++ b/gp2gp-translator/src/integrationTest/resources/e2e-mapping/output-json/PWTP9-output.json
@@ -3816,7 +3816,7 @@
         "reference": "Encounter/7040CC1C-A6A6-4B38-A73A-77D5C474F539"
       },
       "effectiveDateTime": "2010-06-24T10:34:01+00:00",
-      "issued": "2010-06-24T11:34:31.000+00:00",
+      "issued": "2010-06-24T10:34:01.000+00:00",
       "performer": [ {
         "reference": "Practitioner/1E473786-E7FA-785E-C911-A8D38FB56F20"
       } ],
@@ -3883,7 +3883,7 @@
         "reference": "Encounter/71CE665D-D113-4359-B640-73CE6ACBE6AB"
       },
       "effectiveDateTime": "2010-06-24T10:34:01+00:00",
-      "issued": "2010-06-24T11:41:27.000+00:00",
+      "issued": "2010-06-24T10:34:01.000+00:00",
       "performer": [ {
         "reference": "Practitioner/1E473786-E7FA-785E-C911-A8D38FB56F20"
       } ],
@@ -3942,7 +3942,7 @@
         "reference": "Encounter/C5323AB7-2CA9-4E85-85E4-8FA896E45628"
       },
       "effectiveDateTime": "2010-06-24T10:34:01+00:00",
-      "issued": "2010-06-24T11:38:00.000+00:00",
+      "issued": "2010-06-24T10:34:01.000+00:00",
       "performer": [ {
         "reference": "Practitioner/1E473786-E7FA-785E-C911-A8D38FB56F20"
       } ],
@@ -4023,7 +4023,7 @@
         "reference": "Encounter/C5323AB7-2CA9-4E85-85E4-8FA896E45628"
       },
       "effectiveDateTime": "2010-06-24T10:34:01+00:00",
-      "issued": "2010-06-24T11:38:00.000+00:00",
+      "issued": "2010-06-24T10:34:01.000+00:00",
       "performer": [ {
         "reference": "Practitioner/1E473786-E7FA-785E-C911-A8D38FB56F20"
       } ],
@@ -4092,7 +4092,7 @@
         "reference": "Encounter/6F7401EE-5139-4F98-8982-70BDD33D4189"
       },
       "effectiveDateTime": "2010-06-24T10:34:01+00:00",
-      "issued": "2010-06-24T11:44:16.000+00:00",
+      "issued": "2010-06-24T10:34:01.000+00:00",
       "performer": [ {
         "reference": "Practitioner/1E473786-E7FA-785E-C911-A8D38FB56F20"
       } ],
@@ -4151,7 +4151,7 @@
         "reference": "Encounter/9A47C85C-7A97-4656-8CAF-572B29B3A591"
       },
       "effectiveDateTime": "2010-01-20T16:27:19+00:00",
-      "issued": "2010-03-26T13:52:58.000+00:00",
+      "issued": "2010-01-20T16:27:19.000+00:00",
       "performer": [ {
         "reference": "Practitioner/C5DEFBF3-0174-BC6F-182C-B777B9C6FF43"
       } ],
@@ -4212,7 +4212,7 @@
         "reference": "Encounter/9A47C85C-7A97-4656-8CAF-572B29B3A591"
       },
       "effectiveDateTime": "2010-01-20T16:27:19+00:00",
-      "issued": "2010-03-26T13:52:58.000+00:00",
+      "issued": "2010-01-20T16:27:19.000+00:00",
       "performer": [ {
         "reference": "Practitioner/C5DEFBF3-0174-BC6F-182C-B777B9C6FF43"
       } ],
@@ -4273,7 +4273,7 @@
         "reference": "Encounter/9A47C85C-7A97-4656-8CAF-572B29B3A591"
       },
       "effectiveDateTime": "2010-01-20T16:27:19+00:00",
-      "issued": "2010-03-26T13:52:58.000+00:00",
+      "issued": "2010-01-20T16:27:19.000+00:00",
       "performer": [ {
         "reference": "Practitioner/C5DEFBF3-0174-BC6F-182C-B777B9C6FF43"
       } ],
@@ -4334,7 +4334,7 @@
         "reference": "Encounter/9A47C85C-7A97-4656-8CAF-572B29B3A591"
       },
       "effectiveDateTime": "2010-01-20T16:27:19+00:00",
-      "issued": "2010-03-26T13:52:58.000+00:00",
+      "issued": "2010-01-20T16:27:19.000+00:00",
       "performer": [ {
         "reference": "Practitioner/C5DEFBF3-0174-BC6F-182C-B777B9C6FF43"
       } ],
@@ -4395,7 +4395,7 @@
         "reference": "Encounter/B2410617-E36D-4B94-8DAF-24449E3A0297"
       },
       "effectiveDateTime": "2010-01-20T16:27:20+00:00",
-      "issued": "2010-03-26T13:53:28.000+00:00",
+      "issued": "2010-01-20T16:27:20.000+00:00",
       "performer": [ {
         "reference": "Practitioner/C5DEFBF3-0174-BC6F-182C-B777B9C6FF43"
       } ],
@@ -4456,7 +4456,7 @@
         "reference": "Encounter/B2410617-E36D-4B94-8DAF-24449E3A0297"
       },
       "effectiveDateTime": "2010-01-20T16:27:20+00:00",
-      "issued": "2010-03-26T13:53:28.000+00:00",
+      "issued": "2010-01-20T16:27:20.000+00:00",
       "performer": [ {
         "reference": "Practitioner/C5DEFBF3-0174-BC6F-182C-B777B9C6FF43"
       } ],
@@ -4517,7 +4517,7 @@
         "reference": "Encounter/B2410617-E36D-4B94-8DAF-24449E3A0297"
       },
       "effectiveDateTime": "2010-01-20T16:27:20+00:00",
-      "issued": "2010-03-26T13:53:28.000+00:00",
+      "issued": "2010-01-20T16:27:20.000+00:00",
       "performer": [ {
         "reference": "Practitioner/C5DEFBF3-0174-BC6F-182C-B777B9C6FF43"
       } ],
@@ -4578,7 +4578,7 @@
         "reference": "Encounter/B2410617-E36D-4B94-8DAF-24449E3A0297"
       },
       "effectiveDateTime": "2010-01-20T16:27:20+00:00",
-      "issued": "2010-03-26T13:53:28.000+00:00",
+      "issued": "2010-01-20T16:27:20.000+00:00",
       "performer": [ {
         "reference": "Practitioner/C5DEFBF3-0174-BC6F-182C-B777B9C6FF43"
       } ],
@@ -4639,7 +4639,7 @@
         "reference": "Encounter/DD64A383-7DC5-4E15-A0FF-20F2C4D195A5"
       },
       "effectiveDateTime": "2010-01-20T16:27:23+00:00",
-      "issued": "2010-03-26T14:04:43.000+00:00",
+      "issued": "2010-01-20T16:27:23.000+00:00",
       "performer": [ {
         "reference": "Practitioner/C5DEFBF3-0174-BC6F-182C-B777B9C6FF43"
       } ],
@@ -4700,7 +4700,7 @@
         "reference": "Encounter/DD64A383-7DC5-4E15-A0FF-20F2C4D195A5"
       },
       "effectiveDateTime": "2010-01-20T16:27:23+00:00",
-      "issued": "2010-03-26T14:04:43.000+00:00",
+      "issued": "2010-01-20T16:27:23.000+00:00",
       "performer": [ {
         "reference": "Practitioner/C5DEFBF3-0174-BC6F-182C-B777B9C6FF43"
       } ],
@@ -4761,7 +4761,7 @@
         "reference": "Encounter/DD64A383-7DC5-4E15-A0FF-20F2C4D195A5"
       },
       "effectiveDateTime": "2010-01-20T16:27:23+00:00",
-      "issued": "2010-03-26T14:04:43.000+00:00",
+      "issued": "2010-01-20T16:27:23.000+00:00",
       "performer": [ {
         "reference": "Practitioner/C5DEFBF3-0174-BC6F-182C-B777B9C6FF43"
       } ],
@@ -4822,7 +4822,7 @@
         "reference": "Encounter/DD64A383-7DC5-4E15-A0FF-20F2C4D195A5"
       },
       "effectiveDateTime": "2010-01-20T16:27:23+00:00",
-      "issued": "2010-03-26T14:04:43.000+00:00",
+      "issued": "2010-01-20T16:27:23.000+00:00",
       "performer": [ {
         "reference": "Practitioner/C5DEFBF3-0174-BC6F-182C-B777B9C6FF43"
       } ],
@@ -4891,7 +4891,7 @@
         "reference": "Encounter/6ACDA770-F676-4ECB-AE41-3BECCE24D02C"
       },
       "effectiveDateTime": "2010-01-20T10:46:22+00:00",
-      "issued": "2010-03-26T13:49:25.000+00:00",
+      "issued": "2010-01-20T10:46:22.000+00:00",
       "performer": [ {
         "reference": "Practitioner/1E473786-E7FA-785E-C911-A8D38FB56F20"
       } ],
@@ -4952,7 +4952,7 @@
         "reference": "Encounter/6ACDA770-F676-4ECB-AE41-3BECCE24D02C"
       },
       "effectiveDateTime": "2010-01-20T10:46:22+00:00",
-      "issued": "2010-03-26T13:49:25.000+00:00",
+      "issued": "2010-01-20T10:46:22.000+00:00",
       "performer": [ {
         "reference": "Practitioner/1E473786-E7FA-785E-C911-A8D38FB56F20"
       } ],
@@ -5027,7 +5027,7 @@
         "reference": "Encounter/6ACDA770-F676-4ECB-AE41-3BECCE24D02C"
       },
       "effectiveDateTime": "2010-01-20T10:46:22+00:00",
-      "issued": "2010-03-26T13:49:25.000+00:00",
+      "issued": "2010-01-20T10:46:22.000+00:00",
       "performer": [ {
         "reference": "Practitioner/1E473786-E7FA-785E-C911-A8D38FB56F20"
       } ],
@@ -5099,7 +5099,7 @@
         "reference": "Encounter/6ACDA770-F676-4ECB-AE41-3BECCE24D02C"
       },
       "effectiveDateTime": "2010-01-20T10:46:22+00:00",
-      "issued": "2010-03-26T13:49:25.000+00:00",
+      "issued": "2010-01-20T10:46:22.000+00:00",
       "performer": [ {
         "reference": "Practitioner/1E473786-E7FA-785E-C911-A8D38FB56F20"
       } ],
@@ -5168,7 +5168,7 @@
         "reference": "Encounter/6ACDA770-F676-4ECB-AE41-3BECCE24D02C"
       },
       "effectiveDateTime": "2010-01-20T10:46:22+00:00",
-      "issued": "2010-03-26T13:49:25.000+00:00",
+      "issued": "2010-01-20T10:46:22.000+00:00",
       "performer": [ {
         "reference": "Practitioner/1E473786-E7FA-785E-C911-A8D38FB56F20"
       } ],
@@ -5243,7 +5243,7 @@
         "reference": "Encounter/6ACDA770-F676-4ECB-AE41-3BECCE24D02C"
       },
       "effectiveDateTime": "2010-01-20T10:46:22+00:00",
-      "issued": "2010-03-26T13:49:25.000+00:00",
+      "issued": "2010-01-20T10:46:22.000+00:00",
       "performer": [ {
         "reference": "Practitioner/1E473786-E7FA-785E-C911-A8D38FB56F20"
       } ],
@@ -5324,7 +5324,7 @@
         "reference": "Encounter/6ACDA770-F676-4ECB-AE41-3BECCE24D02C"
       },
       "effectiveDateTime": "2010-01-20T10:46:22+00:00",
-      "issued": "2010-03-26T13:49:25.000+00:00",
+      "issued": "2010-01-20T10:46:22.000+00:00",
       "performer": [ {
         "reference": "Practitioner/1E473786-E7FA-785E-C911-A8D38FB56F20"
       } ],
@@ -5408,7 +5408,7 @@
         "reference": "Encounter/6ACDA770-F676-4ECB-AE41-3BECCE24D02C"
       },
       "effectiveDateTime": "2010-01-20T10:46:22+00:00",
-      "issued": "2010-03-26T13:49:25.000+00:00",
+      "issued": "2010-01-20T10:46:22.000+00:00",
       "performer": [ {
         "reference": "Practitioner/1E473786-E7FA-785E-C911-A8D38FB56F20"
       } ],
@@ -5474,7 +5474,7 @@
         "reference": "Encounter/6ACDA770-F676-4ECB-AE41-3BECCE24D02C"
       },
       "effectiveDateTime": "2010-01-20T10:46:22+00:00",
-      "issued": "2010-03-26T13:49:25.000+00:00",
+      "issued": "2010-01-20T10:46:22.000+00:00",
       "performer": [ {
         "reference": "Practitioner/1E473786-E7FA-785E-C911-A8D38FB56F20"
       } ],
@@ -5546,7 +5546,7 @@
         "reference": "Encounter/6ACDA770-F676-4ECB-AE41-3BECCE24D02C"
       },
       "effectiveDateTime": "2010-01-20T10:46:22+00:00",
-      "issued": "2010-03-26T13:49:25.000+00:00",
+      "issued": "2010-01-20T10:46:22.000+00:00",
       "performer": [ {
         "reference": "Practitioner/1E473786-E7FA-785E-C911-A8D38FB56F20"
       } ],
@@ -5621,7 +5621,7 @@
         "reference": "Encounter/6ACDA770-F676-4ECB-AE41-3BECCE24D02C"
       },
       "effectiveDateTime": "2010-01-20T10:46:22+00:00",
-      "issued": "2010-03-26T13:49:25.000+00:00",
+      "issued": "2010-01-20T10:46:22.000+00:00",
       "performer": [ {
         "reference": "Practitioner/1E473786-E7FA-785E-C911-A8D38FB56F20"
       } ],
@@ -5701,7 +5701,7 @@
         "reference": "Encounter/6ACDA770-F676-4ECB-AE41-3BECCE24D02C"
       },
       "effectiveDateTime": "2010-01-20T10:46:22+00:00",
-      "issued": "2010-03-26T13:49:25.000+00:00",
+      "issued": "2010-01-20T10:46:22.000+00:00",
       "performer": [ {
         "reference": "Practitioner/1E473786-E7FA-785E-C911-A8D38FB56F20"
       } ],
@@ -5773,7 +5773,7 @@
         "reference": "Encounter/6ACDA770-F676-4ECB-AE41-3BECCE24D02C"
       },
       "effectiveDateTime": "2010-01-20T10:46:22+00:00",
-      "issued": "2010-03-26T13:49:25.000+00:00",
+      "issued": "2010-01-20T10:46:22.000+00:00",
       "performer": [ {
         "reference": "Practitioner/1E473786-E7FA-785E-C911-A8D38FB56F20"
       } ],
@@ -5848,7 +5848,7 @@
         "reference": "Encounter/6ACDA770-F676-4ECB-AE41-3BECCE24D02C"
       },
       "effectiveDateTime": "2010-01-20T10:46:22+00:00",
-      "issued": "2010-03-26T13:49:25.000+00:00",
+      "issued": "2010-01-20T10:46:22.000+00:00",
       "performer": [ {
         "reference": "Practitioner/1E473786-E7FA-785E-C911-A8D38FB56F20"
       } ],
@@ -5920,7 +5920,7 @@
         "reference": "Encounter/6ACDA770-F676-4ECB-AE41-3BECCE24D02C"
       },
       "effectiveDateTime": "2010-01-20T10:46:22+00:00",
-      "issued": "2010-03-26T13:49:25.000+00:00",
+      "issued": "2010-01-20T10:46:22.000+00:00",
       "performer": [ {
         "reference": "Practitioner/1E473786-E7FA-785E-C911-A8D38FB56F20"
       } ],
@@ -5981,7 +5981,7 @@
         "reference": "Encounter/6ACDA770-F676-4ECB-AE41-3BECCE24D02C"
       },
       "effectiveDateTime": "2010-01-20T10:46:22+00:00",
-      "issued": "2010-03-26T13:49:25.000+00:00",
+      "issued": "2010-01-20T10:46:22.000+00:00",
       "performer": [ {
         "reference": "Practitioner/1E473786-E7FA-785E-C911-A8D38FB56F20"
       } ],
@@ -6056,7 +6056,7 @@
         "reference": "Encounter/6ACDA770-F676-4ECB-AE41-3BECCE24D02C"
       },
       "effectiveDateTime": "2010-01-20T10:46:22+00:00",
-      "issued": "2010-03-26T13:49:25.000+00:00",
+      "issued": "2010-01-20T10:46:22.000+00:00",
       "performer": [ {
         "reference": "Practitioner/1E473786-E7FA-785E-C911-A8D38FB56F20"
       } ],
@@ -6117,7 +6117,7 @@
         "reference": "Encounter/6ACDA770-F676-4ECB-AE41-3BECCE24D02C"
       },
       "effectiveDateTime": "2010-01-20T10:46:22+00:00",
-      "issued": "2010-03-26T13:49:25.000+00:00",
+      "issued": "2010-01-20T10:46:22.000+00:00",
       "performer": [ {
         "reference": "Practitioner/1E473786-E7FA-785E-C911-A8D38FB56F20"
       } ],
@@ -6192,7 +6192,7 @@
         "reference": "Encounter/6ACDA770-F676-4ECB-AE41-3BECCE24D02C"
       },
       "effectiveDateTime": "2010-01-20T10:46:22+00:00",
-      "issued": "2010-03-26T13:49:25.000+00:00",
+      "issued": "2010-01-20T10:46:22.000+00:00",
       "performer": [ {
         "reference": "Practitioner/1E473786-E7FA-785E-C911-A8D38FB56F20"
       } ],
@@ -6267,7 +6267,7 @@
         "reference": "Encounter/6ACDA770-F676-4ECB-AE41-3BECCE24D02C"
       },
       "effectiveDateTime": "2010-01-20T10:46:22+00:00",
-      "issued": "2010-03-26T13:49:25.000+00:00",
+      "issued": "2010-01-20T10:46:22.000+00:00",
       "performer": [ {
         "reference": "Practitioner/1E473786-E7FA-785E-C911-A8D38FB56F20"
       } ],
@@ -6339,7 +6339,7 @@
         "reference": "Encounter/9096889B-4D56-4668-86F7-1E1C63011A46"
       },
       "effectiveDateTime": "2010-01-20T10:46:22+00:00",
-      "issued": "2010-03-26T13:45:44.000+00:00",
+      "issued": "2010-01-20T10:46:22.000+00:00",
       "performer": [ {
         "reference": "Practitioner/1E473786-E7FA-785E-C911-A8D38FB56F20"
       } ],
@@ -6414,7 +6414,7 @@
         "reference": "Encounter/9096889B-4D56-4668-86F7-1E1C63011A46"
       },
       "effectiveDateTime": "2010-01-20T10:46:22+00:00",
-      "issued": "2010-03-26T13:45:44.000+00:00",
+      "issued": "2010-01-20T10:46:22.000+00:00",
       "performer": [ {
         "reference": "Practitioner/1E473786-E7FA-785E-C911-A8D38FB56F20"
       } ],
@@ -6486,7 +6486,7 @@
         "reference": "Encounter/9096889B-4D56-4668-86F7-1E1C63011A46"
       },
       "effectiveDateTime": "2010-01-20T10:46:22+00:00",
-      "issued": "2010-03-26T13:45:44.000+00:00",
+      "issued": "2010-01-20T10:46:22.000+00:00",
       "performer": [ {
         "reference": "Practitioner/1E473786-E7FA-785E-C911-A8D38FB56F20"
       } ],
@@ -6561,7 +6561,7 @@
         "reference": "Encounter/9096889B-4D56-4668-86F7-1E1C63011A46"
       },
       "effectiveDateTime": "2010-01-20T10:46:22+00:00",
-      "issued": "2010-03-26T13:45:44.000+00:00",
+      "issued": "2010-01-20T10:46:22.000+00:00",
       "performer": [ {
         "reference": "Practitioner/1E473786-E7FA-785E-C911-A8D38FB56F20"
       } ],
@@ -6639,7 +6639,7 @@
         "reference": "Encounter/9096889B-4D56-4668-86F7-1E1C63011A46"
       },
       "effectiveDateTime": "2010-01-20T10:46:22+00:00",
-      "issued": "2010-03-26T13:45:44.000+00:00",
+      "issued": "2010-01-20T10:46:22.000+00:00",
       "performer": [ {
         "reference": "Practitioner/1E473786-E7FA-785E-C911-A8D38FB56F20"
       } ],
@@ -6707,7 +6707,7 @@
         "reference": "Encounter/9096889B-4D56-4668-86F7-1E1C63011A46"
       },
       "effectiveDateTime": "2010-01-20T10:46:22+00:00",
-      "issued": "2010-03-26T13:45:44.000+00:00",
+      "issued": "2010-01-20T10:46:22.000+00:00",
       "performer": [ {
         "reference": "Practitioner/1E473786-E7FA-785E-C911-A8D38FB56F20"
       } ],
@@ -6781,7 +6781,7 @@
         "reference": "Encounter/9096889B-4D56-4668-86F7-1E1C63011A46"
       },
       "effectiveDateTime": "2010-01-20T10:46:22+00:00",
-      "issued": "2010-03-26T13:45:44.000+00:00",
+      "issued": "2010-01-20T10:46:22.000+00:00",
       "performer": [ {
         "reference": "Practitioner/1E473786-E7FA-785E-C911-A8D38FB56F20"
       } ],
@@ -6856,7 +6856,7 @@
         "reference": "Encounter/9096889B-4D56-4668-86F7-1E1C63011A46"
       },
       "effectiveDateTime": "2010-01-20T10:46:22+00:00",
-      "issued": "2010-03-26T13:45:44.000+00:00",
+      "issued": "2010-01-20T10:46:22.000+00:00",
       "performer": [ {
         "reference": "Practitioner/1E473786-E7FA-785E-C911-A8D38FB56F20"
       } ],
@@ -6934,7 +6934,7 @@
         "reference": "Encounter/9096889B-4D56-4668-86F7-1E1C63011A46"
       },
       "effectiveDateTime": "2010-01-20T10:46:22+00:00",
-      "issued": "2010-03-26T13:45:44.000+00:00",
+      "issued": "2010-01-20T10:46:22.000+00:00",
       "performer": [ {
         "reference": "Practitioner/1E473786-E7FA-785E-C911-A8D38FB56F20"
       } ],
@@ -6997,7 +6997,7 @@
         "reference": "Encounter/9096889B-4D56-4668-86F7-1E1C63011A46"
       },
       "effectiveDateTime": "2010-01-20T10:46:22+00:00",
-      "issued": "2010-03-26T13:45:44.000+00:00",
+      "issued": "2010-01-20T10:46:22.000+00:00",
       "performer": [ {
         "reference": "Practitioner/1E473786-E7FA-785E-C911-A8D38FB56F20"
       } ],
@@ -7072,7 +7072,7 @@
         "reference": "Encounter/9096889B-4D56-4668-86F7-1E1C63011A46"
       },
       "effectiveDateTime": "2010-01-20T10:46:22+00:00",
-      "issued": "2010-03-26T13:45:44.000+00:00",
+      "issued": "2010-01-20T10:46:22.000+00:00",
       "performer": [ {
         "reference": "Practitioner/1E473786-E7FA-785E-C911-A8D38FB56F20"
       } ],
@@ -7149,7 +7149,7 @@
         "reference": "Encounter/9096889B-4D56-4668-86F7-1E1C63011A46"
       },
       "effectiveDateTime": "2010-01-20T10:46:22+00:00",
-      "issued": "2010-03-26T13:45:44.000+00:00",
+      "issued": "2010-01-20T10:46:22.000+00:00",
       "performer": [ {
         "reference": "Practitioner/1E473786-E7FA-785E-C911-A8D38FB56F20"
       } ],
@@ -7226,7 +7226,7 @@
         "reference": "Encounter/9096889B-4D56-4668-86F7-1E1C63011A46"
       },
       "effectiveDateTime": "2010-01-20T10:46:22+00:00",
-      "issued": "2010-03-26T13:45:44.000+00:00",
+      "issued": "2010-01-20T10:46:22.000+00:00",
       "performer": [ {
         "reference": "Practitioner/1E473786-E7FA-785E-C911-A8D38FB56F20"
       } ],
@@ -7303,7 +7303,7 @@
         "reference": "Encounter/730C507B-32CE-4270-80BA-42F4B62BA064"
       },
       "effectiveDateTime": "2010-01-20T10:46:22+00:00",
-      "issued": "2010-02-09T12:21:06.000+00:00",
+      "issued": "2010-01-20T10:46:22.000+00:00",
       "performer": [ {
         "reference": "Practitioner/1E473786-E7FA-785E-C911-A8D38FB56F20"
       } ],
@@ -7377,7 +7377,7 @@
         "reference": "Encounter/730C507B-32CE-4270-80BA-42F4B62BA064"
       },
       "effectiveDateTime": "2010-01-20T10:46:22+00:00",
-      "issued": "2010-02-09T12:21:06.000+00:00",
+      "issued": "2010-01-20T10:46:22.000+00:00",
       "performer": [ {
         "reference": "Practitioner/1E473786-E7FA-785E-C911-A8D38FB56F20"
       } ],
@@ -7449,7 +7449,7 @@
         "reference": "Encounter/730C507B-32CE-4270-80BA-42F4B62BA064"
       },
       "effectiveDateTime": "2010-01-20T10:46:22+00:00",
-      "issued": "2010-02-09T12:21:06.000+00:00",
+      "issued": "2010-01-20T10:46:22.000+00:00",
       "performer": [ {
         "reference": "Practitioner/1E473786-E7FA-785E-C911-A8D38FB56F20"
       } ],
@@ -7524,7 +7524,7 @@
         "reference": "Encounter/730C507B-32CE-4270-80BA-42F4B62BA064"
       },
       "effectiveDateTime": "2010-01-20T10:46:22+00:00",
-      "issued": "2010-02-09T12:21:06.000+00:00",
+      "issued": "2010-01-20T10:46:22.000+00:00",
       "performer": [ {
         "reference": "Practitioner/1E473786-E7FA-785E-C911-A8D38FB56F20"
       } ],
@@ -7606,7 +7606,7 @@
         "reference": "Encounter/730C507B-32CE-4270-80BA-42F4B62BA064"
       },
       "effectiveDateTime": "2010-01-20T10:46:22+00:00",
-      "issued": "2010-02-09T12:21:06.000+00:00",
+      "issued": "2010-01-20T10:46:22.000+00:00",
       "performer": [ {
         "reference": "Practitioner/1E473786-E7FA-785E-C911-A8D38FB56F20"
       } ],
@@ -7681,7 +7681,7 @@
         "reference": "Encounter/730C507B-32CE-4270-80BA-42F4B62BA064"
       },
       "effectiveDateTime": "2010-01-20T10:46:22+00:00",
-      "issued": "2010-02-09T12:21:06.000+00:00",
+      "issued": "2010-01-20T10:46:22.000+00:00",
       "performer": [ {
         "reference": "Practitioner/1E473786-E7FA-785E-C911-A8D38FB56F20"
       } ],
@@ -7754,7 +7754,7 @@
         "reference": "Encounter/730C507B-32CE-4270-80BA-42F4B62BA064"
       },
       "effectiveDateTime": "2010-01-20T10:46:22+00:00",
-      "issued": "2010-02-09T12:21:06.000+00:00",
+      "issued": "2010-01-20T10:46:22.000+00:00",
       "performer": [ {
         "reference": "Practitioner/1E473786-E7FA-785E-C911-A8D38FB56F20"
       } ],
@@ -7809,7 +7809,7 @@
         "reference": "Encounter/730C507B-32CE-4270-80BA-42F4B62BA064"
       },
       "effectiveDateTime": "2010-01-20T10:46:22+00:00",
-      "issued": "2010-02-09T12:21:06.000+00:00",
+      "issued": "2010-01-20T10:46:22.000+00:00",
       "performer": [ {
         "reference": "Practitioner/1E473786-E7FA-785E-C911-A8D38FB56F20"
       } ],
@@ -7866,7 +7866,7 @@
         "reference": "Encounter/A076B5DA-4B2F-42C4-8807-4A71A26ECD25"
       },
       "effectiveDateTime": "2010-01-20T10:46:22+00:00",
-      "issued": "2010-03-26T13:49:40.000+00:00",
+      "issued": "2010-01-20T10:46:22.000+00:00",
       "performer": [ {
         "reference": "Practitioner/1E473786-E7FA-785E-C911-A8D38FB56F20"
       } ],
@@ -7935,7 +7935,7 @@
         "reference": "Encounter/A076B5DA-4B2F-42C4-8807-4A71A26ECD25"
       },
       "effectiveDateTime": "2010-01-20T10:46:22+00:00",
-      "issued": "2010-03-26T13:49:40.000+00:00",
+      "issued": "2010-01-20T10:46:22.000+00:00",
       "performer": [ {
         "reference": "Practitioner/1E473786-E7FA-785E-C911-A8D38FB56F20"
       } ],
@@ -8001,7 +8001,7 @@
         "reference": "Encounter/B0696913-F11D-4EAA-8BB7-41350B296F3F"
       },
       "effectiveDateTime": "2010-01-20T16:27:23+00:00",
-      "issued": "2010-02-01T09:33:13.000+00:00",
+      "issued": "2010-01-20T16:27:23.000+00:00",
       "performer": [ {
         "reference": "Practitioner/1E473786-E7FA-785E-C911-A8D38FB56F20"
       } ],
@@ -8073,7 +8073,7 @@
         "reference": "Encounter/B0696913-F11D-4EAA-8BB7-41350B296F3F"
       },
       "effectiveDateTime": "2010-01-20T16:27:23+00:00",
-      "issued": "2010-02-01T09:33:13.000+00:00",
+      "issued": "2010-01-20T16:27:23.000+00:00",
       "performer": [ {
         "reference": "Practitioner/1E473786-E7FA-785E-C911-A8D38FB56F20"
       } ],
@@ -8148,7 +8148,7 @@
         "reference": "Encounter/B0696913-F11D-4EAA-8BB7-41350B296F3F"
       },
       "effectiveDateTime": "2010-01-20T16:27:23+00:00",
-      "issued": "2010-02-01T09:33:13.000+00:00",
+      "issued": "2010-01-20T16:27:23.000+00:00",
       "performer": [ {
         "reference": "Practitioner/1E473786-E7FA-785E-C911-A8D38FB56F20"
       } ],
@@ -8220,7 +8220,7 @@
         "reference": "Encounter/B0696913-F11D-4EAA-8BB7-41350B296F3F"
       },
       "effectiveDateTime": "2010-01-20T16:27:23+00:00",
-      "issued": "2010-02-01T09:33:13.000+00:00",
+      "issued": "2010-01-20T16:27:23.000+00:00",
       "performer": [ {
         "reference": "Practitioner/1E473786-E7FA-785E-C911-A8D38FB56F20"
       } ],
@@ -8281,7 +8281,7 @@
         "reference": "Encounter/B0696913-F11D-4EAA-8BB7-41350B296F3F"
       },
       "effectiveDateTime": "2010-01-20T16:27:23+00:00",
-      "issued": "2010-02-01T09:33:13.000+00:00",
+      "issued": "2010-01-20T16:27:23.000+00:00",
       "performer": [ {
         "reference": "Practitioner/1E473786-E7FA-785E-C911-A8D38FB56F20"
       } ],
@@ -8354,7 +8354,7 @@
         "reference": "Encounter/B0696913-F11D-4EAA-8BB7-41350B296F3F"
       },
       "effectiveDateTime": "2010-01-20T16:27:23+00:00",
-      "issued": "2010-02-01T09:33:13.000+00:00",
+      "issued": "2010-01-20T16:27:23.000+00:00",
       "performer": [ {
         "reference": "Practitioner/1E473786-E7FA-785E-C911-A8D38FB56F20"
       } ],
@@ -8426,7 +8426,7 @@
         "reference": "Encounter/B0696913-F11D-4EAA-8BB7-41350B296F3F"
       },
       "effectiveDateTime": "2010-01-20T16:27:23+00:00",
-      "issued": "2010-02-01T09:33:13.000+00:00",
+      "issued": "2010-01-20T16:27:23.000+00:00",
       "performer": [ {
         "reference": "Practitioner/1E473786-E7FA-785E-C911-A8D38FB56F20"
       } ],
@@ -8498,7 +8498,7 @@
         "reference": "Encounter/B0696913-F11D-4EAA-8BB7-41350B296F3F"
       },
       "effectiveDateTime": "2010-01-20T16:27:23+00:00",
-      "issued": "2010-02-01T09:33:13.000+00:00",
+      "issued": "2010-01-20T16:27:23.000+00:00",
       "performer": [ {
         "reference": "Practitioner/1E473786-E7FA-785E-C911-A8D38FB56F20"
       } ],
@@ -8573,7 +8573,7 @@
         "reference": "Encounter/B0696913-F11D-4EAA-8BB7-41350B296F3F"
       },
       "effectiveDateTime": "2010-01-20T16:27:23+00:00",
-      "issued": "2010-02-01T09:33:13.000+00:00",
+      "issued": "2010-01-20T16:27:23.000+00:00",
       "performer": [ {
         "reference": "Practitioner/1E473786-E7FA-785E-C911-A8D38FB56F20"
       } ],
@@ -8635,7 +8635,7 @@
         "reference": "Encounter/B0696913-F11D-4EAA-8BB7-41350B296F3F"
       },
       "effectiveDateTime": "2010-01-20T16:27:23+00:00",
-      "issued": "2010-02-01T09:33:13.000+00:00",
+      "issued": "2010-01-20T16:27:23.000+00:00",
       "performer": [ {
         "reference": "Practitioner/1E473786-E7FA-785E-C911-A8D38FB56F20"
       } ],
@@ -8710,7 +8710,7 @@
         "reference": "Encounter/B0696913-F11D-4EAA-8BB7-41350B296F3F"
       },
       "effectiveDateTime": "2010-01-20T16:27:23+00:00",
-      "issued": "2010-02-01T09:33:13.000+00:00",
+      "issued": "2010-01-20T16:27:23.000+00:00",
       "performer": [ {
         "reference": "Practitioner/1E473786-E7FA-785E-C911-A8D38FB56F20"
       } ],
@@ -8785,7 +8785,7 @@
         "reference": "Encounter/B0696913-F11D-4EAA-8BB7-41350B296F3F"
       },
       "effectiveDateTime": "2010-01-20T16:27:23+00:00",
-      "issued": "2010-02-01T09:33:13.000+00:00",
+      "issued": "2010-01-20T16:27:23.000+00:00",
       "performer": [ {
         "reference": "Practitioner/1E473786-E7FA-785E-C911-A8D38FB56F20"
       } ],
@@ -8860,7 +8860,7 @@
         "reference": "Encounter/B0696913-F11D-4EAA-8BB7-41350B296F3F"
       },
       "effectiveDateTime": "2010-01-20T16:27:23+00:00",
-      "issued": "2010-02-01T09:33:13.000+00:00",
+      "issued": "2010-01-20T16:27:23.000+00:00",
       "performer": [ {
         "reference": "Practitioner/1E473786-E7FA-785E-C911-A8D38FB56F20"
       } ],
@@ -8921,7 +8921,7 @@
         "reference": "Encounter/B0696913-F11D-4EAA-8BB7-41350B296F3F"
       },
       "effectiveDateTime": "2010-01-20T16:27:23+00:00",
-      "issued": "2010-02-01T09:33:13.000+00:00",
+      "issued": "2010-01-20T16:27:23.000+00:00",
       "performer": [ {
         "reference": "Practitioner/1E473786-E7FA-785E-C911-A8D38FB56F20"
       } ],
@@ -8993,7 +8993,7 @@
         "reference": "Encounter/B0696913-F11D-4EAA-8BB7-41350B296F3F"
       },
       "effectiveDateTime": "2010-01-20T16:27:23+00:00",
-      "issued": "2010-02-01T09:33:13.000+00:00",
+      "issued": "2010-01-20T16:27:23.000+00:00",
       "performer": [ {
         "reference": "Practitioner/1E473786-E7FA-785E-C911-A8D38FB56F20"
       } ],
@@ -9060,7 +9060,7 @@
         "reference": "Encounter/B0696913-F11D-4EAA-8BB7-41350B296F3F"
       },
       "effectiveDateTime": "2010-01-20T16:27:23+00:00",
-      "issued": "2010-02-01T09:33:13.000+00:00",
+      "issued": "2010-01-20T16:27:23.000+00:00",
       "performer": [ {
         "reference": "Practitioner/1E473786-E7FA-785E-C911-A8D38FB56F20"
       } ],
@@ -9120,7 +9120,7 @@
         "reference": "Encounter/B0696913-F11D-4EAA-8BB7-41350B296F3F"
       },
       "effectiveDateTime": "2010-01-20T16:27:23+00:00",
-      "issued": "2010-02-01T09:33:13.000+00:00",
+      "issued": "2010-01-20T16:27:23.000+00:00",
       "performer": [ {
         "reference": "Practitioner/1E473786-E7FA-785E-C911-A8D38FB56F20"
       } ],
@@ -9180,7 +9180,7 @@
         "reference": "Encounter/6AF1549E-55BC-481D-A498-19B213312DB7"
       },
       "effectiveDateTime": "2010-01-20T10:46:22+00:00",
-      "issued": "2010-02-09T12:08:18.000+00:00",
+      "issued": "2010-01-20T10:46:22.000+00:00",
       "performer": [ {
         "reference": "Practitioner/C5DEFBF3-0174-BC6F-182C-B777B9C6FF43"
       } ],
@@ -9246,7 +9246,7 @@
         "reference": "Encounter/6AF1549E-55BC-481D-A498-19B213312DB7"
       },
       "effectiveDateTime": "2010-01-20T10:46:22+00:00",
-      "issued": "2010-02-09T12:08:18.000+00:00",
+      "issued": "2010-01-20T10:46:22.000+00:00",
       "performer": [ {
         "reference": "Practitioner/C5DEFBF3-0174-BC6F-182C-B777B9C6FF43"
       } ],
@@ -9309,7 +9309,7 @@
         "reference": "Encounter/6AF1549E-55BC-481D-A498-19B213312DB7"
       },
       "effectiveDateTime": "2010-01-20T10:46:22+00:00",
-      "issued": "2010-02-09T12:08:18.000+00:00",
+      "issued": "2010-01-20T10:46:22.000+00:00",
       "performer": [ {
         "reference": "Practitioner/C5DEFBF3-0174-BC6F-182C-B777B9C6FF43"
       } ],
@@ -9366,7 +9366,7 @@
         "reference": "Encounter/6AF1549E-55BC-481D-A498-19B213312DB7"
       },
       "effectiveDateTime": "2010-01-20T10:46:22+00:00",
-      "issued": "2010-02-09T12:08:18.000+00:00",
+      "issued": "2010-01-20T10:46:22.000+00:00",
       "performer": [ {
         "reference": "Practitioner/C5DEFBF3-0174-BC6F-182C-B777B9C6FF43"
       } ],
@@ -9423,7 +9423,7 @@
         "reference": "Encounter/6AF1549E-55BC-481D-A498-19B213312DB7"
       },
       "effectiveDateTime": "2010-01-20T10:46:22+00:00",
-      "issued": "2010-02-09T12:08:18.000+00:00",
+      "issued": "2010-01-20T10:46:22.000+00:00",
       "performer": [ {
         "reference": "Practitioner/C5DEFBF3-0174-BC6F-182C-B777B9C6FF43"
       } ],
@@ -9477,7 +9477,7 @@
         "reference": "Encounter/6AF1549E-55BC-481D-A498-19B213312DB7"
       },
       "effectiveDateTime": "2010-01-20T10:46:22+00:00",
-      "issued": "2010-02-09T12:08:18.000+00:00",
+      "issued": "2010-01-20T10:46:22.000+00:00",
       "performer": [ {
         "reference": "Practitioner/C5DEFBF3-0174-BC6F-182C-B777B9C6FF43"
       } ],
@@ -9534,7 +9534,7 @@
         "reference": "Encounter/6AF1549E-55BC-481D-A498-19B213312DB7"
       },
       "effectiveDateTime": "2010-01-20T10:46:22+00:00",
-      "issued": "2010-02-09T12:08:18.000+00:00",
+      "issued": "2010-01-20T10:46:22.000+00:00",
       "performer": [ {
         "reference": "Practitioner/C5DEFBF3-0174-BC6F-182C-B777B9C6FF43"
       } ],
@@ -9577,7 +9577,7 @@
         "reference": "Encounter/6AF1549E-55BC-481D-A498-19B213312DB7"
       },
       "effectiveDateTime": "2010-01-20T10:46:22+00:00",
-      "issued": "2010-02-09T12:08:18.000+00:00",
+      "issued": "2010-01-20T10:46:22.000+00:00",
       "performer": [ {
         "reference": "Practitioner/C5DEFBF3-0174-BC6F-182C-B777B9C6FF43"
       } ],
@@ -9620,7 +9620,7 @@
         "reference": "Encounter/6AF1549E-55BC-481D-A498-19B213312DB7"
       },
       "effectiveDateTime": "2010-01-20T10:46:22+00:00",
-      "issued": "2010-02-09T12:08:18.000+00:00",
+      "issued": "2010-01-20T10:46:22.000+00:00",
       "performer": [ {
         "reference": "Practitioner/C5DEFBF3-0174-BC6F-182C-B777B9C6FF43"
       } ],
@@ -9677,7 +9677,7 @@
         "reference": "Encounter/6AF1549E-55BC-481D-A498-19B213312DB7"
       },
       "effectiveDateTime": "2010-01-20T10:46:22+00:00",
-      "issued": "2010-02-09T12:08:18.000+00:00",
+      "issued": "2010-01-20T10:46:22.000+00:00",
       "performer": [ {
         "reference": "Practitioner/C5DEFBF3-0174-BC6F-182C-B777B9C6FF43"
       } ],
@@ -9720,7 +9720,7 @@
         "reference": "Encounter/6AF1549E-55BC-481D-A498-19B213312DB7"
       },
       "effectiveDateTime": "2010-01-20T10:46:22+00:00",
-      "issued": "2010-02-09T12:08:18.000+00:00",
+      "issued": "2010-01-20T10:46:22.000+00:00",
       "performer": [ {
         "reference": "Practitioner/C5DEFBF3-0174-BC6F-182C-B777B9C6FF43"
       } ],
@@ -9763,7 +9763,7 @@
         "reference": "Encounter/6AF1549E-55BC-481D-A498-19B213312DB7"
       },
       "effectiveDateTime": "2010-01-20T10:46:22+00:00",
-      "issued": "2010-02-09T12:08:18.000+00:00",
+      "issued": "2010-01-20T10:46:22.000+00:00",
       "performer": [ {
         "reference": "Practitioner/C5DEFBF3-0174-BC6F-182C-B777B9C6FF43"
       } ],
@@ -9820,7 +9820,7 @@
         "reference": "Encounter/1449860E-3953-4D71-A867-3E1E79D2E11B"
       },
       "effectiveDateTime": "2010-01-20T10:46:22+00:00",
-      "issued": "2010-03-26T13:49:48.000+00:00",
+      "issued": "2010-01-20T10:46:22.000+00:00",
       "performer": [ {
         "reference": "Practitioner/1E473786-E7FA-785E-C911-A8D38FB56F20"
       } ],
@@ -9892,7 +9892,7 @@
         "reference": "Encounter/1449860E-3953-4D71-A867-3E1E79D2E11B"
       },
       "effectiveDateTime": "2010-01-20T10:46:22+00:00",
-      "issued": "2010-03-26T13:49:48.000+00:00",
+      "issued": "2010-01-20T10:46:22.000+00:00",
       "performer": [ {
         "reference": "Practitioner/1E473786-E7FA-785E-C911-A8D38FB56F20"
       } ],
@@ -9967,7 +9967,7 @@
         "reference": "Encounter/1449860E-3953-4D71-A867-3E1E79D2E11B"
       },
       "effectiveDateTime": "2010-01-20T10:46:22+00:00",
-      "issued": "2010-03-26T13:49:48.000+00:00",
+      "issued": "2010-01-20T10:46:22.000+00:00",
       "performer": [ {
         "reference": "Practitioner/1E473786-E7FA-785E-C911-A8D38FB56F20"
       } ],
@@ -10042,7 +10042,7 @@
         "reference": "Encounter/1449860E-3953-4D71-A867-3E1E79D2E11B"
       },
       "effectiveDateTime": "2010-01-20T10:46:22+00:00",
-      "issued": "2010-03-26T13:49:48.000+00:00",
+      "issued": "2010-01-20T10:46:22.000+00:00",
       "performer": [ {
         "reference": "Practitioner/1E473786-E7FA-785E-C911-A8D38FB56F20"
       } ],
@@ -10114,7 +10114,7 @@
         "reference": "Encounter/1449860E-3953-4D71-A867-3E1E79D2E11B"
       },
       "effectiveDateTime": "2010-01-20T10:46:22+00:00",
-      "issued": "2010-03-26T13:49:48.000+00:00",
+      "issued": "2010-01-20T10:46:22.000+00:00",
       "performer": [ {
         "reference": "Practitioner/1E473786-E7FA-785E-C911-A8D38FB56F20"
       } ],
@@ -10181,7 +10181,7 @@
         "reference": "Encounter/1449860E-3953-4D71-A867-3E1E79D2E11B"
       },
       "effectiveDateTime": "2010-01-20T10:46:22+00:00",
-      "issued": "2010-03-26T13:49:48.000+00:00",
+      "issued": "2010-01-20T10:46:22.000+00:00",
       "performer": [ {
         "reference": "Practitioner/1E473786-E7FA-785E-C911-A8D38FB56F20"
       } ],
@@ -10253,7 +10253,7 @@
         "reference": "Encounter/1449860E-3953-4D71-A867-3E1E79D2E11B"
       },
       "effectiveDateTime": "2010-01-20T10:46:22+00:00",
-      "issued": "2010-03-26T13:49:48.000+00:00",
+      "issued": "2010-01-20T10:46:22.000+00:00",
       "performer": [ {
         "reference": "Practitioner/1E473786-E7FA-785E-C911-A8D38FB56F20"
       } ],
@@ -10321,7 +10321,7 @@
         "reference": "Encounter/1449860E-3953-4D71-A867-3E1E79D2E11B"
       },
       "effectiveDateTime": "2010-01-20T10:46:22+00:00",
-      "issued": "2010-03-26T13:49:48.000+00:00",
+      "issued": "2010-01-20T10:46:22.000+00:00",
       "performer": [ {
         "reference": "Practitioner/1E473786-E7FA-785E-C911-A8D38FB56F20"
       } ],

--- a/gp2gp-translator/src/integrationTest/resources/e2e-mapping/output-json/PWTP9-output.json
+++ b/gp2gp-translator/src/integrationTest/resources/e2e-mapping/output-json/PWTP9-output.json
@@ -14562,7 +14562,7 @@
         "reference": "Encounter/DD64A383-7DC5-4E15-A0FF-20F2C4D195A5"
       },
       "effectiveDateTime": "2010-01-20T16:27:23+00:00",
-      "issued": "2010-03-26T14:04:43.000+00:00",
+      "issued": "2010-01-20T16:27:23.000+00:00",
       "performer": [ {
         "reference": "Practitioner/C5DEFBF3-0174-BC6F-182C-B777B9C6FF43"
       } ],
@@ -14600,7 +14600,7 @@
         "reference": "Encounter/9096889B-4D56-4668-86F7-1E1C63011A46"
       },
       "effectiveDateTime": "2010-01-20T10:46:22+00:00",
-      "issued": "2010-03-26T13:45:44.000+00:00",
+      "issued": "2010-01-20T10:46:22.000+00:00",
       "performer": [ {
         "reference": "Practitioner/1E473786-E7FA-785E-C911-A8D38FB56F20"
       } ],
@@ -14638,7 +14638,7 @@
         "reference": "Encounter/9096889B-4D56-4668-86F7-1E1C63011A46"
       },
       "effectiveDateTime": "2010-01-20T10:46:22+00:00",
-      "issued": "2010-03-26T13:45:44.000+00:00",
+      "issued": "2010-01-20T10:46:22.000+00:00",
       "performer": [ {
         "reference": "Practitioner/1E473786-E7FA-785E-C911-A8D38FB56F20"
       } ],
@@ -14675,7 +14675,7 @@
       "context": {
         "reference": "Encounter/9096889B-4D56-4668-86F7-1E1C63011A46"
       },
-      "issued": "2010-03-26T13:45:44.000+00:00",
+      "issued": "2010-01-20T10:46:22.000+00:00",
       "performer": [ {
         "reference": "Practitioner/1E473786-E7FA-785E-C911-A8D38FB56F20"
       } ],
@@ -14712,7 +14712,7 @@
       "context": {
         "reference": "Encounter/9096889B-4D56-4668-86F7-1E1C63011A46"
       },
-      "issued": "2010-03-26T13:45:44.000+00:00",
+      "issued": "2010-01-20T10:46:22.000+00:00",
       "performer": [ {
         "reference": "Practitioner/1E473786-E7FA-785E-C911-A8D38FB56F20"
       } ],
@@ -14749,7 +14749,7 @@
       "context": {
         "reference": "Encounter/9096889B-4D56-4668-86F7-1E1C63011A46"
       },
-      "issued": "2010-03-26T13:45:44.000+00:00",
+      "issued": "2010-01-20T10:46:22.000+00:00",
       "performer": [ {
         "reference": "Practitioner/1E473786-E7FA-785E-C911-A8D38FB56F20"
       } ],
@@ -14787,7 +14787,7 @@
         "reference": "Encounter/730C507B-32CE-4270-80BA-42F4B62BA064"
       },
       "effectiveDateTime": "2010-01-20T10:46:22+00:00",
-      "issued": "2010-02-09T12:21:06.000+00:00",
+      "issued": "2010-01-20T10:46:22.000+00:00",
       "performer": [ {
         "reference": "Practitioner/1E473786-E7FA-785E-C911-A8D38FB56F20"
       } ],
@@ -14824,7 +14824,7 @@
       "context": {
         "reference": "Encounter/730C507B-32CE-4270-80BA-42F4B62BA064"
       },
-      "issued": "2010-02-09T12:21:06.000+00:00",
+      "issued": "2010-01-20T10:46:22.000+00:00",
       "performer": [ {
         "reference": "Practitioner/1E473786-E7FA-785E-C911-A8D38FB56F20"
       } ],
@@ -14861,7 +14861,7 @@
       "context": {
         "reference": "Encounter/730C507B-32CE-4270-80BA-42F4B62BA064"
       },
-      "issued": "2010-02-09T12:21:06.000+00:00",
+      "issued": "2010-01-20T10:46:22.000+00:00",
       "performer": [ {
         "reference": "Practitioner/1E473786-E7FA-785E-C911-A8D38FB56F20"
       } ],
@@ -14898,7 +14898,7 @@
       "context": {
         "reference": "Encounter/730C507B-32CE-4270-80BA-42F4B62BA064"
       },
-      "issued": "2010-02-09T12:21:06.000+00:00",
+      "issued": "2010-01-20T10:46:22.000+00:00",
       "performer": [ {
         "reference": "Practitioner/1E473786-E7FA-785E-C911-A8D38FB56F20"
       } ],
@@ -14936,7 +14936,7 @@
         "reference": "Encounter/B0696913-F11D-4EAA-8BB7-41350B296F3F"
       },
       "effectiveDateTime": "2010-01-20T16:27:23+00:00",
-      "issued": "2010-02-01T09:33:13.000+00:00",
+      "issued": "2010-01-20T16:27:23.000+00:00",
       "performer": [ {
         "reference": "Practitioner/1E473786-E7FA-785E-C911-A8D38FB56F20"
       } ],
@@ -14973,7 +14973,7 @@
       "context": {
         "reference": "Encounter/B0696913-F11D-4EAA-8BB7-41350B296F3F"
       },
-      "issued": "2010-02-01T09:33:13.000+00:00",
+      "issued": "2010-01-20T16:27:23.000+00:00",
       "performer": [ {
         "reference": "Practitioner/1E473786-E7FA-785E-C911-A8D38FB56F20"
       } ],
@@ -15010,7 +15010,7 @@
       "context": {
         "reference": "Encounter/B0696913-F11D-4EAA-8BB7-41350B296F3F"
       },
-      "issued": "2010-02-01T09:33:13.000+00:00",
+      "issued": "2010-01-20T16:27:23.000+00:00",
       "performer": [ {
         "reference": "Practitioner/1E473786-E7FA-785E-C911-A8D38FB56F20"
       } ],
@@ -15045,7 +15045,7 @@
         "reference": "Patient/00000000-0000-0000-0000-000000000003"
       },
       "effectiveDateTime": "2001-03-30",
-      "issued": "2010-02-09T12:31:51.000+00:00",
+      "issued": "2001-03-30T00:00:00.000+00:00",
       "performer": [ {
         "reference": "Practitioner/C5DEFBF3-0174-BC6F-182C-B777B9C6FF43"
       } ],
@@ -15074,7 +15074,7 @@
         "reference": "Patient/00000000-0000-0000-0000-000000000003"
       },
       "effectiveDateTime": "2001-03-30",
-      "issued": "2010-02-09T12:31:51.000+00:00",
+      "issued": "2001-03-30T00:00:00.000+00:00",
       "performer": [ {
         "reference": "Practitioner/C5DEFBF3-0174-BC6F-182C-B777B9C6FF43"
       } ],
@@ -15103,7 +15103,7 @@
         "reference": "Patient/00000000-0000-0000-0000-000000000003"
       },
       "effectiveDateTime": "2001-03-30",
-      "issued": "2010-02-09T12:31:51.000+00:00",
+      "issued": "2001-03-30T00:00:00.000+00:00",
       "performer": [ {
         "reference": "Practitioner/C5DEFBF3-0174-BC6F-182C-B777B9C6FF43"
       } ],
@@ -15132,7 +15132,7 @@
         "reference": "Patient/00000000-0000-0000-0000-000000000003"
       },
       "effectiveDateTime": "2002-03-30",
-      "issued": "2010-06-24T10:54:39.000+00:00",
+      "issued": "2002-03-30T00:00:00.000+00:00",
       "performer": [ {
         "reference": "Practitioner/1E473786-E7FA-785E-C911-A8D38FB56F20"
       } ],
@@ -15161,7 +15161,7 @@
         "reference": "Patient/00000000-0000-0000-0000-000000000003"
       },
       "effectiveDateTime": "2002-03-30",
-      "issued": "2010-06-24T11:52:01.000+00:00",
+      "issued": "2002-03-30T00:00:00.000+00:00",
       "performer": [ {
         "reference": "Practitioner/1E473786-E7FA-785E-C911-A8D38FB56F20"
       } ],
@@ -15193,7 +15193,7 @@
         "reference": "Encounter/DD64A383-7DC5-4E15-A0FF-20F2C4D195A5"
       },
       "effectiveDateTime": "2010-01-20T16:27:23+00:00",
-      "issued": "2010-03-26T14:04:43.000+00:00",
+      "issued": "2010-01-20T16:27:23.000+00:00",
       "performer": [ {
         "reference": "Practitioner/C5DEFBF3-0174-BC6F-182C-B777B9C6FF43"
       } ]
@@ -15224,7 +15224,7 @@
         "reference": "Encounter/9096889B-4D56-4668-86F7-1E1C63011A46"
       },
       "effectiveDateTime": "2010-01-20T10:46:22+00:00",
-      "issued": "2010-03-26T13:45:44.000+00:00",
+      "issued": "2010-01-20T10:46:22.000+00:00",
       "performer": [ {
         "reference": "Practitioner/1E473786-E7FA-785E-C911-A8D38FB56F20"
       } ]
@@ -15255,7 +15255,7 @@
         "reference": "Encounter/730C507B-32CE-4270-80BA-42F4B62BA064"
       },
       "effectiveDateTime": "2010-01-20T10:46:22+00:00",
-      "issued": "2010-02-09T12:21:06.000+00:00",
+      "issued": "2010-01-20T10:46:22.000+00:00",
       "performer": [ {
         "reference": "Practitioner/1E473786-E7FA-785E-C911-A8D38FB56F20"
       } ]
@@ -15286,7 +15286,7 @@
         "reference": "Encounter/B0696913-F11D-4EAA-8BB7-41350B296F3F"
       },
       "effectiveDateTime": "2010-01-20T16:27:23+00:00",
-      "issued": "2010-02-01T09:33:13.000+00:00",
+      "issued": "2010-01-20T16:27:23.000+00:00",
       "performer": [ {
         "reference": "Practitioner/1E473786-E7FA-785E-C911-A8D38FB56F20"
       } ]

--- a/gp2gp-translator/src/integrationTest/resources/json/LargeMessage/expectedBundleScenario6.json
+++ b/gp2gp-translator/src/integrationTest/resources/json/LargeMessage/expectedBundleScenario6.json
@@ -956,7 +956,7 @@
         "reference": "Encounter/3B96CB3A-14C2-4FB3-823E-04A7D86BC123"
       },
       "effectiveDateTime": "2018-06-12",
-      "issued": "2018-06-12T08:24:07.000+00:00",
+      "issued": "2018-06-12T00:00:00.000+00:00",
       "performer": [ {
         "reference": "Practitioner/FC4889C6-50CD-4DC1-9FE2-961BAA81DBBC"
       } ],
@@ -988,7 +988,7 @@
         "reference": "Encounter/3B96CB3A-14C2-4FB3-823E-04A7D86BC123"
       },
       "effectiveDateTime": "2018-06-12",
-      "issued": "2018-06-12T08:24:07.000+00:00",
+      "issued": "2018-06-12T00:00:00.000+00:00",
       "performer": [ {
         "reference": "Practitioner/FC4889C6-50CD-4DC1-9FE2-961BAA81DBBC"
       } ],
@@ -1020,7 +1020,7 @@
         "reference": "Encounter/3B96CB3A-14C2-4FB3-823E-04A7D86BC123"
       },
       "effectiveDateTime": "2018-06-12",
-      "issued": "2018-06-12T08:24:07.000+00:00",
+      "issued": "2018-06-12T00:00:00.000+00:00",
       "performer": [ {
         "reference": "Practitioner/FC4889C6-50CD-4DC1-9FE2-961BAA81DBBC"
       } ],

--- a/gp2gp-translator/src/integrationTest/resources/json/LargeMessage/expectedBundleScenario7.json
+++ b/gp2gp-translator/src/integrationTest/resources/json/LargeMessage/expectedBundleScenario7.json
@@ -504,7 +504,7 @@
         "reference": "Encounter/26EE99BB-00FF-4596-9D8B-1D349C1D70A1"
       },
       "effectiveDateTime": "2018-06-12",
-      "issued": "2013-10-25T15:53:28.000+00:00",
+      "issued": "2018-06-12T00:00:00.000+00:00",
       "performer": [ {
         "reference": "Practitioner/00000000-0000-0000-0000-000000000009"
       } ],

--- a/gp2gp-translator/src/integrationTest/resources/json/expectedBundle.json
+++ b/gp2gp-translator/src/integrationTest/resources/json/expectedBundle.json
@@ -22647,7 +22647,7 @@
         "reference": "Patient/00000000-0000-0000-0000-000000000009"
       },
       "effectiveDateTime": "2010-02-23T00:00:00+00:00",
-      "issued": "2020-01-01T01:01:01.000+00:00",
+      "issued": "2010-02-25T15:41:00.000+00:00",
       "performer": [ {
         "reference": "Practitioner/2D70F602-6BB1-47E0-B2EC-39912A59787D"
       } ],
@@ -22701,7 +22701,7 @@
         "reference": "Patient/00000000-0000-0000-0000-000000000009"
       },
       "effectiveDateTime": "2010-02-23T00:00:00+00:00",
-      "issued": "2020-01-01T01:01:01.000+00:00",
+      "issued": "2010-02-25T15:41:00.000+00:00",
       "performer": [ {
         "reference": "Practitioner/2D70F602-6BB1-47E0-B2EC-39912A59787D"
       } ],
@@ -22762,7 +22762,7 @@
         "reference": "Patient/00000000-0000-0000-0000-000000000009"
       },
       "effectiveDateTime": "2010-02-23T00:00:00+00:00",
-      "issued": "2020-01-01T01:01:01.000+00:00",
+      "issued": "2010-02-25T15:41:00.000+00:00",
       "performer": [ {
         "reference": "Practitioner/2D70F602-6BB1-47E0-B2EC-39912A59787D"
       } ],
@@ -22926,7 +22926,7 @@
         "reference": "Encounter/9FB8560B-A7FF-4F04-9E0B-CFBB4D0AF4E9"
       },
       "effectiveDateTime": "2010-02-23T00:00:00+00:00",
-      "issued": "2010-01-13T15:13:32.000+00:00",
+      "issued": "2010-02-25T15:41:00.000+00:00",
       "performer": [ {
         "reference": "Practitioner/70555A33-0550-405D-BB67-E9805440B38C"
       } ],
@@ -22994,7 +22994,7 @@
         "reference": "Encounter/9FB8560B-A7FF-4F04-9E0B-CFBB4D0AF4E9"
       },
       "effectiveDateTime": "2010-02-23T00:00:00+00:00",
-      "issued": "2010-01-13T15:13:32.000+00:00",
+      "issued": "2010-02-25T15:41:00.000+00:00",
       "performer": [ {
         "reference": "Practitioner/70555A33-0550-405D-BB67-E9805440B38C"
       } ],

--- a/gp2gp-translator/src/integrationTest/resources/json/expectedBundle.json
+++ b/gp2gp-translator/src/integrationTest/resources/json/expectedBundle.json
@@ -24347,7 +24347,7 @@
         "reference": "Encounter/CDFC5DF7-2D1B-4EBB-BE5C-6BD2E19405FF"
       },
       "effectiveDateTime": "2011-01-14",
-      "issued": "2010-01-14T10:34:30.000+00:00",
+      "issued": "2011-01-14T00:00:00.000+00:00",
       "performer": [ {
         "reference": "Practitioner/2D70F602-6BB1-47E0-B2EC-39912A59787D"
       } ],
@@ -24379,7 +24379,7 @@
         "reference": "Encounter/4E95E2AF-BF10-45BB-AAA5-2547BD42C806"
       },
       "effectiveDateTime": "2010-03-23T15:42:00+00:00",
-      "issued": "2010-03-23T16:07:49.000+00:00",
+      "issued": "2010-03-23T15:42:00.000+00:00",
       "performer": [ {
         "reference": "Practitioner/2D70F602-6BB1-47E0-B2EC-39912A59787D"
       } ],
@@ -24411,7 +24411,7 @@
         "reference": "Encounter/2485BC20-90B4-11EC-B1E5-0800200C9A66"
       },
       "effectiveDateTime": "2006-04-25T15:30:00+00:00",
-      "issued": "2010-01-13T15:13:32.000+00:00",
+      "issued": "2006-04-25T15:30:00.000+00:00",
       "performer": [ {
         "reference": "Practitioner/3707E1F0-9011-11EC-B1E5-0800200C9A66"
       } ],
@@ -24443,7 +24443,7 @@
         "reference": "Encounter/2485BC20-90B4-11EC-B1E5-0800200C9A66"
       },
       "effectiveDateTime": "2020-10-12T13:33:44+00:00",
-      "issued": "2010-01-13T15:13:32.000+00:00",
+      "issued": "2020-10-12T13:33:44.000+00:00",
       "performer": [ {
         "reference": "Practitioner/3707E1F0-9011-11EC-B1E5-0800200C9A66"
       } ],
@@ -24474,7 +24474,7 @@
       "context": {
         "reference": "Encounter/2485BC20-90B4-11EC-B1E5-0800200C9A66"
       },
-      "issued": "2010-01-13T15:13:32.000+00:00",
+      "issued": "2010-01-13T00:00:00.000+00:00",
       "performer": [ {
         "reference": "Practitioner/3707E1F0-9011-11EC-B1E5-0800200C9A66"
       } ],
@@ -24511,7 +24511,7 @@
       "context": {
         "reference": "Encounter/2485BC20-90B4-11EC-B1E5-0800200C9A66"
       },
-      "issued": "2010-01-13T15:13:32.000+00:00",
+      "issued": "2010-01-13T00:00:00.000+00:00",
       "performer": [ {
         "reference": "Practitioner/3707E1F0-9011-11EC-B1E5-0800200C9A66"
       } ],
@@ -24549,7 +24549,7 @@
         "reference": "Encounter/2485BC20-90B4-11EC-B1E5-0800200C9A66"
       },
       "effectiveDateTime": "2011-01-11T15:33:00+00:00",
-      "issued": "2010-01-13T15:13:32.000+00:00",
+      "issued": "2011-01-11T15:33:00.000+00:00",
       "performer": [ {
         "reference": "Practitioner/3707E1F0-9011-11EC-B1E5-0800200C9A66"
       } ],
@@ -24577,7 +24577,7 @@
       "subject": {
         "reference": "Patient/00000000-0000-0000-0000-000000000009"
       },
-      "issued": "2020-01-01T01:01:01.000+00:00",
+      "issued": "2020-12-15T15:17:04.000+00:00",
       "performer": [ {
         "reference": "Practitioner/2D70F602-6BB1-47E0-B2EC-39912A59787D"
       } ],
@@ -24611,7 +24611,7 @@
       "subject": {
         "reference": "Patient/00000000-0000-0000-0000-000000000009"
       },
-      "issued": "2020-01-01T01:01:01.000+00:00",
+      "issued": "2020-12-15T15:17:13.000+00:00",
       "performer": [ {
         "reference": "Practitioner/2D70F602-6BB1-47E0-B2EC-39912A59787D"
       } ],
@@ -24645,7 +24645,7 @@
       "subject": {
         "reference": "Patient/00000000-0000-0000-0000-000000000009"
       },
-      "issued": "2020-01-01T01:01:01.000+00:00",
+      "issued": "2022-03-24T12:42:13.000+00:00",
       "performer": [ {
         "reference": "Practitioner/2D70F602-6BB1-47E0-B2EC-39912A59787D"
       } ],
@@ -24683,7 +24683,7 @@
         "reference": "Encounter/9FB8560B-A7FF-4F04-9E0B-CFBB4D0AF4E9"
       },
       "effectiveDateTime": "2020-10-12T13:33:44+00:00",
-      "issued": "2010-01-13T15:13:32.000+00:00",
+      "issued": "2020-10-12T13:33:44.000+00:00",
       "performer": [ {
         "reference": "Practitioner/70555A33-0550-405D-BB67-E9805440B38C"
       } ],
@@ -24714,7 +24714,7 @@
       "context": {
         "reference": "Encounter/9FB8560B-A7FF-4F04-9E0B-CFBB4D0AF4E9"
       },
-      "issued": "2010-01-13T15:13:32.000+00:00",
+      "issued": "2010-01-13T00:00:00.000+00:00",
       "performer": [ {
         "reference": "Practitioner/70555A33-0550-405D-BB67-E9805440B38C"
       } ],
@@ -24751,7 +24751,7 @@
       "context": {
         "reference": "Encounter/9FB8560B-A7FF-4F04-9E0B-CFBB4D0AF4E9"
       },
-      "issued": "2010-01-13T15:13:32.000+00:00",
+      "issued": "2010-01-13T00:00:00.000+00:00",
       "performer": [ {
         "reference": "Practitioner/70555A33-0550-405D-BB67-E9805440B38C"
       } ],
@@ -24788,7 +24788,7 @@
       "context": {
         "reference": "Encounter/9FB8560B-A7FF-4F04-9E0B-CFBB4D0AF4E9"
       },
-      "issued": "2010-01-13T15:13:32.000+00:00",
+      "issued": "2010-02-23T00:00:00.000+00:00",
       "performer": [ {
         "reference": "Practitioner/70555A33-0550-405D-BB67-E9805440B38C"
       } ],
@@ -24826,7 +24826,7 @@
         "reference": "Encounter/9FB8560B-A7FF-4F04-9E0B-CFBB4D0AF4E9"
       },
       "effectiveDateTime": "2011-01-11T15:33:00+00:00",
-      "issued": "2010-01-13T15:13:32.000+00:00",
+      "issued": "2011-01-11T15:33:00.000+00:00",
       "performer": [ {
         "reference": "Practitioner/70555A33-0550-405D-BB67-E9805440B38C"
       } ],

--- a/gp2gp-translator/src/integrationTest/resources/json/expectedBundle.json
+++ b/gp2gp-translator/src/integrationTest/resources/json/expectedBundle.json
@@ -24880,7 +24880,7 @@
         "reference": "Encounter/9FB8560B-A7FF-4F04-9E0B-CFBB4D0AF4E9"
       },
       "effectiveDateTime": "2010-02-23T00:00:00+00:00",
-      "issued": "2010-01-13T15:13:32.000+00:00",
+      "issued": "2010-02-25T15:41:00.000+00:00",
       "performer": [ {
         "reference": "Practitioner/70555A33-0550-405D-BB67-E9805440B38C"
       } ],

--- a/gp2gp-translator/src/main/java/uk/nhs/adaptors/pss/translator/mapper/ObservationCommentMapper.java
+++ b/gp2gp-translator/src/main/java/uk/nhs/adaptors/pss/translator/mapper/ObservationCommentMapper.java
@@ -47,7 +47,7 @@ public class ObservationCommentMapper extends AbstractMapper<Observation> {
                 .filter(Objects::nonNull)
                 .filter(narrativeStatement -> !isDocumentReference(narrativeStatement))
                 .map(narrativeStatement -> mapObservation(composition, narrativeStatement, patient, encounters, practiseCode)))
-            .collect((Collectors.toCollection(ArrayList::new)));
+                .collect((Collectors.toCollection(ArrayList::new)));
     }
 
     private Observation mapObservation(RCMRMT030101UKEhrComposition ehrComposition,
@@ -60,7 +60,7 @@ public class ObservationCommentMapper extends AbstractMapper<Observation> {
         observation.setMeta(generateMeta(META_URL));
         observation.setStatus(FINAL);
         observation.setSubject(new Reference(patient));
-        observation.setIssuedElement(createIssued(ehrComposition));
+        observation.setIssuedElement(createIssued(narrativeStatement));
         observation.setCode(createCodeableConcept());
         observation.addPerformer(createPerformer(ehrComposition, narrativeStatement));
         observation.addIdentifier(buildIdentifier(narrativeStatementId.getRoot(), practiseCode));
@@ -84,12 +84,12 @@ public class ObservationCommentMapper extends AbstractMapper<Observation> {
         }
     }
 
-    private InstantType createIssued(RCMRMT030101UKEhrComposition composition) {
-
-        if (!composition.getAuthor().getTime().hasNullFlavor()) {
-            return DateFormatUtil.parseToInstantType(composition.getAuthor().getTime().getValue());
+    private InstantType createIssued(RCMRMT030101UKNarrativeStatement narrativeStatement) {
+        if (narrativeStatement.hasAvailabilityTime() && narrativeStatement.getAvailabilityTime().hasValue()) {
+            return DateFormatUtil.parseToInstantType(
+                narrativeStatement.getAvailabilityTime().getValue()
+            );
         }
-
         return null;
     }
 

--- a/gp2gp-translator/src/test/java/uk/nhs/adaptors/pss/translator/mapper/ObservationCommentMapperTest.java
+++ b/gp2gp-translator/src/test/java/uk/nhs/adaptors/pss/translator/mapper/ObservationCommentMapperTest.java
@@ -65,7 +65,7 @@ public class ObservationCommentMapperTest {
         assertThat(observation.getEffective().toString()).isEqualTo(
             DateFormatUtil.parseToDateTimeType(narrativeStatement.getAvailabilityTime().getValue()).toString());
 
-        assertThat(observation.getIssuedElement().asStringValue()).isEqualTo("2010-01-14T00:00:00.000+00:00");
+        assertThat(observation.getIssuedElement().asStringValue()).isEqualTo("2020-10-12T13:33:44.000+00:00");
 
         var identifier = observation.getIdentifier().get(0);
         assertThat(identifier.getValue()).isEqualTo(narrativeStatementId);
@@ -123,8 +123,8 @@ public class ObservationCommentMapperTest {
     }
 
     @Test
-    public void mapObservationsCompositionHasNoAuthorTime() {
-        var ehrExtract = unmarshallEhrExtract("nullflavour_composition_author_time.xml");
+    public void mapObservationsCompositionHasNoAvailabilityTime() {
+        var ehrExtract = unmarshallEhrExtract("nullflavour_availability_time.xml");
 
         List<Observation> observations =
             observationCommentMapper.mapResources(ehrExtract, patient, Collections.emptyList(), PRACTISE_CODE);

--- a/gp2gp-translator/src/test/java/uk/nhs/adaptors/pss/translator/mapper/diagnosticreport/SpecimenBatteryMapperTest.java
+++ b/gp2gp-translator/src/test/java/uk/nhs/adaptors/pss/translator/mapper/diagnosticreport/SpecimenBatteryMapperTest.java
@@ -2,6 +2,7 @@ package uk.nhs.adaptors.pss.translator.mapper.diagnosticreport;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.hl7.fhir.dstu3.model.Observation.ObservationStatus;
+import static org.junit.jupiter.api.Assertions.assertAll;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.when;
 import static org.springframework.util.ResourceUtils.getFile;
@@ -13,11 +14,8 @@ import static uk.nhs.adaptors.pss.translator.util.XmlUnmarshallUtil.unmarshallFi
 import java.util.ArrayList;
 import java.util.List;
 
-import org.hl7.fhir.dstu3.model.CodeableConcept;
-import org.hl7.fhir.dstu3.model.DateTimeType;
 import org.hl7.fhir.dstu3.model.DiagnosticReport;
 import org.hl7.fhir.dstu3.model.Encounter;
-import org.hl7.fhir.dstu3.model.InstantType;
 import org.hl7.fhir.dstu3.model.Observation;
 import org.hl7.fhir.dstu3.model.Observation.ObservationRelationshipType;
 import org.hl7.fhir.dstu3.model.Patient;
@@ -37,31 +35,22 @@ import uk.nhs.adaptors.pss.translator.mapper.diagnosticreport.SpecimenBatteryMap
 import uk.nhs.adaptors.pss.translator.util.CompoundStatementResourceExtractors;
 import uk.nhs.adaptors.pss.translator.util.DegradedCodeableConcepts;
 import static uk.nhs.adaptors.common.util.CodeableConceptUtils.createCodeableConcept;
+import static uk.nhs.adaptors.pss.translator.util.XmlUnmarshallUtil.unmarshallString;
 
 @ExtendWith(MockitoExtension.class)
 public class SpecimenBatteryMapperTest {
 
-    private static final String RESOURCES_BASE = "xml/SpecimenBattery/";
-
-    private static final String BATTERY_CLASSCODE = "BATTERY";
-    private static final String PRACTISE_CODE = "TEST_PRACTISE_CODE";
-    private static final String OBSERVATION_ID = "SPECIMEN_CHILD_BATTERY_COMPOUND_STATEMENT_ID_1";
-    private static final String OBSERVATION_STATEMENT_ID_1 = "BATTERY_DIRECT_CHILD_OBSERVATION_STATEMENT";
-    private static final String OBSERVATION_STATEMENT_ID_2 = "OBSERVATION_STATEMENT_ID";
-    private static final String DIAGNOSTIC_REPORT_ID = "DIAGNOSTIC_REPORT_ID";
-    private static final String ENCOUNTER_ID = "ENCOUNTER_ID";
-    private static final String PATIENT_ID = "TEST_PATIENT_ID";
-    private static final String SPECIMEN_ID = "TEST_SPECIMEN_ID_1";
-    private static final String META_PROFILE_SUFFIX = "Observation-1";
-    private static final String EXPECTED_COMMENT = "Looks like Covid";
-    private static final Patient PATIENT = (Patient) new Patient().setId(PATIENT_ID);
-    private static final DiagnosticReport DIAGNOSTIC_REPORT = (DiagnosticReport) new DiagnosticReport().setId(DIAGNOSTIC_REPORT_ID);
-    private static final InstantType OBSERVATION_ISSUED = parseToInstantType("202203021160700");
-    private static final DateTimeType OBSERVATION_EFFECTIVE = parseToDateTimeType("20100223000000");
-    private static final String CODING_DISPLAY_MOCK = "Test Display";
-    private static final String SNOMED_SYSTEM = "http://snomed.info/sct";
-    private static final CodeableConcept CODEABLE_CONCEPT = createCodeableConcept(null, SNOMED_SYSTEM, CODING_DISPLAY_MOCK);
-    private final List<Encounter> encounters = generateEncounters();
+    public static final String EHR_EXTRACT_WRAPPER = """
+        <EhrExtract xmlns="urn:hl7-org:v3" classCode="EXTRACT" moodCode="EVN">
+            <component>
+                <ehrFolder>
+                    <component>
+                        {{ehrComposition}}
+                    </component>
+                </ehrFolder>
+            </component>
+        </EhrExtract>
+        """;
 
     @Mock
     private CodeableConceptMapper codeableConceptMapper;
@@ -69,112 +58,274 @@ public class SpecimenBatteryMapperTest {
     @InjectMocks
     private SpecimenBatteryMapper specimenBatteryMapper;
 
-    @Test
-    public void testMappingObservationFromBatteryCompoundStatement() {
-        final RCMRMT030101UK04EhrExtract ehrExtract = unmarshallEhrExtract("specimen_battery_compound_statement.xml");
-        var batteryCompoundStatement = getBatteryCompoundStatements(ehrExtract);
+    @Test void When_MappingObservationWithAvailabilityTimeInBatteryCompoundStatement_Expect_IssuedUsesThisValue() {
+        final var ehrCompositionXml = """
+            <ehrComposition>
+                <id root="ENCOUNTER_ID"/>
+                <component>
+                    <CompoundStatement classCode="CLUSTER">
+                        <id root="DR_TEST_ID"/>
+                        <component>
+                            <CompoundStatement classCode="CLUSTER">
+                                <id root="TEST_SPECIMEN_ID_1"/>
+                                <component typeCode="COMP" contextConductionInd="true">
+                                    <CompoundStatement classCode="BATTERY" moodCode="EVN">
+                                        <id root="SPECIMEN_CHILD_BATTERY_COMPOUND_STATEMENT_ID_1"/>
+                                        <availabilityTime value="20100225154300"/>
+                                    </CompoundStatement>
+                                </component>
+                            </CompoundStatement>
+                        </component>
+                    </CompoundStatement>
+                </component>
+            </ehrComposition>
+            """;
 
-        final List<Observation> observations = getObservations();
-        final List<Observation> observationComments = getObservationComments();
-
-        var batteryParameters = SpecimenBatteryParameters.builder()
-            .ehrExtract(ehrExtract)
-            .batteryCompoundStatement(batteryCompoundStatement)
-            .specimenCompoundStatement(getSpecimenCompoundStatement(ehrExtract))
-            .ehrComposition(getEhrComposition(ehrExtract))
-            .diagnosticReport(DIAGNOSTIC_REPORT)
-            .patient(PATIENT)
-            .encounters(encounters)
-            .practiseCode(PRACTISE_CODE)
-            .observations(observations)
-            .observationComments(observationComments)
-            .build();
+        final var ehrExtract = unmarshallEhrExtractFromEhrCompositionXml(ehrCompositionXml);
+        final var batteryCompoundStatement = getBatteryCompoundStatements(ehrExtract);
+        final var batteryParameters = getSpecimenBatteryParameters(
+            ehrExtract,
+            batteryCompoundStatement,
+            getObservations(),
+            getObservationComments()
+        );
 
         final Observation observation = specimenBatteryMapper.mapBatteryObservation(batteryParameters);
 
-        assertThat(observation.getId()).isEqualTo(OBSERVATION_ID);
-        assertThat(observation.getIdentifierFirstRep().getSystem()).contains(PRACTISE_CODE);
-        assertThat(observation.getEffectiveDateTimeType().getValueAsString()).isEqualTo(OBSERVATION_EFFECTIVE.getValueAsString());
-        assertThat(observation.getIssuedElement().getValueAsString()).isEqualTo(OBSERVATION_ISSUED.getValueAsString());
-        assertThat(observation.getSpecimen().hasReference()).isTrue();
-        assertThat(observation.getSpecimen().getReference()).contains(SPECIMEN_ID);
-        assertThat(observation.getStatus()).isEqualTo(ObservationStatus.FINAL);
-        assertThat(observation.getMeta().getProfile().get(0).getValue()).contains(META_PROFILE_SUFFIX);
-        assertThat(observation.getComment()).isEqualTo(EXPECTED_COMMENT);
-        assertThat(observation.getContext().hasReference()).isTrue();
-        assertThat(observation.getContext().getReference()).contains(ENCOUNTER_ID);
+        assertThat(observation.getIssuedElement().asStringValue())
+            .isEqualTo(parseToInstantType("20100225154300").asStringValue());
+    }
 
-        assertThat(observations.get(0).getRelated()).isNotEmpty();
-        assertThat(observations.get(0).getRelatedFirstRep().getType()).isEqualTo(ObservationRelationshipType.DERIVEDFROM);
+    @Test void When_MappingObservationWithAvailabilityTimeInDiagnosticReport_Expect_IssuedUsesThisValue() {
+        final var ehrCompositionXml = """
+            <ehrComposition>
+                <id root="ENCOUNTER_ID"/>
+                <component>
+                    <CompoundStatement classCode="CLUSTER">
+                        <id root="DR_TEST_ID"/>
+                        <availabilityTime value="20100225154200"/>
+                        <component>
+                            <CompoundStatement classCode="CLUSTER">
+                                <id root="TEST_SPECIMEN_ID_1"/>
+                                <component typeCode="COMP" contextConductionInd="true">
+                                    <CompoundStatement classCode="BATTERY" moodCode="EVN">
+                                        <id root="SPECIMEN_CHILD_BATTERY_COMPOUND_STATEMENT_ID_1"/>
+                                    </CompoundStatement>
+                                </component>
+                            </CompoundStatement>
+                        </component>
+                    </CompoundStatement>
+                </component>
+            </ehrComposition>
+            """;
 
-        assertSubject(observation);
-        assertRelated(observation);
+        final var ehrExtract = unmarshallEhrExtractFromEhrCompositionXml(ehrCompositionXml);
+        final var batteryCompoundStatement = getBatteryCompoundStatements(ehrExtract);
+        final var batteryParameters = getSpecimenBatteryParameters(
+            ehrExtract,
+            batteryCompoundStatement,
+            getObservations(),
+            getObservationComments()
+        );
 
-        assertThat(observationComments).hasSize(2);
+        final Observation observation = specimenBatteryMapper.mapBatteryObservation(batteryParameters);
 
-        var observationCommentIds = observationComments.stream()
-            .map(Observation::getId)
-            .toList();
+        assertThat(observation.getIssuedElement().asStringValue())
+            .isEqualTo(parseToInstantType("20100225154200").asStringValue());
+    }
 
-        assertThat(observationCommentIds).doesNotContain("BATTERY_DIRECT_CHILD_NARRATIVE_STATEMENT_ID");
+    @Test void When_MappingObservationOnlyEhrCompositionAuthorTime_Expect_IssuedUsesThisValue() {
+        final var ehrCompositionXml = """
+            <ehrComposition>
+                <id root="ENCOUNTER_ID"/>
+                <author typeCode="AUT" contextControlCode="OP">
+                    <time value="20220302105070"/>
+                    <agentRef classCode="AGNT">
+                        <id root="749107A2-4975-441F-8EDF-ADFF451FD12D"/>
+                    </agentRef>
+                </author>
+                <component>
+                    <CompoundStatement classCode="CLUSTER">
+                        <id root="DR_TEST_ID"/>
+                        <component>
+                            <CompoundStatement classCode="CLUSTER">
+                                <id root="TEST_SPECIMEN_ID_1"/>
+                                <component typeCode="COMP" contextConductionInd="true">
+                                    <CompoundStatement classCode="BATTERY" moodCode="EVN">
+                                        <id root="SPECIMEN_CHILD_BATTERY_COMPOUND_STATEMENT_ID_1"/>
+                                    </CompoundStatement>
+                                </component>
+                            </CompoundStatement>
+                        </component>
+                    </CompoundStatement>
+                </component>
+            </ehrComposition>
+            """;
+
+        final var ehrExtract = unmarshallEhrExtractFromEhrCompositionXml(ehrCompositionXml);
+        final var batteryCompoundStatement = getBatteryCompoundStatements(ehrExtract);
+        final var batteryParameters = getSpecimenBatteryParameters(
+            ehrExtract,
+            batteryCompoundStatement,
+            getObservations(),
+            getObservationComments()
+        );
+
+        final Observation observation = specimenBatteryMapper.mapBatteryObservation(batteryParameters);
+
+        assertThat(observation.getIssuedElement().asStringValue())
+            .isEqualTo(parseToInstantType("20220302105070").asStringValue());
+    }
+
+    @Test
+    public void When_MappingObservation_Expect_ObservationFieldsAreCorrectlyMapped() {
+        final var ehrCompositionXml =
+            """
+            <ehrComposition classCode="COMPOSITION" moodCode="EVN">
+                <id root="ENCOUNTER_ID" />
+                <component typeCode="COMP">
+                    <CompoundStatement classCode="CLUSTER" moodCode="EVN">
+                        <id root="DR_TEST_ID" />
+                        <component typeCode="COMP" contextConductionInd="true">
+                            <CompoundStatement classCode="CLUSTER" moodCode="EVN">
+                                <id root="TEST_SPECIMEN_ID_1" />
+                                <component typeCode="COMP" contextConductionInd="true">
+                                    <CompoundStatement classCode="BATTERY" moodCode="EVN">
+                                        <id root="SPECIMEN_CHILD_BATTERY_COMPOUND_STATEMENT_ID_1" />
+                                        <effectiveTime>
+                                            <center value="20100223000000" />
+                                        </effectiveTime>
+                                        <component typeCode="COMP" contextConductionInd="true">
+                                            <NarrativeStatement classCode="OBS" moodCode="EVN">
+                                                    <id root="BATTERY_DIRECT_CHILD_NARRATIVE_STATEMENT_ID"/>
+                                                    <text mediaType="text/x-h7uk-pmip">Looks like Covid</text>
+                                            </NarrativeStatement>
+                                        </component>
+                                    </CompoundStatement>
+                                </component>
+                            </CompoundStatement>
+                        </component>
+                    </CompoundStatement>
+                </component>
+            </ehrComposition>
+            """;
+
+        final var ehrExtract = unmarshallEhrExtractFromEhrCompositionXml(ehrCompositionXml);
+        final var batteryCompoundStatement = getBatteryCompoundStatements(ehrExtract);
+        final var batteryParameters = getSpecimenBatteryParameters(
+            ehrExtract,
+            batteryCompoundStatement,
+            getObservations(),
+            getObservationComments()
+        );
+
+        final Observation observation = specimenBatteryMapper.mapBatteryObservation(batteryParameters);
+
+        assertAll(
+            () -> assertThat(observation.getId())
+                .isEqualTo("SPECIMEN_CHILD_BATTERY_COMPOUND_STATEMENT_ID_1"),
+            () -> assertThat(observation.getIdentifierFirstRep().getSystem())
+                .contains("TEST_PRACTISE_CODE"),
+            () -> assertThat(observation.getEffectiveDateTimeType().getValueAsString())
+                .isEqualTo(parseToDateTimeType("20100223000000").getValueAsString()),
+            () -> assertThat(observation.getSpecimen().getReference())
+                .contains("TEST_SPECIMEN_ID_1"),
+            () -> assertThat(observation.getStatus())
+                .isEqualTo(ObservationStatus.FINAL),
+            () -> assertThat(observation.getMeta().getProfile().get(0).getValue())
+                .contains("Observation-1"),
+            () -> assertThat(observation.getComment())
+                .isEqualTo("Looks like Covid"),
+            () -> assertThat(observation.getContext().getReference())
+                .contains("ENCOUNTER_ID"),
+            () -> assertThat(observation.getSubject().getResource().getIdElement().getValue())
+                .isEqualTo("TEST_PATIENT_ID")
+        );
+    }
+
+    @Test
+    public void When_MappingObservation_Expect_ObservationRelationshipsSet() {
+        final var ehrExtract = getSpecimenBatteryEhrExtract();
+        final var batteryCompoundStatement = getBatteryCompoundStatements(ehrExtract);
+        final var observations = getObservations();
+        final var batteryParameters = getSpecimenBatteryParameters(
+            ehrExtract,
+            batteryCompoundStatement,
+            observations,
+            getObservationComments());
+
+        final Observation observation = specimenBatteryMapper.mapBatteryObservation(batteryParameters);
+
+        assertAll(
+            () -> assertThat(observations.get(0).getRelatedFirstRep().getType())
+                .isEqualTo(ObservationRelationshipType.DERIVEDFROM),
+            () -> assertThat(observation.getRelatedFirstRep().getTarget().getReference())
+                .contains("BATTERY_DIRECT_CHILD_OBSERVATION_STATEMENT"),
+            () -> assertThat(observation.getRelated().get(1).getTarget().getReference())
+                .contains("OBSERVATION_STATEMENT_ID")
+        );
+    }
+
+    @Test
+    public void When_MappingObservation_Expect_ObservationCommentsDoNotContainBatteryDirectChildNarrativeStatement() {
+        final var ehrExtract = getSpecimenBatteryEhrExtract();
+        final var batteryCompoundStatement = getBatteryCompoundStatements(ehrExtract);
+        final var observationComments = getObservationComments();
+        final var batteryParameters = getSpecimenBatteryParameters(
+            ehrExtract,
+            batteryCompoundStatement,
+            getObservations(),
+            observationComments);
+
+        specimenBatteryMapper.mapBatteryObservation(batteryParameters);
+
+        final var observationCommentIds = observationComments.stream().map(Observation::getId).toList();
+
+        assertAll(
+            () -> assertThat(observationComments)
+                .hasSize(2),
+            () -> assertThat(observationCommentIds)
+                .doesNotContain("BATTERY_DIRECT_CHILD_NARRATIVE_STATEMENT_ID")
+        );
     }
 
     @Test
     public void When_MappingObservationFromBatteryCompoundStatementWithSnomedCode_Expect_CorrectlyMapped() {
-        when(codeableConceptMapper.mapToCodeableConcept(any())).thenReturn(CODEABLE_CONCEPT);
+        final var codeableConcept = createCodeableConcept("1.2.3.4.5", "http://snomed.info/sct", "Test Display");
+        when(codeableConceptMapper.mapToCodeableConcept(any())).thenReturn(codeableConcept);
 
-        final RCMRMT030101UK04EhrExtract ehrExtract = unmarshallEhrExtract("specimen_battery_compound_statement.xml");
+        final RCMRMT030101UK04EhrExtract ehrExtract = getSpecimenBatteryEhrExtract();
         var batteryCompoundStatement = getBatteryCompoundStatements(ehrExtract);
 
-        final List<Observation> observations = getObservations();
-        final List<Observation> observationComments = getObservationComments();
-
-        var batteryParameters = SpecimenBatteryParameters.builder()
-            .ehrExtract(ehrExtract)
-            .batteryCompoundStatement(batteryCompoundStatement)
-            .specimenCompoundStatement(getSpecimenCompoundStatement(ehrExtract))
-            .ehrComposition(getEhrComposition(ehrExtract))
-            .diagnosticReport(DIAGNOSTIC_REPORT)
-            .patient(PATIENT)
-            .encounters(encounters)
-            .practiseCode(PRACTISE_CODE)
-            .observations(observations)
-            .observationComments(observationComments)
-            .build();
+        var batteryParameters = getSpecimenBatteryParameters(
+            ehrExtract,
+            batteryCompoundStatement,
+            getObservations(),
+            getObservationComments());
 
         final Observation observation = specimenBatteryMapper.mapBatteryObservation(batteryParameters);
 
-        assertThat(observation.getCode()).isEqualTo(CODEABLE_CONCEPT);
+        assertThat(observation.getCode())
+            .isEqualTo(codeableConcept);
     }
 
     @Test
     public void When_MappingObservationFromBatteryCompoundStatementWithoutSnomedCode_Expect_DegradedCode() {
-
-        var codeableConcept = createCodeableConcept("1.2.3.4.5", null, CODING_DISPLAY_MOCK);
+        var codeableConcept = createCodeableConcept("1.2.3.4.5", null, "Test Display");
         when(codeableConceptMapper.mapToCodeableConcept(any())).thenReturn(codeableConcept);
 
-        final RCMRMT030101UK04EhrExtract ehrExtract = unmarshallEhrExtract("specimen_battery_compound_statement.xml");
+        final RCMRMT030101UK04EhrExtract ehrExtract = getSpecimenBatteryEhrExtract();
         var batteryCompoundStatement = getBatteryCompoundStatements(ehrExtract);
 
         final List<Observation> observations = getObservations();
         final List<Observation> observationComments = getObservationComments();
 
-        var batteryParameters = SpecimenBatteryParameters.builder()
-            .ehrExtract(ehrExtract)
-            .batteryCompoundStatement(batteryCompoundStatement)
-            .specimenCompoundStatement(getSpecimenCompoundStatement(ehrExtract))
-            .ehrComposition(getEhrComposition(ehrExtract))
-            .diagnosticReport(DIAGNOSTIC_REPORT)
-            .patient(PATIENT)
-            .encounters(encounters)
-            .practiseCode(PRACTISE_CODE)
-            .observations(observations)
-            .observationComments(observationComments)
-            .build();
+        var batteryParameters = getSpecimenBatteryParameters(ehrExtract, batteryCompoundStatement, observations, observationComments);
 
         final Observation observation = specimenBatteryMapper.mapBatteryObservation(batteryParameters);
 
-        assertThat(observation.getCode().getCodingFirstRep()).isEqualTo(DegradedCodeableConcepts.DEGRADED_OTHER);
+        assertThat(observation.getCode().getCodingFirstRep())
+            .isEqualTo(DegradedCodeableConcepts.DEGRADED_OTHER);
     }
 
     private List<Observation> getObservationComments() {
@@ -216,17 +367,24 @@ public class SpecimenBatteryMapperTest {
         return observationComments;
     }
 
-    private void assertRelated(Observation observation) {
-        assertThat(observation.getRelated()).isNotEmpty();
-        assertThat(observation.getRelatedFirstRep().hasTarget()).isTrue();
-        assertThat(observation.getRelatedFirstRep().getTarget().getReference()).contains(OBSERVATION_STATEMENT_ID_1);
-        assertThat(observation.getRelated().get(1).getTarget().getReference()).contains(OBSERVATION_STATEMENT_ID_2);
-    }
+    private SpecimenBatteryParameters getSpecimenBatteryParameters(
+        RCMRMT030101UK04EhrExtract ehrExtract,
+        RCMRMT030101UKCompoundStatement batteryCompoundStatement,
+        List<Observation> observations,
+        List<Observation> observationComments) {
 
-    private void assertSubject(Observation observation) {
-        assertThat(observation.getSubject()).isNotNull();
-        assertThat(observation.getSubject().getResource()).isNotNull();
-        assertThat(observation.getSubject().getResource().getIdElement().getValue()).isEqualTo(PATIENT_ID);
+        return SpecimenBatteryParameters.builder()
+            .ehrExtract(ehrExtract)
+            .batteryCompoundStatement(batteryCompoundStatement)
+            .specimenCompoundStatement(getSpecimenCompoundStatement(ehrExtract))
+            .ehrComposition(getEhrComposition(ehrExtract))
+            .diagnosticReport(getDiagnosticReport(ehrExtract))
+            .patient((Patient) new Patient().setId("TEST_PATIENT_ID"))
+            .encounters(List.of((Encounter) new Encounter().setId("ENCOUNTER_ID")))
+            .practiseCode("TEST_PRACTISE_CODE")
+            .observations(observations)
+            .observationComments(observationComments)
+            .build();
     }
 
     private RCMRMT030101UKEhrComposition getEhrComposition(RCMRMT030101UK04EhrExtract ehrExtract) {
@@ -234,34 +392,52 @@ public class SpecimenBatteryMapperTest {
     }
 
     private RCMRMT030101UKCompoundStatement getSpecimenCompoundStatement(RCMRMT030101UK04EhrExtract ehrExtract) {
-
         return getEhrComposition(ehrExtract).getComponent().get(0).getCompoundStatement()
             .getComponent().get(0).getCompoundStatement();
     }
 
+    private DiagnosticReport getDiagnosticReport(RCMRMT030101UK04EhrExtract ehrExtract) {
+        var compoundStatement = getEhrComposition(ehrExtract).getComponent().get(0).getCompoundStatement();
+        var diagnosticReport = new DiagnosticReport();
+        diagnosticReport.setId(compoundStatement.getId().get(0).getRoot());
+
+        if (compoundStatement.getAvailabilityTime() != null) {
+            diagnosticReport.setIssued(
+                parseToDateTimeType(compoundStatement.getAvailabilityTime().getValue()).getValue()
+            );
+        }
+
+        return diagnosticReport;
+    }
+
     private List<Observation> getObservations() {
         return List.of(
-            (Observation) new Observation().setId(OBSERVATION_STATEMENT_ID_1),
-            (Observation) new Observation().setId(OBSERVATION_STATEMENT_ID_2)
+            (Observation) new Observation().setId("BATTERY_DIRECT_CHILD_OBSERVATION_STATEMENT"),
+            (Observation) new Observation().setId("OBSERVATION_STATEMENT_ID")
         );
     }
 
     private RCMRMT030101UKCompoundStatement getBatteryCompoundStatements(RCMRMT030101UK04EhrExtract ehrExtract) {
-
         return getEhrComposition(ehrExtract).getComponent()
             .stream()
             .flatMap(CompoundStatementResourceExtractors::extractAllCompoundStatements)
-            .filter(compoundStatement -> BATTERY_CLASSCODE.equals(compoundStatement.getClassCode().get(0)))
-            .findFirst().get();
-    }
-
-    private List<Encounter> generateEncounters() {
-        return List.of((Encounter) new Encounter().setId(ENCOUNTER_ID));
+            .filter(compoundStatement -> "BATTERY".equals(compoundStatement.getClassCode().get(0)))
+            .findFirst()
+            .orElseThrow();
     }
 
     @SneakyThrows
-    private RCMRMT030101UK04EhrExtract unmarshallEhrExtract(String filename) {
-        return unmarshallFile(getFile("classpath:" + RESOURCES_BASE + filename), RCMRMT030101UK04EhrExtract.class);
+    private RCMRMT030101UK04EhrExtract getSpecimenBatteryEhrExtract() {
+        return unmarshallFile(
+            getFile("classpath:xml/SpecimenBattery/specimen_battery_compound_statement.xml"),
+            RCMRMT030101UK04EhrExtract.class
+        );
+    }
+
+    @SneakyThrows
+    private RCMRMT030101UK04EhrExtract unmarshallEhrExtractFromEhrCompositionXml(String ehrCompositionXml) {
+        var ehrExtractXml = EHR_EXTRACT_WRAPPER.replace("{{ehrComposition}}", ehrCompositionXml);
+        return unmarshallString(ehrExtractXml, RCMRMT030101UK04EhrExtract.class);
     }
 }
 

--- a/gp2gp-translator/src/test/java/uk/nhs/adaptors/pss/translator/mapper/diagnosticreport/SpecimenCompoundsMapperTest.java
+++ b/gp2gp-translator/src/test/java/uk/nhs/adaptors/pss/translator/mapper/diagnosticreport/SpecimenCompoundsMapperTest.java
@@ -66,6 +66,7 @@ public class SpecimenCompoundsMapperTest {
         );
 
         assertParentSpecimenIsReferenced(observations.get(0));
+        assertThat(observations.get(0).getIssuedElement().asStringValue()).isEqualTo("2010-02-25T15:41:00.000+00:00");
         assertThat(diagnosticReports.get(0).getResult()).isNotEmpty();
 
         final Reference result = diagnosticReports.get(0).getResult().get(0);
@@ -85,6 +86,7 @@ public class SpecimenCompoundsMapperTest {
         final Observation observationComment = observationComments.get(0);
 
         assertParentSpecimenIsReferenced(observation);
+        assertThat(observation.getIssuedElement().asStringValue()).isEqualTo("2010-02-25T15:41:00.000+00:00");
 
         assertThat(observation.getRelated()).isEmpty();
         assertThat(observationComments).hasSize(2);
@@ -104,7 +106,9 @@ public class SpecimenCompoundsMapperTest {
         );
 
         assertParentSpecimenIsReferenced(observations.get(0));
+        assertThat(observations.get(0).getIssuedElement().asStringValue()).isEqualTo("2010-02-25T15:41:00.000+00:00");
         assertParentSpecimenIsReferenced(observations.get(1));
+        assertThat(observations.get(0).getIssuedElement().asStringValue()).isEqualTo("2010-02-25T15:41:00.000+00:00");
         assertThat(observationComments).hasSize(2);
         assertThat(observationComments.get(0).getComment()).isEqualTo(TEST_COMMENT_LINE_1);
 
@@ -120,6 +124,7 @@ public class SpecimenCompoundsMapperTest {
         );
 
         assertParentSpecimenIsReferenced(observations.get(0));
+        assertThat(observations.get(0).getIssuedElement().asStringValue()).isEqualTo("2022-03-14T18:24:45.000+00:00");
         assertThat(observationComments).hasSize(2);
         assertThat(observationComments.get(0).getRelated()).isNotEmpty();
         assertThat(observationComments.get(0).getRelated()).isNotEmpty();
@@ -137,8 +142,21 @@ public class SpecimenCompoundsMapperTest {
         );
 
         assertParentSpecimenIsReferenced(observations.get(0));
+        assertThat(observations.get(0).getIssuedElement().asStringValue()).isEqualTo("2022-03-14T18:24:45.000+00:00");
         assertThat(observationComments.size()).isOne();
         assertThat(observations.get(0).getComment()).isEqualTo(TEST_COMMENT_LINE + "\n" + TEST_COMMENT_LINE_1);
+    }
+
+    @Test public void testHandlingObservationStatementWithUnkAvailabilityTime() {
+        final RCMRMT030101UK04EhrExtract ehrExtract = unmarshallEhrExtract("specimen_cluster_compound_statement_availability_time_unk.xml");
+
+        specimenCompoundsMapper.handleSpecimenChildComponents(
+            ehrExtract, observations, observationComments, diagnosticReports, PATIENT, List.of(), TEST_PRACTISE_CODE
+        );
+
+        final Observation observation = observations.get(0);
+
+        assertThat(observation.getIssuedElement().asStringValue()).isNull();
     }
 
     private void assertParentSpecimenIsReferenced(Observation observation) {

--- a/gp2gp-translator/src/test/resources/xml/ObservationComment/nullflavour_availability_time.xml
+++ b/gp2gp-translator/src/test/resources/xml/ObservationComment/nullflavour_availability_time.xml
@@ -23,7 +23,7 @@
                             <id root="5E496953-065B-41F2-9577-BE8F2FBD0757"/>
                             <text mediaType="text/x-h7uk-pmip">Some example text</text>
                             <statusCode code="COMPLETE"/>
-                            <availabilityTime value="20201012143344"/>
+                            <availabilityTime nullFlavor="UNK" />
                         </NarrativeStatement>
                     </component>
                 </ehrComposition>

--- a/gp2gp-translator/src/test/resources/xml/SpecimenBattery/specimen_battery_compound_statement.xml
+++ b/gp2gp-translator/src/test/resources/xml/SpecimenBattery/specimen_battery_compound_statement.xml
@@ -5,7 +5,7 @@
                 <ehrComposition classCode="COMPOSITION" moodCode="EVN">
                     <id root="ENCOUNTER_ID"/>
                     <author typeCode="AUT" contextControlCode="OP">
-                        <time value="202203021160700"/>
+                        <time value="20220302105070"/>
                         <agentRef classCode="AGNT">
                             <id root="749107A2-4975-441F-8EDF-ADFF451FD12D"/>
                         </agentRef>
@@ -41,7 +41,7 @@
                                     <effectiveTime>
                                         <center nullFlavor="NI"/>
                                     </effectiveTime>
-                                    <availabilityTime value="20100225154100"/>
+                                    <availabilityTime value="20100225154200"/>
                                     <specimen typeCode="SPC">
                                         <specimenRole classCode="SPEC">
                                             <id root="37252CF4-D7F6-4CBA-89B2-63477F0C8374"/>
@@ -67,7 +67,7 @@
                                             <effectiveTime>
                                                 <center value="20100223000000"/>
                                             </effectiveTime>
-                                            <availabilityTime value="20100225154100"/>
+                                            <availabilityTime value="20100225154300"/>
                                             <component typeCode="COMP" contextConductionInd="true">
                                                 <ObservationStatement classCode="OBS" moodCode="EVN">
                                                     <id root="BATTERY_DIRECT_CHILD_OBSERVATION_STATEMENT"/>
@@ -81,7 +81,7 @@
                                                     <effectiveTime>
                                                         <center value="20100223000000"/>
                                                     </effectiveTime>
-                                                    <availabilityTime value="20100225154100"/>
+                                                    <availabilityTime value="20100225154400"/>
                                                 </ObservationStatement>
                                             </component>
                                             <component typeCode="COMP" contextConductionInd="true">
@@ -109,7 +109,7 @@ Looks like Covid
                                                     <effectiveTime>
                                                         <center value="20100223000000"/>
                                                     </effectiveTime>
-                                                    <availabilityTime value="20100225154100"/>
+                                                    <availabilityTime value="20100225154600"/>
                                                     <component typeCode="COMP" contextConductionInd="true">
                                                         <ObservationStatement classCode="OBS" moodCode="EVN">
                                                             <id root="OBSERVATION_STATEMENT_ID"/>
@@ -123,7 +123,7 @@ Looks like Covid
                                                             <effectiveTime>
                                                                 <center value="20100223000000"/>
                                                             </effectiveTime>
-                                                            <availabilityTime value="20100225154100"/>
+                                                            <availabilityTime value="20100225154700"/>
                                                         </ObservationStatement>
                                                     </component>
                                                     <component typeCode="COMP" contextConductionInd="true">

--- a/gp2gp-translator/src/test/resources/xml/SpecimenComponents/specimen_cluster_compound_statement_availability_time_unk.xml
+++ b/gp2gp-translator/src/test/resources/xml/SpecimenComponents/specimen_cluster_compound_statement_availability_time_unk.xml
@@ -1,0 +1,97 @@
+<EhrExtract xmlns="urn:hl7-org:v3" classCode="EXTRACT" moodCode="EVN">
+    <component typeCode="COMP">
+        <ehrFolder classCode="FOLDER" moodCode="EVN">
+            <component typeCode="COMP">
+                <ehrComposition classCode="COMPOSITION" moodCode="EVN">
+                    <id root="CA4AD477-C33B-4FE7-8417-A242BB3D23AF"/>
+                    <author typeCode="AUT" contextControlCode="OP">
+                        <time value="20200101010101"/>
+                        <agentRef classCode="AGNT">
+                            <id root="749107A2-4975-441F-8EDF-ADFF451FD12D"/>
+                        </agentRef>
+                    </author>
+                    <Participant2 typeCode="PRF" contextControlCode="OP">
+                        <agentRef classCode="AGNT">
+                            <id root="2D70F602-6BB1-47E0-B2EC-39912A59787D"/>
+                        </agentRef>
+                    </Participant2>
+                    <component typeCode="COMP">
+                        <CompoundStatement classCode="CLUSTER" moodCode="EVN">
+                            <id root="DR_TEST_ID"/>
+                            <code code="16488004" codeSystem="2.16.840.1.113883.2.1.3.2.4.15"
+                                  displayName="laboratory reporting">
+                                <originalText>Filed Report</originalText>
+                            </code>
+                            <statusCode code="COMPLETE"/>
+                            <effectiveTime>
+                                <center nullFlavor="NI"/>
+                            </effectiveTime>
+                            <availabilityTime value="20100225154100"/>
+                            <Participant typeCode="AUT" contextControlCode="OP">
+                                <agentRef classCode="AGNT">
+                                    <id root="394559384658936"/>
+                                </agentRef>
+                            </Participant>
+                            <component typeCode="COMP" contextConductionInd="true">
+                                <CompoundStatement classCode="CLUSTER" moodCode="EVN">
+                                    <id root="TEST_SPECIMEN_ID_1"/>
+                                    <code code="123038009" codeSystem="2.16.840.1.113883.2.1.3.2.4.15"
+                                          displayName="specimen (specimen)"/>
+                                    <statusCode code="COMPLETE"/>
+                                    <effectiveTime>
+                                        <center nullFlavor="NI"/>
+                                    </effectiveTime>
+                                    <availabilityTime value="20100225154100"/>
+                                    <specimen typeCode="SPC">
+                                        <specimenRole classCode="SPEC">
+                                            <id root="37252CF4-D7F6-4CBA-89B2-63477F0C8374"/>
+                                            <id root="2.16.840.1.113883.2.1.4.5.2" extension="CH000056DN"/>
+                                            <effectiveTime>
+                                                <center value="20100223000000"/>
+                                            </effectiveTime>
+                                            <specimenSpecimenMaterial determinerCode="INSTANCE" classCode="MAT">
+                                                <desc>URINE</desc>
+                                            </specimenSpecimenMaterial>
+                                        </specimenRole>
+                                    </specimen>
+                                    <component typeCode="COMP" contextConductionInd="true">
+                                        <CompoundStatement classCode="CLUSTER" moodCode="EVN">
+                                            <id root="SPECIMEN_CHILD_CLUSTER_COMPOUND_STATEMENT_ID_1"/>
+                                            <code code="465..00" codeSystem="2.16.840.1.113883.2.1.6.2"
+                                                  displayName="Urine pregnancy Test">
+                                                <translation code="1003161000000106"
+                                                             codeSystem="2.16.840.1.113883.2.1.3.2.4.15"
+                                                             displayName="Urine pregnancy test"/>
+                                            </code>
+                                            <statusCode code="COMPLETE"/>
+                                            <effectiveTime>
+                                                <center value="20100223000000"/>
+                                            </effectiveTime>
+                                            <availabilityTime value="20100225154100"/>
+                                            <component typeCode="COMP" contextConductionInd="true">
+                                                <ObservationStatement classCode="OBS" moodCode="EVN">
+                                                    <id root="OBSERVATION_STATEMENT_ID"/>
+                                                    <code code="465..00" codeSystem="2.16.840.1.113883.2.1.6.2"
+                                                          displayName="Urine pregnancy Test">
+                                                        <translation code="1003161000000106"
+                                                                     codeSystem="2.16.840.1.113883.2.1.3.2.4.15"
+                                                                     displayName="Urine pregnancy test"/>
+                                                    </code>
+                                                    <statusCode code="COMPLETE"/>
+                                                    <effectiveTime>
+                                                        <center value="20100223000000"/>
+                                                    </effectiveTime>
+                                                    <availabilityTime nullFlavor="UNK"/>
+                                                </ObservationStatement>
+                                            </component>
+                                        </CompoundStatement>
+                                    </component>
+                                </CompoundStatement>
+                            </component>
+                        </CompoundStatement>
+                    </component>
+                </ehrComposition>
+            </component>
+        </ehrFolder>
+    </component>
+</EhrExtract>


### PR DESCRIPTION
## Why

In NIAD-2991 we were provided with an anonymised GP2GP investigation from production, where the availabilityTime for:
- Test Group Header
- Test Result
- Filing Coment

Were the values which seemed to be the correct value to use for `issued`.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [x] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have updated the [Changelog](/CHANGELOG.md) with details of my change in the UNRELEASED section if this change will affect end users
- [x] A corresponding change has been made to the [Mapping Documentation repository][mapping-docs]: https://github.com/NHSDigital/patient-switching-adaptors-mapping-documentation/pull/52

[mapping-docs]: https://github.com/NHSDigital/patient-switching-adaptors-mapping-documentation