### PR TITLE
NIAD-2851: Remove unexplained call to handleObservationStatement

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,12 +5,13 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## [Unreleased]
 
-## Added
-* Password percent-encoding has been added to help handle the caeses when password includes special '%' characters
+### Fixed
+* Resolved issue where the SNOMED import script would reject a password containing a '%' character.
+* Fixed some Test Results being given a duplicated `Observation.category` entries for `Laboratory`.
 
 ## [3.0.2] - 2024-07-18
 
-## Added
+### Added
 * If a `ehrComposition` record includes a `confidentialityCode`, the `meta.security` field of the corresponding
   `Encounter` FHIR resource will now be [appropriately populated][nopat-docs].
 * Add support for an Organization being referenced within the `ReferralRequest.recipient` field.

--- a/gp2gp-translator/src/integrationTest/resources/e2e-mapping/output-json/PWTP9-output.json
+++ b/gp2gp-translator/src/integrationTest/resources/e2e-mapping/output-json/PWTP9-output.json
@@ -4129,12 +4129,6 @@
           "code": "laboratory",
           "display": "Laboratory"
         } ]
-      }, {
-        "coding": [ {
-          "system": "http://hl7.org/fhir/observation-category",
-          "code": "laboratory",
-          "display": "Laboratory"
-        } ]
       } ],
       "code": {
         "coding": [ {
@@ -4185,12 +4179,6 @@
       } ],
       "status": "final",
       "category": [ {
-        "coding": [ {
-          "system": "http://hl7.org/fhir/observation-category",
-          "code": "laboratory",
-          "display": "Laboratory"
-        } ]
-      }, {
         "coding": [ {
           "system": "http://hl7.org/fhir/observation-category",
           "code": "laboratory",
@@ -4251,12 +4239,6 @@
           "code": "laboratory",
           "display": "Laboratory"
         } ]
-      }, {
-        "coding": [ {
-          "system": "http://hl7.org/fhir/observation-category",
-          "code": "laboratory",
-          "display": "Laboratory"
-        } ]
       } ],
       "code": {
         "coding": [ {
@@ -4307,12 +4289,6 @@
       } ],
       "status": "final",
       "category": [ {
-        "coding": [ {
-          "system": "http://hl7.org/fhir/observation-category",
-          "code": "laboratory",
-          "display": "Laboratory"
-        } ]
-      }, {
         "coding": [ {
           "system": "http://hl7.org/fhir/observation-category",
           "code": "laboratory",
@@ -4373,12 +4349,6 @@
           "code": "laboratory",
           "display": "Laboratory"
         } ]
-      }, {
-        "coding": [ {
-          "system": "http://hl7.org/fhir/observation-category",
-          "code": "laboratory",
-          "display": "Laboratory"
-        } ]
       } ],
       "code": {
         "coding": [ {
@@ -4429,12 +4399,6 @@
       } ],
       "status": "final",
       "category": [ {
-        "coding": [ {
-          "system": "http://hl7.org/fhir/observation-category",
-          "code": "laboratory",
-          "display": "Laboratory"
-        } ]
-      }, {
         "coding": [ {
           "system": "http://hl7.org/fhir/observation-category",
           "code": "laboratory",
@@ -4495,12 +4459,6 @@
           "code": "laboratory",
           "display": "Laboratory"
         } ]
-      }, {
-        "coding": [ {
-          "system": "http://hl7.org/fhir/observation-category",
-          "code": "laboratory",
-          "display": "Laboratory"
-        } ]
       } ],
       "code": {
         "coding": [ {
@@ -4551,12 +4509,6 @@
       } ],
       "status": "final",
       "category": [ {
-        "coding": [ {
-          "system": "http://hl7.org/fhir/observation-category",
-          "code": "laboratory",
-          "display": "Laboratory"
-        } ]
-      }, {
         "coding": [ {
           "system": "http://hl7.org/fhir/observation-category",
           "code": "laboratory",
@@ -4617,12 +4569,6 @@
           "code": "laboratory",
           "display": "Laboratory"
         } ]
-      }, {
-        "coding": [ {
-          "system": "http://hl7.org/fhir/observation-category",
-          "code": "laboratory",
-          "display": "Laboratory"
-        } ]
       } ],
       "code": {
         "coding": [ {
@@ -4673,12 +4619,6 @@
       } ],
       "status": "final",
       "category": [ {
-        "coding": [ {
-          "system": "http://hl7.org/fhir/observation-category",
-          "code": "laboratory",
-          "display": "Laboratory"
-        } ]
-      }, {
         "coding": [ {
           "system": "http://hl7.org/fhir/observation-category",
           "code": "laboratory",
@@ -4739,12 +4679,6 @@
           "code": "laboratory",
           "display": "Laboratory"
         } ]
-      }, {
-        "coding": [ {
-          "system": "http://hl7.org/fhir/observation-category",
-          "code": "laboratory",
-          "display": "Laboratory"
-        } ]
       } ],
       "code": {
         "coding": [ {
@@ -4795,12 +4729,6 @@
       } ],
       "status": "final",
       "category": [ {
-        "coding": [ {
-          "system": "http://hl7.org/fhir/observation-category",
-          "code": "laboratory",
-          "display": "Laboratory"
-        } ]
-      }, {
         "coding": [ {
           "system": "http://hl7.org/fhir/observation-category",
           "code": "laboratory",
@@ -5283,12 +5211,6 @@
       } ],
       "status": "final",
       "category": [ {
-        "coding": [ {
-          "system": "http://hl7.org/fhir/observation-category",
-          "code": "laboratory",
-          "display": "Laboratory"
-        } ]
-      }, {
         "coding": [ {
           "system": "http://hl7.org/fhir/observation-category",
           "code": "laboratory",
@@ -6606,12 +6528,6 @@
           "code": "laboratory",
           "display": "Laboratory"
         } ]
-      }, {
-        "coding": [ {
-          "system": "http://hl7.org/fhir/observation-category",
-          "code": "laboratory",
-          "display": "Laboratory"
-        } ]
       } ],
       "code": {
         "coding": [ {
@@ -6896,12 +6812,6 @@
       } ],
       "status": "final",
       "category": [ {
-        "coding": [ {
-          "system": "http://hl7.org/fhir/observation-category",
-          "code": "laboratory",
-          "display": "Laboratory"
-        } ]
-      }, {
         "coding": [ {
           "system": "http://hl7.org/fhir/observation-category",
           "code": "laboratory",
@@ -9147,12 +9057,6 @@
           "code": "laboratory",
           "display": "Laboratory"
         } ]
-      }, {
-        "coding": [ {
-          "system": "http://hl7.org/fhir/observation-category",
-          "code": "laboratory",
-          "display": "Laboratory"
-        } ]
       } ],
       "code": {
         "coding": [ {
@@ -9208,12 +9112,6 @@
       } ],
       "status": "final",
       "category": [ {
-        "coding": [ {
-          "system": "http://hl7.org/fhir/observation-category",
-          "code": "laboratory",
-          "display": "Laboratory"
-        } ]
-      }, {
         "coding": [ {
           "system": "http://hl7.org/fhir/observation-category",
           "code": "laboratory",

--- a/gp2gp-translator/src/integrationTest/resources/json/expectedBundle.json
+++ b/gp2gp-translator/src/integrationTest/resources/json/expectedBundle.json
@@ -22958,12 +22958,6 @@
           "code": "laboratory",
           "display": "Laboratory"
         } ]
-      }, {
-        "coding": [ {
-          "system": "http://hl7.org/fhir/observation-category",
-          "code": "laboratory",
-          "display": "Laboratory"
-        } ]
       } ],
       "code": {
         "coding": [ {

--- a/gp2gp-translator/src/main/java/uk/nhs/adaptors/pss/translator/mapper/diagnosticreport/SpecimenCompoundsMapper.java
+++ b/gp2gp-translator/src/main/java/uk/nhs/adaptors/pss/translator/mapper/diagnosticreport/SpecimenCompoundsMapper.java
@@ -230,19 +230,6 @@ public class SpecimenCompoundsMapper {
             );
         }
 
-        batteryCompoundStatement.getComponent().stream()
-            .filter(RCMRMT030101UKComponent02::hasCompoundStatement)
-            .map(RCMRMT030101UKComponent02::getCompoundStatement)
-            .forEach(compoundStatement -> compoundStatement.getComponent().stream()
-                .filter(RCMRMT030101UKComponent02::hasObservationStatement)
-                .map(RCMRMT030101UKComponent02::getObservationStatement)
-                .findFirst()
-                .ifPresent(
-                    observationStatement -> getObservationById(observations, observationStatement.getId().getRoot()).ifPresent(
-                        observation -> handleObservationStatement(specimenCompoundStatement, observationStatement, observation)
-                    )
-                ));
-
         var observationStatements = batteryCompoundStatement.getComponent().stream()
             .filter(RCMRMT030101UKComponent02::hasObservationStatement)
             .map(RCMRMT030101UKComponent02::getObservationStatement)


### PR DESCRIPTION
## Why

A BATTERY CompoundStatement can only have two types of component inside it according to the GP2GP specification. These are:

- A CLUSTER CompoundStatement
- An ObservationStatement

The existing code within handleBatteryCompoundStatement deals with each of those cases already. The additional code removed in this change appears to deal with any type of CompoundStatement. Given that the only CompoundStatement which is valid to appear here is a CLUSTER, and the code for handleClusterCompoundStatement already calls handleObservationStatement, there is no point to this code.

By removing this duplicate call to handleObservationStatement we also fix the issue where Observations are being generated with two identical "category" values of "Laboratory".

Furthermore, this code is completely untested. It is a liability in its current state, so the removal of it reduces the chance of it breaking and introducing more unwelcome unintended side-effects.

## Type of change

Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [x] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have updated the [Changelog](/CHANGELOG.md) with details of my change in the UNRELEASED section if this change will affect end users
- [ ] A corresponding change has been made to the [Mapping Documentation repository][mapping-docs]

[mapping-docs]: https://github.com/NHSDigital/patient-switching-adaptors-mapping-documentation