### PR TITLE
Removal of deprecated StringUtils class + test cleanup

### DIFF
--- a/gp2gp-translator/src/main/java/uk/nhs/adaptors/pss/translator/config/AmqpConfiguration.java
+++ b/gp2gp-translator/src/main/java/uk/nhs/adaptors/pss/translator/config/AmqpConfiguration.java
@@ -2,6 +2,7 @@ package uk.nhs.adaptors.pss.translator.config;
 
 import static org.springframework.jms.listener.DefaultMessageListenerContainer.CACHE_CONSUMER;
 
+import org.apache.commons.lang3.StringUtils;
 import org.apache.qpid.jms.JmsConnectionFactory;
 import org.apache.qpid.jms.JmsDestination;
 import org.apache.qpid.jms.message.JmsMessageSupport;
@@ -17,7 +18,6 @@ import org.springframework.jms.core.JmsTemplate;
 import org.springframework.jms.support.converter.MappingJackson2MessageConverter;
 import org.springframework.jms.support.converter.MessageConverter;
 
-import io.micrometer.core.instrument.util.StringUtils;
 import uk.nhs.adaptors.pss.translator.amqp.JmsListenerErrorHandler;
 
 @Configuration

--- a/gp2gp-translator/src/main/java/uk/nhs/adaptors/pss/translator/mapper/AgentDirectoryMapper.java
+++ b/gp2gp-translator/src/main/java/uk/nhs/adaptors/pss/translator/mapper/AgentDirectoryMapper.java
@@ -9,6 +9,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
 
+import org.apache.commons.lang3.StringUtils;
 import org.hl7.fhir.dstu3.model.Address;
 import org.hl7.fhir.dstu3.model.CodeableConcept;
 import org.hl7.fhir.dstu3.model.ContactPoint;
@@ -34,7 +35,6 @@ import org.hl7.v3.TEL;
 import org.springframework.stereotype.Service;
 import org.springframework.util.CollectionUtils;
 
-import io.micrometer.core.instrument.util.StringUtils;
 import uk.nhs.adaptors.pss.translator.util.AddressUtil;
 import uk.nhs.adaptors.pss.translator.util.CodeSystemsUtil;
 import uk.nhs.adaptors.pss.translator.util.TelecomUtil;

--- a/gp2gp-translator/src/test/java/uk/nhs/adaptors/pss/translator/mapper/AllergyIntoleranceMapperTest.java
+++ b/gp2gp-translator/src/test/java/uk/nhs/adaptors/pss/translator/mapper/AllergyIntoleranceMapperTest.java
@@ -93,7 +93,7 @@ public class AllergyIntoleranceMapperTest {
         List<AllergyIntolerance> allergyIntolerances = allergyIntoleranceMapper.mapResources(ehrExtract, getPatient(),
             getEncounterList(), PRACTISE_CODE);
 
-        assertThat(allergyIntolerances.size()).isEqualTo(1);
+        assertThat(allergyIntolerances).hasSize(1);
         var allergyIntolerance = allergyIntolerances.get(0);
 
         assertFixedValues(allergyIntolerance);
@@ -209,7 +209,7 @@ public class AllergyIntoleranceMapperTest {
         List<AllergyIntolerance> allergyIntolerances = allergyIntoleranceMapper.mapResources(ehrExtract, getPatient(),
             getEncounterList(), PRACTISE_CODE);
 
-        assertThat(allergyIntolerances.size()).isEqualTo(1);
+        assertThat(allergyIntolerances).hasSize(1);
         var allergyIntolerance = allergyIntolerances.get(0);
 
         assertThat(allergyIntolerance.getCode().getCodingFirstRep())
@@ -225,7 +225,7 @@ public class AllergyIntoleranceMapperTest {
         List<AllergyIntolerance> allergyIntolerances = allergyIntoleranceMapper.mapResources(ehrExtract, getPatient(),
                 getEncounterList(), PRACTISE_CODE);
 
-        assertThat(allergyIntolerances.size()).isEqualTo(1);
+        assertThat(allergyIntolerances).hasSize(1);
         var allergyIntolerance = allergyIntolerances.get(0);
 
         assertThat(allergyIntolerance.getCode().getCodingFirstRep())
@@ -242,7 +242,7 @@ public class AllergyIntoleranceMapperTest {
         List<AllergyIntolerance> allergyIntolerances = allergyIntoleranceMapper.mapResources(ehrExtract, getPatient(),
             getEncounterList(), PRACTISE_CODE);
 
-        assertThat(allergyIntolerances.size()).isEqualTo(1);
+        assertThat(allergyIntolerances).hasSize(1);
         var allergyIntolerance = allergyIntolerances.get(0);
 
         assertFixedValues(allergyIntolerance);
@@ -257,7 +257,7 @@ public class AllergyIntoleranceMapperTest {
         List<AllergyIntolerance> allergyIntolerances = allergyIntoleranceMapper.mapResources(ehrExtract, getPatient(),
             getEncounterList(), PRACTISE_CODE);
 
-        assertThat(allergyIntolerances.size()).isEqualTo(1);
+        assertThat(allergyIntolerances).hasSize(1);
         var allergyIntolerance = allergyIntolerances.get(0);
 
         assertFixedValues(allergyIntolerance);
@@ -278,7 +278,7 @@ public class AllergyIntoleranceMapperTest {
         List<AllergyIntolerance> allergyIntolerances = allergyIntoleranceMapper.mapResources(ehrExtract, getPatient(),
                 getEncounterList(), PRACTISE_CODE);
 
-        assertThat(allergyIntolerances.size()).isEqualTo(1);
+        assertThat(allergyIntolerances).hasSize(1);
         var allergyIntolerance = allergyIntolerances.get(0);
 
         assertFixedValues(allergyIntolerance);
@@ -314,7 +314,7 @@ public class AllergyIntoleranceMapperTest {
         List<AllergyIntolerance> allergyIntolerances = allergyIntoleranceMapper.mapResources(ehrExtract, getPatient(),
             getEncounterList(), PRACTISE_CODE);
 
-        assertThat(allergyIntolerances.size()).isEqualTo(1);
+        assertThat(allergyIntolerances).hasSize(1);
         var allergyIntolerance = allergyIntolerances.get(0);
 
         assertFixedValues(allergyIntolerance);
@@ -341,7 +341,7 @@ public class AllergyIntoleranceMapperTest {
         List<AllergyIntolerance> allergyIntolerances = allergyIntoleranceMapper.mapResources(ehrExtract, getPatient(),
             getEncounterList(), PRACTISE_CODE);
 
-        assertThat(allergyIntolerances.size()).isEqualTo(1);
+        assertThat(allergyIntolerances).hasSize(1);
         var allergyIntolerance = allergyIntolerances.get(0);
 
         assertFixedValues(allergyIntolerance);
@@ -368,7 +368,7 @@ public class AllergyIntoleranceMapperTest {
         List<AllergyIntolerance> allergyIntolerances = allergyIntoleranceMapper.mapResources(ehrExtract, getPatient(),
             getEncounterList(), PRACTISE_CODE);
 
-        assertThat(allergyIntolerances.size()).isEqualTo(1);
+        assertThat(allergyIntolerances).hasSize(1);
         var allergyIntolerance = allergyIntolerances.get(0);
 
         assertFixedValues(allergyIntolerance);

--- a/gp2gp-translator/src/test/java/uk/nhs/adaptors/pss/translator/mapper/BloodPressureMapperTest.java
+++ b/gp2gp-translator/src/test/java/uk/nhs/adaptors/pss/translator/mapper/BloodPressureMapperTest.java
@@ -202,7 +202,7 @@ public class BloodPressureMapperTest {
 
         var bloodPressure = bloodPressureMapper.mapResources(ehrExtract, patient, ENCOUNTER_LIST, PRACTISE_CODE).get(0);
 
-        assertThat(bloodPressure.getEffective() instanceof DateTimeType).isTrue();
+        assertThat(bloodPressure.getEffective()).isInstanceOf(DateTimeType.class);
         assertThat(bloodPressure.getEffectiveDateTimeType().getValueAsString()).isEqualTo("2006-04-25");
     }
 
@@ -213,7 +213,7 @@ public class BloodPressureMapperTest {
 
         var bloodPressure = bloodPressureMapper.mapResources(ehrExtract, patient, ENCOUNTER_LIST, PRACTISE_CODE).get(0);
 
-        assertThat(bloodPressure.getEffective() instanceof Period).isTrue();
+        assertThat(bloodPressure.getEffective()).isInstanceOf(Period.class);
         assertThat(bloodPressure.getEffectivePeriod().getStartElement().getValueAsString()).isEqualTo("2006-04-25");
         assertThat(bloodPressure.getEffectivePeriod().getEndElement().getValueAsString()).isEqualTo("2006-04-26");
     }

--- a/gp2gp-translator/src/test/java/uk/nhs/adaptors/pss/translator/mapper/ObservationMapperTest.java
+++ b/gp2gp-translator/src/test/java/uk/nhs/adaptors/pss/translator/mapper/ObservationMapperTest.java
@@ -87,11 +87,11 @@ public class ObservationMapperTest {
 
         assertFixedValues(observation);
         assertThat(observation.getId()).isEqualTo(EXAMPLE_ID);
-        assertThat(observation.getEffective() instanceof DateTimeType).isTrue();
+        assertThat(observation.getEffective()).isInstanceOf(DateTimeType.class);
         assertThat(observation.getEffectiveDateTimeType().getValue()).isEqualTo("2019-07-08T13:35:00+00:00");
         assertThat(observation.getIssuedElement().asStringValue()).isEqualTo(ISSUED_EHR_COMPOSITION_EXAMPLE);
         assertThat(observation.getPerformer().get(0).getReference()).isEqualTo(PPRF_PARTICIPANT_ID);
-        assertThat(observation.getValue() instanceof Quantity).isTrue();
+        assertThat(observation.getValue()).isInstanceOf(Quantity.class);
         assertQuantity(observation.getValueQuantity(), QUANTITY_VALUE, "kilogram per square meter", "kg/m2");
         assertInterpretation(observation.getInterpretation(), "High", "H", "High");
         assertThat(observation.getComment()).isEqualTo("Subject: Uncle Test text 1");
@@ -174,7 +174,7 @@ public class ObservationMapperTest {
         var ehrExtract = unmarshallEhrExtractElement("value_st_observation_example.xml");
         var observation = observationMapper.mapResources(ehrExtract, patient, ENCOUNTER_LIST, PRACTISE_CODE).get(0);
 
-        assertThat(observation.getValue() instanceof StringType).isTrue();
+        assertThat(observation.getValue()).isInstanceOf(StringType.class);
         assertThat(observation.getValueStringType().getValue()).isEqualToIgnoringWhitespace(NEGATIVE_VALUE);
     }
 
@@ -183,7 +183,7 @@ public class ObservationMapperTest {
         var ehrExtract = unmarshallEhrExtractElement("value_cv_display_name_observation_example.xml");
         var observation = observationMapper.mapResources(ehrExtract, patient, ENCOUNTER_LIST, PRACTISE_CODE).get(0);
 
-        assertThat(observation.getValue() instanceof StringType).isTrue();
+        assertThat(observation.getValue()).isInstanceOf(StringType.class);
         assertThat(observation.getValueStringType().getValue()).isEqualTo(TEST_DISPLAY_VALUE);
     }
 

--- a/gp2gp-translator/src/test/java/uk/nhs/adaptors/pss/translator/mapper/medication/MedicationStatementMapperTest.java
+++ b/gp2gp-translator/src/test/java/uk/nhs/adaptors/pss/translator/mapper/medication/MedicationStatementMapperTest.java
@@ -102,7 +102,7 @@ public class MedicationStatementMapperTest {
 
         var lastIssuedDate = medicationStatement1.getExtensionsByUrl(
             "https://fhir.nhs.uk/STU3/StructureDefinition/Extension-CareConnect-GPC-MedicationStatementLastIssueDate-1");
-        assertThat(lastIssuedDate.size()).isZero();
+        assertThat(lastIssuedDate).isEmpty();
 
         var prescribingAgency = medicationStatement1
             .getExtensionsByUrl("https://fhir.nhs.uk/STU3/StructureDefinition/Extension-CareConnect-GPC-PrescribingAgency-1");

--- a/gp2gp-translator/src/test/java/uk/nhs/adaptors/pss/translator/util/AddressUtilTest.java
+++ b/gp2gp-translator/src/test/java/uk/nhs/adaptors/pss/translator/util/AddressUtilTest.java
@@ -50,7 +50,7 @@ public class AddressUtilTest {
 
         assertThat(address.getUse()).isEqualTo(Address.AddressUse.WORK);
         assertThat(address.getType()).isEqualTo(Address.AddressType.PHYSICAL);
-        assertThat(address.getLine().size()).isZero();
+        assertThat(address.getLine()).isEmpty();
         assertThat(address.getPostalCode()).isNull();
     }
 

--- a/gp2gp-translator/src/test/java/uk/nhs/adaptors/pss/translator/util/CompoundStatementUtilTest.java
+++ b/gp2gp-translator/src/test/java/uk/nhs/adaptors/pss/translator/util/CompoundStatementUtilTest.java
@@ -116,9 +116,9 @@ public class CompoundStatementUtilTest {
                 RCMRMT030101UKComponent02::hasMedicationStatement,
                 RCMRMT030101UKComponent02::getMedicationStatement);
 
-        assertThat(mappedValuesLinkSet.size()).isEqualTo(EXPECTED_LINKSET_MIXED_COUNT);
-        assertThat(mappedValuesObservationStatement.size()).isEqualTo(EXPECTED_OBSERVATION_STATEMENT_MIXED_COUNT);
-        assertThat(mappedValuesMedicationStatement.size()).isEqualTo(EXPECTED_MEDICATION_STATEMENT_MIXED_COUNT);
+        assertThat(mappedValuesLinkSet).hasSize(EXPECTED_LINKSET_MIXED_COUNT);
+        assertThat(mappedValuesObservationStatement).hasSize(EXPECTED_OBSERVATION_STATEMENT_MIXED_COUNT);
+        assertThat(mappedValuesMedicationStatement).hasSize(EXPECTED_MEDICATION_STATEMENT_MIXED_COUNT);
 
         mappedValuesLinkSet.forEach(
             linkSet -> assertTrue(linkSet instanceof RCMRMT030101UKLinkSet)

--- a/gp2gp-translator/src/test/java/uk/nhs/adaptors/pss/translator/util/DegradedCodeableConceptsTests.java
+++ b/gp2gp-translator/src/test/java/uk/nhs/adaptors/pss/translator/util/DegradedCodeableConceptsTests.java
@@ -22,7 +22,7 @@ public class DegradedCodeableConceptsTests {
 
         DegradedCodeableConcepts.addDegradedEntryIfRequired(codeableConcept, DegradedCodeableConcepts.DEGRADED_PLAN);
 
-        assertThat(codeableConcept.getCoding().size()).isEqualTo(1);
+        assertThat(codeableConcept.getCoding()).hasSize(1);
         assertThat(codeableConcept.getCodingFirstRep()).isEqualTo(snomedCoding);
     }
 
@@ -32,7 +32,7 @@ public class DegradedCodeableConceptsTests {
 
         DegradedCodeableConcepts.addDegradedEntryIfRequired(codeableConcept, DegradedCodeableConcepts.DEGRADED_PLAN);
 
-        assertThat(codeableConcept.getCoding().size()).isEqualTo(1);
+        assertThat(codeableConcept.getCoding()).hasSize(1);
         assertThat(codeableConcept.getCodingFirstRep()).isEqualTo(DegradedCodeableConcepts.DEGRADED_PLAN);
     }
 
@@ -44,7 +44,7 @@ public class DegradedCodeableConceptsTests {
 
         DegradedCodeableConcepts.addDegradedEntryIfRequired(codeableConcept, DegradedCodeableConcepts.DEGRADED_PLAN);
 
-        assertThat(codeableConcept.getCoding().size()).isEqualTo(2);
+        assertThat(codeableConcept.getCoding()).hasSize(2);
         assertThat(codeableConcept.getCodingFirstRep()).isEqualTo(DegradedCodeableConcepts.DEGRADED_PLAN);
         assertThat(codeableConcept.getCoding().get(1)).isEqualTo(nonSnomedCoding);
     }

--- a/gpc-api-facade/src/main/java/uk/nhs/adaptors/pss/gpc/config/AmqpConfiguration.java
+++ b/gpc-api-facade/src/main/java/uk/nhs/adaptors/pss/gpc/config/AmqpConfiguration.java
@@ -1,5 +1,6 @@
 package uk.nhs.adaptors.pss.gpc.config;
 
+import org.apache.commons.lang3.StringUtils;
 import org.apache.qpid.jms.JmsConnectionFactory;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.context.annotation.Bean;
@@ -7,8 +8,6 @@ import org.springframework.context.annotation.Configuration;
 import org.springframework.jms.core.JmsTemplate;
 import org.springframework.jms.support.converter.MappingJackson2MessageConverter;
 import org.springframework.jms.support.converter.MessageConverter;
-
-import io.micrometer.core.instrument.util.StringUtils;
 
 @Configuration
 public class AmqpConfiguration {

--- a/gpc-api-facade/src/main/java/uk/nhs/adaptors/pss/gpc/controller/validation/PatientTransferRequestValidator.java
+++ b/gpc-api-facade/src/main/java/uk/nhs/adaptors/pss/gpc/controller/validation/PatientTransferRequestValidator.java
@@ -5,11 +5,11 @@ import static java.util.Objects.nonNull;
 import jakarta.validation.ConstraintValidator;
 import jakarta.validation.ConstraintValidatorContext;
 
+import org.apache.commons.lang3.StringUtils;
 import org.hl7.fhir.dstu3.model.Identifier;
 import org.hl7.fhir.dstu3.model.Parameters;
 import org.springframework.stereotype.Component;
 
-import io.micrometer.core.instrument.util.StringUtils;
 import lombok.extern.slf4j.Slf4j;
 import uk.nhs.adaptors.common.exception.FhirValidationException;
 


### PR DESCRIPTION
## What
StringUtils replacement + test classes cleanup

## Why
StringUtils class of io.micrometer library has been declared as deprecated, hence it was replaced by another alternative StringUtils implementation

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Internal change (non-breaking change with no effect on the functionality affecting end users)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:

- [x] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] I have updated the [Changelog](/CHANGELOG.md) with details of my change in the UNRELEASED section if this change will affect end users
- [ ] A corresponding change has been made to the [Mapping Documentation repository][mapping-docs]

[mapping-docs]: https://github.com/NHSDigital/patient-switching-adaptors-mapping-documentation