### PR TITLE
NIAD-3138: password encoding

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,11 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
+## [Unreleased]
+
+## Added
+* Password percent-encoding has been added to help handle the caeses when password includes special '%' characters
+
 ## [3.0.2] - 2024-07-18
 
 ## Added

--- a/snomed-database-loader/load_release-postgresql.sh
+++ b/snomed-database-loader/load_release-postgresql.sh
@@ -42,7 +42,6 @@ if [[ $1 == *uk_sct2mo* ]]; then
 fi
 
 stringencoder() {
-    # urlencode <string>
     local length="${#1}"
     for (( i = 0; i < length; i++ )); do
         local c="${1:i:1}"

--- a/snomed-database-loader/load_release-postgresql.sh
+++ b/snomed-database-loader/load_release-postgresql.sh
@@ -41,7 +41,20 @@ if [[ $1 == *uk_sct2mo* ]]; then
 	isMonolith=true
 fi
 
-databaseUri="postgresql://${PS_DB_OWNER_NAME}:${POSTGRES_PASSWORD}@${PS_DB_HOST}:${PS_DB_PORT}/${dbName}"
+stringencoder() {
+    # urlencode <string>
+    local length="${#1}"
+    for (( i = 0; i < length; i++ )); do
+        local c="${1:i:1}"
+        case $c in
+            [a-zA-Z0-9.~_-]) printf "$c" ;;
+            *) printf '%%%02X' "'$c" ;;
+        esac
+    done
+}
+
+ENCODED_POSTGRES_PASSWORD="$(stringencoder ${POSTGRES_PASSWORD})"
+databaseUri="postgresql://${PS_DB_OWNER_NAME}:${ENCODED_POSTGRES_PASSWORD}@${PS_DB_HOST}:${PS_DB_PORT}/${dbName}"
 
 #Unzip the files here, junking the structure
 localExtract="tmp_extracted"

--- a/snomed-database-loader/load_release-postgresql.sh
+++ b/snomed-database-loader/load_release-postgresql.sh
@@ -41,18 +41,18 @@ if [[ $1 == *uk_sct2mo* ]]; then
 	isMonolith=true
 fi
 
-stringencoder() {
+percentEncoder() {
     local length="${#1}"
     for (( i = 0; i < length; i++ )); do
-        local c="${1:i:1}"
-        case $c in
-            [a-zA-Z0-9.~_-]) printf "$c" ;;
-            *) printf '%%%02X' "'$c" ;;
+        local character="${1:i:1}"
+        case $character in
+            [a-zA-Z0-9.~_-]) printf "$character" ;;
+            *) printf '%%%02X' "'$character" ;;
         esac
     done
 }
 
-ENCODED_POSTGRES_PASSWORD="$(stringencoder ${POSTGRES_PASSWORD})"
+ENCODED_POSTGRES_PASSWORD="$(percentEncoder ${POSTGRES_PASSWORD})"
 databaseUri="postgresql://${PS_DB_OWNER_NAME}:${ENCODED_POSTGRES_PASSWORD}@${PS_DB_HOST}:${PS_DB_PORT}/${dbName}"
 
 #Unzip the files here, junking the structure


### PR DESCRIPTION
## What

Password percent-encoding 

## Why

Sometimes passwords can include '%' special characters which could result in "psql: error: invalid percent-encoded token...". So in order to mitigate such a situation the password percent-encoding has been introduced by this PR.

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Internal change (non-breaking change with no effect on the functionality affecting end users)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:

- [x] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have updated the [Changelog](/CHANGELOG.md) with details of my change in the UNRELEASED section if this change will affect end users
- [ ] A corresponding change has been made to the [Mapping Documentation repository][mapping-docs]

[mapping-docs]: https://github.com/NHSDigital/patient-switching-adaptors-mapping-documentation