### PR TITLE
NIAD-2961-preserve-test-group-header-ordering

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 ### Added
 * The AllergyIntoleranceMapper has been enhanced to support the redaction fix. If an Allergy Intolerance record includes a confidentialityCode, the meta.security field of the corresponding FHIR resource will now be appropriately populated.
 
+### Fixed
+* DiagnosticReports now preserves original ordering for mapped result references.
+
 ## [3.0.0] - 2024-07-02
 
 ### Removed

--- a/gp2gp-translator/src/integrationTest/resources/e2e-mapping/output-json/PWTP9-output.json
+++ b/gp2gp-translator/src/integrationTest/resources/e2e-mapping/output-json/PWTP9-output.json
@@ -13734,15 +13734,15 @@
       "result": [ {
         "reference": "Observation/00000000-0000-0000-0000-000000000006"
       }, {
+        "reference": "Observation/B39D6784-5532-45FB-BDCC-7F7F21A70857"
+      }, {
+        "reference": "Observation/CDC2077F-F701-47F9-AFF9-87E8C07E8C69"
+      }, {
         "reference": "Observation/05E6D1C6-9B66-4D02-8FC3-C5CF3CC0EB1C"
       }, {
         "reference": "Observation/CFAF8307-C6B6-4EB4-A69D-81DDE4D2CD91"
       }, {
         "reference": "Observation/45F8816D-FC99-4131-ABE6-01CD8A8DE49C"
-      }, {
-        "reference": "Observation/B39D6784-5532-45FB-BDCC-7F7F21A70857"
-      }, {
-        "reference": "Observation/CDC2077F-F701-47F9-AFF9-87E8C07E8C69"
       } ],
       "conclusion": "                                                                    Clinical Details:\n                                                                    NOTE:Specimen date"
     }
@@ -13781,13 +13781,13 @@
       "result": [ {
         "reference": "Observation/00000000-0000-0000-0000-000000000007"
       }, {
+        "reference": "Observation/15A8BA89-FF03-4880-B540-613745F6BFE3"
+      }, {
         "reference": "Observation/471FD197-79B8-47C0-B5D1-6A4AFBA3D31D"
       }, {
         "reference": "Observation/59F968AD-21F1-4B97-96DE-D1AE22091132"
       }, {
         "reference": "Observation/36DA8895-114B-40D6-9FA1-82B543D86893"
-      }, {
-        "reference": "Observation/15A8BA89-FF03-4880-B540-613745F6BFE3"
       } ]
     }
   }, {
@@ -13864,11 +13864,11 @@
       "result": [ {
         "reference": "Observation/00000000-0000-0000-0000-000000000008"
       }, {
+        "reference": "Observation/0F1AD848-FA61-4278-B273-048B0E247D39"
+      }, {
         "reference": "Observation/768BF90A-8E36-49D0-9D29-BD3FF0DE733D"
       }, {
         "reference": "Observation/69832EFE-727E-4270-BDF5-179851BDF295"
-      }, {
-        "reference": "Observation/0F1AD848-FA61-4278-B273-048B0E247D39"
       } ],
       "conclusion": "                                                                    Infection"
     }
@@ -13905,6 +13905,8 @@
         "reference": "Specimen/EC494B1A-FFEF-41E2-94AB-B287AE516361"
       } ],
       "result": [ {
+        "reference": "Observation/8DDBEE57-3545-490B-BE7F-EEB352A5BB6F"
+      }, {
         "reference": "Observation/E956E311-2809-400A-97E1-73F6CD15F98A"
       }, {
         "reference": "Observation/701F4CF2-3A60-4117-9DF5-8178D4FCA019"
@@ -13924,8 +13926,6 @@
         "reference": "Observation/CF963013-BE3D-4845-865A-05722B1DB292"
       }, {
         "reference": "Observation/D04342AD-DD02-40A4-AE8B-CBB62588B448"
-      }, {
-        "reference": "Observation/8DDBEE57-3545-490B-BE7F-EEB352A5BB6F"
       } ]
     }
   }, {
@@ -13961,11 +13961,11 @@
         "reference": "Specimen/EFB6D2BC-B95B-42DE-A021-6C83225E7BAC"
       } ],
       "result": [ {
-        "reference": "Observation/5578BCAA-4C60-482E-ADFD-095CC8CAB102"
-      }, {
         "reference": "Observation/EBEDD7EA-EE7A-4632-BEE4-FDDA9B4D4B11"
       }, {
         "reference": "Observation/2418B6B6-C4C0-46CB-9030-5B7DD39C80FC"
+      }, {
+        "reference": "Observation/5578BCAA-4C60-482E-ADFD-095CC8CAB102"
       } ],
       "conclusion": "                                                                    No clinical details given"
     }

--- a/gp2gp-translator/src/main/java/uk/nhs/adaptors/pss/translator/mapper/diagnosticreport/SpecimenCompoundsMapper.java
+++ b/gp2gp-translator/src/main/java/uk/nhs/adaptors/pss/translator/mapper/diagnosticreport/SpecimenCompoundsMapper.java
@@ -10,6 +10,7 @@ import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
 
+import lombok.extern.slf4j.Slf4j;
 import org.hl7.fhir.dstu3.model.CodeableConcept;
 import org.hl7.fhir.dstu3.model.DiagnosticReport;
 import org.hl7.fhir.dstu3.model.Encounter;
@@ -26,6 +27,7 @@ import org.hl7.v3.RCMRMT030101UKEhrComposition;
 import org.hl7.v3.RCMRMT030101UKEhrExtract;
 import org.hl7.v3.RCMRMT030101UKNarrativeStatement;
 import org.hl7.v3.RCMRMT030101UKObservationStatement;
+import org.jetbrains.annotations.NotNull;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
@@ -36,6 +38,7 @@ import uk.nhs.adaptors.pss.translator.util.DateFormatUtil;
 
 import static uk.nhs.adaptors.common.util.CodeableConceptUtils.createCodeableConcept;
 
+@Slf4j
 @Service
 @RequiredArgsConstructor(onConstructor = @__(@Autowired))
 public class SpecimenCompoundsMapper {
@@ -49,45 +52,50 @@ public class SpecimenCompoundsMapper {
 
     private final SpecimenBatteryMapper batteryMapper;
 
-    public List<Observation> handleSpecimenChildComponents(RCMRMT030101UKEhrExtract ehrExtract, List<Observation> observations,
-                                                           List<Observation> observationComments, List<DiagnosticReport> diagnosticReports,
-                                                           Patient patient, List<Encounter> encounters, String practiseCode) {
-
+    public List<Observation> handleSpecimenChildComponents(
+        RCMRMT030101UKEhrExtract ehrExtract,
+        List<Observation> observations,
+        List<Observation> observationComments,
+        List<DiagnosticReport> diagnosticReports,
+        Patient patient, List<Encounter> encounters, String practiseCode
+    ) {
         final List<Observation> batteryObservations = new ArrayList<>();
 
         for (var diagnosticReport : diagnosticReports) {
-
             var diagnosticReportCompoundStatement = getCompoundStatementByDRId(ehrExtract, diagnosticReport.getId());
+            if (diagnosticReportCompoundStatement.isEmpty()) {
+                continue;
+            }
 
-            if (diagnosticReportCompoundStatement.isPresent()) {
+            for (var specimenCompoundStatement : getSpecimenCompoundStatements(diagnosticReportCompoundStatement.get())) {
+                handleSpecimenObservationStatement(observations, diagnosticReport, specimenCompoundStatement);
 
-                for (var specimenCompoundStatement : getSpecimenCompoundStatements(diagnosticReportCompoundStatement.orElseThrow())) {
+                var nestedSpecimenCompoundStatements = getNestedSpecimenCompoundStatements(specimenCompoundStatement);
 
-                    for (var specimenObservationStatement : getObservationStatementsInCompound(specimenCompoundStatement)) {
-                        getObservationById(observations, specimenObservationStatement.getId().getRoot())
-                            .ifPresent(observation -> {
-                                handleObservationStatement(specimenCompoundStatement, specimenObservationStatement, observation);
-                                DiagnosticReportMapper.addResultToDiagnosticReport(observation, diagnosticReport);
-                            });
-                    }
-
-                    for (var clusterCompoundStatement : getCompoundStatementsInSpecimenCompound(specimenCompoundStatement,
-                        CLUSTER_CLASSCODE)) {
+                for (var nestedSpecimenCompoundStatement : nestedSpecimenCompoundStatements) {
+                    if (CLUSTER_CLASSCODE.equals(nestedSpecimenCompoundStatement.getClassCode().get(0))) {
                         handleClusterCompoundStatement(
-                            specimenCompoundStatement, clusterCompoundStatement, observations, observationComments, diagnosticReport,
+                            specimenCompoundStatement,
+                            nestedSpecimenCompoundStatement,
+                            observations,
+                            observationComments,
+                            diagnosticReport,
                             false
                         );
                     }
 
-                    for (var batteryCompoundStatement : getCompoundStatementsInSpecimenCompound(specimenCompoundStatement,
-                        BATTERY_CLASSCODE)) {
+                    if (BATTERY_CLASSCODE.equals(nestedSpecimenCompoundStatement.getClassCode().get(0))) {
                         handleBatteryCompoundStatement(
-                            specimenCompoundStatement, batteryCompoundStatement, observations, observationComments, diagnosticReport
+                            specimenCompoundStatement,
+                            nestedSpecimenCompoundStatement,
+                            observations,
+                            observationComments,
+                            diagnosticReport
                         );
 
                         final SpecimenBatteryParameters batteryParameters = SpecimenBatteryParameters.builder()
                             .ehrExtract(ehrExtract)
-                            .batteryCompoundStatement(batteryCompoundStatement)
+                            .batteryCompoundStatement(nestedSpecimenCompoundStatement)
                             .specimenCompoundStatement(specimenCompoundStatement)
                             .ehrComposition(getCurrentEhrComposition(ehrExtract, diagnosticReportCompoundStatement.orElseThrow()))
                             .diagnosticReport(diagnosticReport)
@@ -105,6 +113,31 @@ public class SpecimenCompoundsMapper {
         }
 
         return batteryObservations;
+    }
+
+    private static @NotNull List<RCMRMT030101UKCompoundStatement> getNestedSpecimenCompoundStatements(
+        RCMRMT030101UKCompoundStatement specimenCompoundStatement
+    ) {
+        return specimenCompoundStatement.getComponent()
+            .stream()
+            .filter(RCMRMT030101UKComponent02::hasCompoundStatement)
+            .map(RCMRMT030101UKComponent02::getCompoundStatement)
+            .filter(SpecimenCompoundsMapper::hasBatteryOrClusterClassCode)
+            .toList();
+    }
+
+    private void handleSpecimenObservationStatement(
+        List<Observation> observations,
+        DiagnosticReport diagnosticReport,
+        RCMRMT030101UKCompoundStatement specimenCompoundStatement
+    ) {
+        for (var specimenObservationStatement : getObservationStatementsInCompound(specimenCompoundStatement)) {
+            getObservationById(observations, specimenObservationStatement.getId().getRoot())
+                .ifPresent(observation -> {
+                    handleObservationStatement(specimenCompoundStatement, specimenObservationStatement, observation);
+                    DiagnosticReportMapper.addResultToDiagnosticReport(observation, diagnosticReport);
+                });
+        }
     }
 
     private void handleObservationStatement(RCMRMT030101UKCompoundStatement specimenCompoundStatement,
@@ -282,17 +315,6 @@ public class SpecimenCompoundsMapper {
             .toList();
     }
 
-    private List<RCMRMT030101UKCompoundStatement> getCompoundStatementsInSpecimenCompound(
-        RCMRMT030101UKCompoundStatement specimenCompoundStatement, String classCode) {
-
-        return specimenCompoundStatement.getComponent()
-            .stream()
-            .filter(RCMRMT030101UKComponent02::hasCompoundStatement)
-            .map(RCMRMT030101UKComponent02::getCompoundStatement)
-            .filter(compoundStatement -> classCode.equals(compoundStatement.getClassCode().get(0)))
-            .toList();
-    }
-
     private RCMRMT030101UKEhrComposition getCurrentEhrComposition(RCMRMT030101UKEhrExtract ehrExtract,
                                                                   RCMRMT030101UKCompoundStatement parentCompoundStatement) {
 
@@ -305,5 +327,10 @@ public class SpecimenCompoundsMapper {
                 .flatMap(CompoundStatementResourceExtractors::extractAllCompoundStatements)
                 .anyMatch(parentCompoundStatement::equals)
             ).findFirst().get();
+    }
+
+    private static boolean hasBatteryOrClusterClassCode(RCMRMT030101UKCompoundStatement compoundStatement) {
+        return CLUSTER_CLASSCODE.equals(compoundStatement.getClassCode().get(0))
+            || BATTERY_CLASSCODE.equals(compoundStatement.getClassCode().get(0));
     }
 }

--- a/gp2gp-translator/src/main/java/uk/nhs/adaptors/pss/translator/mapper/diagnosticreport/SpecimenCompoundsMapper.java
+++ b/gp2gp-translator/src/main/java/uk/nhs/adaptors/pss/translator/mapper/diagnosticreport/SpecimenCompoundsMapper.java
@@ -57,7 +57,9 @@ public class SpecimenCompoundsMapper {
         List<Observation> observations,
         List<Observation> observationComments,
         List<DiagnosticReport> diagnosticReports,
-        Patient patient, List<Encounter> encounters, String practiseCode
+        Patient patient,
+        List<Encounter> encounters,
+        String practiseCode
     ) {
         final List<Observation> batteryObservations = new ArrayList<>();
 
@@ -131,13 +133,12 @@ public class SpecimenCompoundsMapper {
         DiagnosticReport diagnosticReport,
         RCMRMT030101UKCompoundStatement specimenCompoundStatement
     ) {
-        for (var specimenObservationStatement : getObservationStatementsInCompound(specimenCompoundStatement)) {
+        getObservationStatementsInCompound(specimenCompoundStatement).forEach(specimenObservationStatement ->
             getObservationById(observations, specimenObservationStatement.getId().getRoot())
-                .ifPresent(observation -> {
-                    handleObservationStatement(specimenCompoundStatement, specimenObservationStatement, observation);
-                    DiagnosticReportMapper.addResultToDiagnosticReport(observation, diagnosticReport);
-                });
-        }
+            .ifPresent(observation -> {
+                handleObservationStatement(specimenCompoundStatement, specimenObservationStatement, observation);
+                DiagnosticReportMapper.addResultToDiagnosticReport(observation, diagnosticReport);
+            }));
     }
 
     private void handleObservationStatement(RCMRMT030101UKCompoundStatement specimenCompoundStatement,

--- a/gp2gp-translator/src/test/java/uk/nhs/adaptors/pss/translator/mapper/diagnosticreport/SpecimenCompoundsMapperTest.java
+++ b/gp2gp-translator/src/test/java/uk/nhs/adaptors/pss/translator/mapper/diagnosticreport/SpecimenCompoundsMapperTest.java
@@ -170,7 +170,7 @@ public class SpecimenCompoundsMapperTest {
     }
 
     @Test public void testOrderingIsPreservedForDiagnosticReportResults() {
-        final RCMRMT030101UKEhrExtract  ehrExtract =
+        final RCMRMT030101UKEhrExtract ehrExtract =
             unmarshallEhrExtract("specimen_with_three_test_group_headers.xml");
 
         final var testObservations = List.of(
@@ -204,6 +204,7 @@ public class SpecimenCompoundsMapperTest {
             List.of(),
             TEST_PRACTISE_CODE
         );
+
         var diagnosticReport = diagnosticReports.get(0);
 
         assertAll(

--- a/gp2gp-translator/src/test/resources/xml/SpecimenComponents/specimen_with_three_test_group_headers.xml
+++ b/gp2gp-translator/src/test/resources/xml/SpecimenComponents/specimen_with_three_test_group_headers.xml
@@ -1,0 +1,100 @@
+<EhrExtract xmlns="urn:hl7-org:v3">
+    <component>
+        <ehrFolder>
+            <component>
+                <ehrComposition>
+                    <id root="B0696913-F11D-4EAA-8BB7-41350B296F3F" />
+                    <component>
+                        <CompoundStatement classCode="CLUSTER">
+                            <id root="DR_TEST_ID"/>
+                            <code code="16488004"
+                                  codeSystem="2.16.840.1.113883.2.1.3.2.4.15"
+                                  displayName="laboratory reporting">
+                                <originalText>Filed Report</originalText>
+                            </code>
+                            <statusCode code="COMPLETE"/>
+                            <availabilityTime value="20100120162700"/>
+                            <component>
+                                <CompoundStatement classCode="CLUSTER">
+                                    <id root="2067A980-8CA7-491C-A22E-10BB116F75B9"/>
+                                    <code code="123038009"
+                                          codeSystem="2.16.840.1.113883.2.1.3.2.4.15"
+                                          displayName="specimen (specimen)"/>
+                                    <statusCode code="COMPLETE"/>
+                                    <availabilityTime value="20100120162700"/>
+                                    <specimen>
+                                        <specimenRole>
+                                            <id root="3B27273D-3D34-414A-90D5-167B8D8112CF"/>
+                                            <effectiveTime>
+                                                <center value="200307031514"/>
+                                            </effectiveTime>
+                                            <specimenSpecimenMaterial>
+                                                <desc>Blood</desc>
+                                            </specimenSpecimenMaterial>
+                                        </specimenRole>
+                                    </specimen>
+                                    <component>
+                                        <CompoundStatement classCode="BATTERY">
+                                            <id root="TEST-GROUP-HEADER-1"/>
+                                            <code nullFlavor="UNK">
+                                                <originalText>Full blood count - FBC</originalText>
+                                            </code>
+                                            <statusCode code="COMPLETE"/>
+                                            <availabilityTime value="20100120162700"/>
+                                            <component>
+                                                <ObservationStatement>
+                                                    <id root="OBSERVATION-STATEMENT-ID-1" />
+                                                    <availabilityTime value="20100120162700" />
+                                                </ObservationStatement>
+                                            </component>
+                                        </CompoundStatement>
+                                    </component>
+                                    <component>
+                                        <CompoundStatement classCode="CLUSTER">
+                                            <id root="TEST-GROUP-HEADER-2"/>
+                                            <code code="42I..00"
+                                                  codeSystem="2.16.840.1.113883.2.1.6.2"
+                                                  displayName="Differential white cell count" />
+                                            <statusCode code="COMPLETE"/>
+                                            <availabilityTime value="20100120162700"/>
+                                            <component>
+                                                <ObservationStatement>
+                                                    <id root="OBSERVATION-STATEMENT-ID-2" />
+                                                    <code code="42I..00"
+                                                          codeSystem="2.16.840.1.113883.2.1.6.2"
+                                                          displayName="Differential white cell count" />
+                                                    <statusCode code="COMPLETE" />
+                                                    <availabilityTime value="20100120162700" />
+                                                </ObservationStatement>
+                                            </component>
+                                        </CompoundStatement>
+                                    </component>
+                                    <component>
+                                        <CompoundStatement classCode="CLUSTER">
+                                            <id root="TEST-GROUP-HEADER-3"/>
+                                            <code code="43A..00"
+                                                  codeSystem="2.16.840.1.113883.2.1.6.2"
+                                                  displayName="Infectious mononucleosis test" />
+                                            <statusCode code="COMPLETE"/>
+                                            <availabilityTime value="20100120162700"/>
+                                            <component>
+                                                <ObservationStatement>
+                                                    <id root="OBSERVATION-STATEMENT-ID-3" />
+                                                    <code code="43A..00"
+                                                          codeSystem="2.16.840.1.113883.2.1.6.2"
+                                                          displayName="Infectious mononucleosis test" />
+                                                    <statusCode code="COMPLETE" />
+                                                    <availabilityTime value="20100120162700" />
+                                                </ObservationStatement>
+                                            </component>
+                                        </CompoundStatement>
+                                    </component>
+                                </CompoundStatement>
+                            </component>
+                        </CompoundStatement>
+                    </component>
+                </ehrComposition>
+            </component>
+        </ehrFolder>
+    </component>
+</EhrExtract>


### PR DESCRIPTION
## What

Have added an additional test to ensure test group header references are correctly ordered
Updated SpecimenCompoundMapper to cycle through all "BATTERY" and "CLUSTER" in order rather than processing each type seperately.
This ensures that they are added to the diaganostic report results in the correct order.

## Why

The PS Adaptor does not preserve the correct order of "Test Group Headers" within a Diagnostic Report.
 This can result in the resources being displayed in the incorrect order in the consuming system.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have updated the [Changelog](/CHANGELOG.md) with details of my change in the UNRELEASED section if this change will affect end users
- [x] A corresponding change has been made to the [Mapping Documentation repository][mapping-docs]

[mapping-docs]: https://github.com/NHSDigital/patient-switching-adaptors-mapping-documentation