### PR TITLE
Refactor: Rename test class name to match production code class name

### DIFF
--- a/gp2gp-translator/src/test/java/uk/nhs/adaptors/pss/translator/mapper/DocumentReferenceMapperTest.java
+++ b/gp2gp-translator/src/test/java/uk/nhs/adaptors/pss/translator/mapper/DocumentReferenceMapperTest.java
@@ -32,7 +32,7 @@ import uk.nhs.adaptors.pss.translator.util.DegradedCodeableConcepts;
 import static uk.nhs.adaptors.common.util.CodeableConceptUtils.createCodeableConcept;
 
 @ExtendWith(MockitoExtension.class)
-public class DocumentReferenceTest {
+public class DocumentReferenceMapperTest {
 
     private static final String XML_RESOURCES_BASE = "xml/DocumentReference/";
     private static final String NARRATIVE_STATEMENT_ROOT_ID = "5E496953-065B-41F2-9577-BE8F2FBD0757";


### PR DESCRIPTION
## Why

Easier to find test when it's naming matches convention.

## Type of change

Internal change (non-breaking change with no effect on the functionality affecting end users

## Checklist:

- [x] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] I have updated the [Changelog](/CHANGELOG.md) with details of my change in the UNRELEASED section if this change will affect end users
- [ ] A corresponding change has been made to the [Mapping Documentation repository][mapping-docs]

[mapping-docs]: https://github.com/NHSDigital/patient-switching-adaptors-mapping-documentation