### PR TITLE
 [NIAD-2988] Lowercase Conversation ID for getMigrationRequest()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## [Unreleased]
 
+### Changed
+* The `/$gpc.ack` endpoint is now case insensitive and supports uppercase and lowercase values for the `conversationId` header values.
+
 ### Added
 * Retry mechanism has been added for MHS Runtime exceptions 
 

--- a/gpc-api-facade/src/integrationTest/java/uk/nhs/adaptors/pss/gpc/controller/AcknowledgeRecordControllerIT.java
+++ b/gpc-api-facade/src/integrationTest/java/uk/nhs/adaptors/pss/gpc/controller/AcknowledgeRecordControllerIT.java
@@ -3,7 +3,9 @@ package uk.nhs.adaptors.pss.gpc.controller;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.EnumSource;
+import org.junit.jupiter.params.provider.MethodSource;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
@@ -16,6 +18,7 @@ import uk.nhs.adaptors.common.enums.MigrationStatus;
 import uk.nhs.adaptors.connector.service.MigrationStatusLogService;
 
 import java.util.UUID;
+import java.util.stream.Stream;
 
 import static org.springframework.boot.test.context.SpringBootTest.WebEnvironment.RANDOM_PORT;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch;
@@ -124,29 +127,13 @@ public class AcknowledgeRecordControllerIT {
                 .andExpect(content().json(expectedResponseBody));
     }
 
-    @Test
-    public void Given_LowercaseConversationId_When_SendAcknowledgeRequest_Expect_ResponseStatusCode200() throws Exception {
-        // given
-        final String lowercaseConversationId = UUID.randomUUID().toString();
-
+    @ParameterizedTest
+    @MethodSource("getMixedCaseIds")
+    void Given_LowerAndUppercaseConversationId_When_SendAcknowledgeRequest_Expect_ResponseStatusCode200(String conversationId) throws Exception {
         // when
-        addMigrationRequestAndLogWithStatus(lowercaseConversationId, MIGRATION_COMPLETED);
+        addMigrationRequestAndLogWithStatus(conversationId, MIGRATION_COMPLETED);
         mockMvc.perform(post(ACKNOWLEDGE_RECORD_ENDPOINT)
-                .header(CONVERSATION_ID_HEADER, lowercaseConversationId)
-                .header(CONFIRMATION_RESPONSE_HEADER, ConfirmationResponse.ACCEPTED))
-            // then
-            .andExpect(status().isOk());
-    }
-
-    @Test
-    public void Given_UppercaseConversationId_When_SendAcknowledgeRequest_Expect_ResponseStatusCode200() throws Exception {
-        // given
-        final String uppercaseConversationId = UUID.randomUUID().toString().toUpperCase();
-
-        // when
-        addMigrationRequestAndLogWithStatus(uppercaseConversationId, MIGRATION_COMPLETED);
-        mockMvc.perform(post(ACKNOWLEDGE_RECORD_ENDPOINT)
-                .header(CONVERSATION_ID_HEADER, uppercaseConversationId)
+                .header(CONVERSATION_ID_HEADER, conversationId)
                 .header(CONFIRMATION_RESPONSE_HEADER, ConfirmationResponse.ACCEPTED))
             // then
             .andExpect(status().isOk());
@@ -172,5 +159,12 @@ public class AcknowledgeRecordControllerIT {
         patientMigrationRequestDao.addNewRequest(PATIENT_NUMBER, conversationId, LOSING_PRACTICE_ODS, WINNING_PRACTICE_ODS);
         patientMigrationRequestDao.saveBundleAndInboundMessageData(conversationId, BUNDLE_VALUE, INBOUND_MESSAGE_VALUE);
         migrationStatusLogService.addMigrationStatusLog(status, conversationId, null, null);
+    }
+
+    private static Stream<Arguments> getMixedCaseIds() {
+        return Stream.of(
+            Arguments.of(UUID.randomUUID().toString()),
+            Arguments.of(UUID.randomUUID().toString().toUpperCase())
+        );
     }
 }

--- a/gpc-api-facade/src/integrationTest/java/uk/nhs/adaptors/pss/gpc/controller/AcknowledgeRecordControllerIT.java
+++ b/gpc-api-facade/src/integrationTest/java/uk/nhs/adaptors/pss/gpc/controller/AcknowledgeRecordControllerIT.java
@@ -129,7 +129,8 @@ public class AcknowledgeRecordControllerIT {
 
     @ParameterizedTest
     @MethodSource("getMixedCaseIds")
-    void Given_LowerAndUppercaseConversationId_When_SendAcknowledgeRequest_Expect_ResponseStatusCode200(String conversationId) throws Exception {
+    void When_SendAcknowledgeRequestWithLowerAndUppercaseConversationIdHeader_Expect_ResponseStatusCode200(String conversationId)
+        throws Exception {
         // when
         addMigrationRequestAndLogWithStatus(conversationId, MIGRATION_COMPLETED);
         mockMvc.perform(post(ACKNOWLEDGE_RECORD_ENDPOINT)

--- a/gpc-api-facade/src/integrationTest/java/uk/nhs/adaptors/pss/gpc/controller/AcknowledgeRecordControllerIT.java
+++ b/gpc-api-facade/src/integrationTest/java/uk/nhs/adaptors/pss/gpc/controller/AcknowledgeRecordControllerIT.java
@@ -152,7 +152,6 @@ public class AcknowledgeRecordControllerIT {
                 .andExpect(content().json(expectedResponseBody));
     }
 
-    // Helper Methods
     private void addMigrationRequestAndLogWithStatus(String conversationId, MigrationStatus status) {
         // Currently, when requests are created - they are uppercase.
         conversationId = conversationId.toUpperCase();

--- a/gpc-api-facade/src/main/java/uk/nhs/adaptors/pss/gpc/service/AcknowledgeRecordService.java
+++ b/gpc-api-facade/src/main/java/uk/nhs/adaptors/pss/gpc/service/AcknowledgeRecordService.java
@@ -26,7 +26,7 @@ public class AcknowledgeRecordService {
     public Boolean handleAcknowledgeRecord(
             @NotNull @NotEmpty String conversationId,
             @NotNull @NotEmpty String confirmationResponseString) {
-        var patientMigrationRequest = patientMigrationRequestDao.getMigrationRequest(conversationId);
+        var patientMigrationRequest = patientMigrationRequestDao.getMigrationRequest(conversationId.toLowerCase());
         if (patientMigrationRequest == null) {
             return false;
         }

--- a/gpc-api-facade/src/main/java/uk/nhs/adaptors/pss/gpc/service/AcknowledgeRecordService.java
+++ b/gpc-api-facade/src/main/java/uk/nhs/adaptors/pss/gpc/service/AcknowledgeRecordService.java
@@ -13,6 +13,8 @@ import uk.nhs.adaptors.pss.gpc.amqp.PssQueuePublisher;
 import javax.validation.constraints.NotEmpty;
 import javax.validation.constraints.NotNull;
 
+import java.util.Locale;
+
 import static org.apache.commons.lang3.EnumUtils.getEnumIgnoreCase;
 import static uk.nhs.adaptors.common.enums.QueueMessageType.ACKNOWLEDGE_RECORD;
 
@@ -26,7 +28,9 @@ public class AcknowledgeRecordService {
     public Boolean handleAcknowledgeRecord(
             @NotNull @NotEmpty String conversationId,
             @NotNull @NotEmpty String confirmationResponseString) {
-        var patientMigrationRequest = patientMigrationRequestDao.getMigrationRequest(conversationId.toLowerCase());
+        var patientMigrationRequest = patientMigrationRequestDao.getMigrationRequest(
+            conversationId.toUpperCase(Locale.ROOT)
+        );
         if (patientMigrationRequest == null) {
             return false;
         }

--- a/gpc-api-facade/src/test/java/uk/nhs/adaptors/pss/gpc/service/AcknowledgeRecordServiceTest.java
+++ b/gpc-api-facade/src/test/java/uk/nhs/adaptors/pss/gpc/service/AcknowledgeRecordServiceTest.java
@@ -27,7 +27,7 @@ import static uk.nhs.adaptors.common.enums.QueueMessageType.ACKNOWLEDGE_RECORD;
 
 @ExtendWith(MockitoExtension.class)
 public class AcknowledgeRecordServiceTest {
-    private static final String CONVERSATION_ID_VALUE = UUID.randomUUID().toString();
+    private static final String CONVERSATION_ID_VALUE = UUID.randomUUID().toString().toUpperCase();
     private static final String INVALID_CONFIRMATION_RESPONSE_VALUE = "NotAValidResponse";
     private static final Integer PATIENT_MIGRATION_REQUEST_ID = 1;
 

--- a/gpc-api-facade/src/test/java/uk/nhs/adaptors/pss/gpc/service/PatientTransferServiceTest.java
+++ b/gpc-api-facade/src/test/java/uk/nhs/adaptors/pss/gpc/service/PatientTransferServiceTest.java
@@ -225,7 +225,7 @@ public class PatientTransferServiceTest {
     @MethodSource("generateCompletedStatuses")
     public void checkExistingPatientMigrationRequestInProgressWhenPreviousMigrationCompleted(MigrationStatus status) {
 
-        final String newConversationId = UUID.randomUUID().toString();
+        final String newConversationId = UUID.randomUUID().toString().toUpperCase();
         final PatientMigrationRequest patientMigrationRequest = createPatientMigrationRequest();
         final MigrationStatusLog migrationStatusLog = createMigrationStatusLog(status);
 


### PR DESCRIPTION
## What

Previously:
- **Given** a POST request made to the `/$gpc.ack` endpoint.
- **When** a request header is passed for `conversationId` with a lowercase UUIDv4.
- **Then** the response would be status 500 (Internal Server Error).

Now:
- **Given** a POST request made to the `/$gpc.ack` endpoint.
- **When** a request header is passed for `conversationId` with a lowercase OR uppercase UUIDv4.
- **Then** the response would be status 200 (OK).

## Why

This bug could cause confusion and questions from NMEs as to why the endpoint doesn’t work.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [x] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have updated the [Changelog](/CHANGELOG.md) with details of my change in the UNRELEASED section if this change will affect end users
- [ ] A corresponding change has been made to the [Mapping Documentation repository][mapping-docs]

[mapping-docs]: https://github.com/NHSDigital/patient-switching-adaptors-mapping-documentation