### PR TITLE
Fix method name to match bean name

### DIFF
--- a/gp2gp-translator/src/main/java/uk/nhs/adaptors/pss/translator/config/AmqpConfiguration.java
+++ b/gp2gp-translator/src/main/java/uk/nhs/adaptors/pss/translator/config/AmqpConfiguration.java
@@ -135,7 +135,7 @@ public class AmqpConfiguration {
     }
 
     @Bean("jmsTemplatePssQueue")
-    public JmsTemplate jmsTemplateMhsQueue(@Qualifier("pssQueueConnectionFactory") JmsConnectionFactory connectionFactory,
+    public JmsTemplate jmsTemplatePssQueue(@Qualifier("pssQueueConnectionFactory") JmsConnectionFactory connectionFactory,
         PssQueueProperties properties) {
         JmsTemplate jmsTemplate = new JmsTemplate();
         jmsTemplate.setConnectionFactory(connectionFactory);


### PR DESCRIPTION
## Why

Spring 6 will complain about this.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [x] I have performed a self-review of my code
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] I have updated the [Changelog](/CHANGELOG.md) with details of my change in the UNRELEASED section if this change will affect end users
- [ ] A corresponding change has been made to the [Mapping Documentation repository][mapping-docs]

[mapping-docs]: https://github.com/NHSDigital/patient-switching-adaptors-mapping-documentation