### PR TITLE
Niad-3129

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 ## Added
 * If a `medicationStatement` or `medicationRequest` record includes a `confidentialityCode`, the `meta.security` field of the
 corresponding FHIR resource will now be [appropriately populated][nopat-docs].
+* If a `procedureRequest` record includes a `confidentialityCode`, the `meta.security` field of the
+    corresponding FHIR resource will now be [appropriately populated][nopat-docs].
 
 ### Fixed
 * Resolved issue where the SNOMED import script would reject a password containing a '%' character.

--- a/gp2gp-translator/src/main/java/uk/nhs/adaptors/pss/translator/mapper/ProcedureRequestMapper.java
+++ b/gp2gp-translator/src/main/java/uk/nhs/adaptors/pss/translator/mapper/ProcedureRequestMapper.java
@@ -11,6 +11,7 @@ import org.apache.commons.lang3.StringUtils;
 import org.hl7.fhir.dstu3.model.Annotation;
 import org.hl7.fhir.dstu3.model.DateTimeType;
 import org.hl7.fhir.dstu3.model.Encounter;
+import org.hl7.fhir.dstu3.model.Meta;
 import org.hl7.fhir.dstu3.model.Patient;
 import org.hl7.fhir.dstu3.model.ProcedureRequest;
 import org.hl7.fhir.dstu3.model.ProcedureRequest.ProcedureRequestIntent;
@@ -25,6 +26,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
 import lombok.RequiredArgsConstructor;
+import uk.nhs.adaptors.pss.translator.service.ConfidentialityService;
 import uk.nhs.adaptors.pss.translator.util.DateFormatUtil;
 import uk.nhs.adaptors.pss.translator.util.DegradedCodeableConcepts;
 import uk.nhs.adaptors.pss.translator.util.ParticipantReferenceUtil;
@@ -40,6 +42,7 @@ public class ProcedureRequestMapper extends AbstractMapper<ProcedureRequest> {
     private static final String STATUS_SEEN = "status: seen";
 
     private final CodeableConceptMapper codeableConceptMapper;
+    private final ConfidentialityService confidentialityService;
 
     public List<ProcedureRequest> mapResources(RCMRMT030101UKEhrExtract ehrExtract, Patient patient, List<Encounter> encounters,
                                                String practiseCode) {
@@ -57,35 +60,65 @@ public class ProcedureRequestMapper extends AbstractMapper<ProcedureRequest> {
             RCMRMT030101UKPlanStatement planStatement,
             Patient patient,
             List<Encounter> encounters,
-            String practiseCode
-    ) {
+            String practiseCode) {
 
         var id = planStatement.getId().getRoot();
-        var procedureRequest = new ProcedureRequest();
-        procedureRequest
-            .setStatus(getStatus(planStatement.getText()))
-            .setIntent(ProcedureRequestIntent.PLAN)
-            .setAuthoredOnElement(getAuthoredOn(planStatement.getAvailabilityTime(), ehrComposition))
-            .setOccurrence(getOccurrenceDate(planStatement.getEffectiveTime()))
-            .setSubject(new Reference(patient))
-            .setMeta(generateMeta(META_PROFILE))
-            .setId(id);
-        procedureRequest.getIdentifier().add(buildIdentifier(id, practiseCode));
-        procedureRequest.getNote().add(getNote(planStatement.getText()));
-        procedureRequest.setCode(codeableConceptMapper.mapToCodeableConcept(planStatement.getCode()));
-        procedureRequest.getRequester().setAgent(ParticipantReferenceUtil.getParticipantReference(planStatement.getParticipant(),
-            ehrComposition));
+        Meta meta = createMeta(ehrComposition, planStatement);
+        var procedureRequest = buildBaseProcedureRequest(ehrComposition, planStatement, patient, id, meta);
+        addAdditionalInformationToProcedureRequest(procedureRequest, planStatement, id, practiseCode, ehrComposition, encounters);
 
-        setProcedureRequestContext(procedureRequest, ehrComposition, encounters);
+        return handleDegradedCode(procedureRequest);
+    }
 
+    private Meta createMeta(RCMRMT030101UKEhrComposition ehrComposition, RCMRMT030101UKPlanStatement planStatement) {
+        return confidentialityService.createMetaAndAddSecurityIfConfidentialityCodesPresent(
+            META_PROFILE,
+            ehrComposition.getConfidentialityCode(),
+            planStatement.getConfidentialityCode());
+    }
+
+    private ProcedureRequest handleDegradedCode(ProcedureRequest procedureRequest) {
         if (procedureRequest.getCode() == null) {
             return procedureRequest;
         }
 
         DegradedCodeableConcepts.addDegradedEntryIfRequired(
-                procedureRequest.getCode(),
-                DegradedCodeableConcepts.DEGRADED_PLAN);
+            procedureRequest.getCode(),
+            DegradedCodeableConcepts.DEGRADED_PLAN);
 
+        return procedureRequest;
+    }
+
+    private void addAdditionalInformationToProcedureRequest(
+        ProcedureRequest procedureRequest,
+        RCMRMT030101UKPlanStatement planStatement,
+        String id,
+        String practiceCode,
+        RCMRMT030101UKEhrComposition ehrComposition,
+        List<Encounter> encounters) {
+
+        procedureRequest.getIdentifier().add(buildIdentifier(id, practiceCode));
+        procedureRequest.getNote().add(getNote(planStatement.getText()));
+        procedureRequest.setCode(codeableConceptMapper.mapToCodeableConcept(planStatement.getCode()));
+        procedureRequest.getRequester().setAgent(ParticipantReferenceUtil.getParticipantReference(planStatement.getParticipant(), ehrComposition));
+        setProcedureRequestContext(procedureRequest, ehrComposition, encounters);
+    }
+
+    private ProcedureRequest buildBaseProcedureRequest(
+        RCMRMT030101UKEhrComposition ehrComposition,
+        RCMRMT030101UKPlanStatement planStatement,
+        Patient patient,
+        String id,
+        Meta meta) {
+
+        var procedureRequest = new ProcedureRequest();
+        procedureRequest.setStatus(getStatus(planStatement.getText()))
+                        .setIntent(ProcedureRequestIntent.PLAN)
+                        .setAuthoredOnElement(getAuthoredOn(planStatement.getAvailabilityTime(), ehrComposition))
+                        .setOccurrence(getOccurrenceDate(planStatement.getEffectiveTime()))
+                        .setSubject(new Reference(patient))
+                        .setMeta(meta)
+                        .setId(id);
         return procedureRequest;
     }
 

--- a/gp2gp-translator/src/main/java/uk/nhs/adaptors/pss/translator/mapper/ProcedureRequestMapper.java
+++ b/gp2gp-translator/src/main/java/uk/nhs/adaptors/pss/translator/mapper/ProcedureRequestMapper.java
@@ -2,7 +2,6 @@ package uk.nhs.adaptors.pss.translator.mapper;
 
 import static uk.nhs.adaptors.pss.translator.util.CompoundStatementResourceExtractors.extractAllPlanStatements;
 import static uk.nhs.adaptors.pss.translator.util.ResourceUtil.buildIdentifier;
-import static uk.nhs.adaptors.pss.translator.util.ResourceUtil.generateMeta;
 
 import java.util.List;
 import java.util.Objects;
@@ -100,7 +99,9 @@ public class ProcedureRequestMapper extends AbstractMapper<ProcedureRequest> {
         procedureRequest.getIdentifier().add(buildIdentifier(id, practiceCode));
         procedureRequest.getNote().add(getNote(planStatement.getText()));
         procedureRequest.setCode(codeableConceptMapper.mapToCodeableConcept(planStatement.getCode()));
-        procedureRequest.getRequester().setAgent(ParticipantReferenceUtil.getParticipantReference(planStatement.getParticipant(), ehrComposition));
+        procedureRequest
+            .getRequester()
+            .setAgent(ParticipantReferenceUtil.getParticipantReference(planStatement.getParticipant(), ehrComposition));
         setProcedureRequestContext(procedureRequest, ehrComposition, encounters);
     }
 

--- a/gp2gp-translator/src/main/java/uk/nhs/adaptors/pss/translator/mapper/ProcedureRequestMapper.java
+++ b/gp2gp-translator/src/main/java/uk/nhs/adaptors/pss/translator/mapper/ProcedureRequestMapper.java
@@ -62,18 +62,14 @@ public class ProcedureRequestMapper extends AbstractMapper<ProcedureRequest> {
             String practiseCode) {
 
         var id = planStatement.getId().getRoot();
-        Meta meta = createMeta(ehrComposition, planStatement);
+        Meta meta = confidentialityService.createMetaAndAddSecurityIfConfidentialityCodesPresent(
+            META_PROFILE,
+            ehrComposition.getConfidentialityCode(),
+            planStatement.getConfidentialityCode());
         var procedureRequest = buildBaseProcedureRequest(ehrComposition, planStatement, patient, id, meta);
         addAdditionalInformationToProcedureRequest(procedureRequest, planStatement, id, practiseCode, ehrComposition, encounters);
 
         return handleDegradedCode(procedureRequest);
-    }
-
-    private Meta createMeta(RCMRMT030101UKEhrComposition ehrComposition, RCMRMT030101UKPlanStatement planStatement) {
-        return confidentialityService.createMetaAndAddSecurityIfConfidentialityCodesPresent(
-            META_PROFILE,
-            ehrComposition.getConfidentialityCode(),
-            planStatement.getConfidentialityCode());
     }
 
     private ProcedureRequest handleDegradedCode(ProcedureRequest procedureRequest) {

--- a/gp2gp-translator/src/test/java/uk/nhs/adaptors/pss/translator/mapper/ProcedureRequestMapperTest.java
+++ b/gp2gp-translator/src/test/java/uk/nhs/adaptors/pss/translator/mapper/ProcedureRequestMapperTest.java
@@ -71,8 +71,7 @@ public class ProcedureRequestMapperTest {
     private static final CV NOPAT_CV = TestUtility.createCv(
         "NOPAT",
         "http://hl7.org/fhir/v3/ActCode",
-        "no disclosure to patient, family or caregivers without attending provider's authorization"
-    );
+        "no disclosure to patient, family or caregivers without attending provider's authorization");
 
     private static final CV ALTERNATIVE_CV = TestUtility.createCv(
         "NOSCRUB",
@@ -207,8 +206,12 @@ public class ProcedureRequestMapperTest {
             Optional.empty()
         )).thenReturn(ALTERNATIVE_META);
 
-        ProcedureRequest procedureRequest = procedureRequestMapper.mapToProcedureRequest(ehrComposition,
-                                                                                         planStatement, SUBJECT, ENCOUNTERS, PRACTISE_CODE);
+        ProcedureRequest procedureRequest = procedureRequestMapper.mapToProcedureRequest(
+            ehrComposition,
+            planStatement,
+            SUBJECT,
+            ENCOUNTERS,
+            PRACTISE_CODE);
 
         assertNotNull(procedureRequest);
         assertMetaSecurityNotPresent(procedureRequest);

--- a/gp2gp-translator/src/test/java/uk/nhs/adaptors/pss/translator/mapper/ProcedureRequestMapperTest.java
+++ b/gp2gp-translator/src/test/java/uk/nhs/adaptors/pss/translator/mapper/ProcedureRequestMapperTest.java
@@ -77,8 +77,7 @@ public class ProcedureRequestMapperTest {
     private static final CV ALTERNATIVE_CV = TestUtility.createCv(
         "NOSCRUB",
         "http://hl7.org/fhir/v3/FakeCode",
-        "no scrubbing of the patient, family or caregivers without attending provider's authorization"
-                                                                 );
+        "no scrubbing of the patient, family or caregivers without attending provider's authorization");
 
     private static Stream<Arguments> planStatementStatuses() {
         return Stream.of(

--- a/gp2gp-translator/src/test/java/uk/nhs/adaptors/pss/translator/mapper/ProcedureRequestMapperTest.java
+++ b/gp2gp-translator/src/test/java/uk/nhs/adaptors/pss/translator/mapper/ProcedureRequestMapperTest.java
@@ -169,7 +169,6 @@ public class ProcedureRequestMapperTest {
         ProcedureRequest procedureRequest = procedureRequestMapper.mapToProcedureRequest(ehrComposition,
                                                                                          planStatement, SUBJECT, ENCOUNTERS, PRACTISE_CODE);
 
-        assertNotNull(procedureRequest);
         assertMetaSecurityIsPresent(procedureRequest.getMeta());
     }
 
@@ -189,7 +188,6 @@ public class ProcedureRequestMapperTest {
         ProcedureRequest procedureRequest = procedureRequestMapper.mapToProcedureRequest(ehrComposition,
                                                                                          planStatement, SUBJECT, ENCOUNTERS, PRACTISE_CODE);
 
-        assertNotNull(procedureRequest);
         assertMetaSecurityIsPresent(procedureRequest.getMeta());
     }
 
@@ -213,7 +211,6 @@ public class ProcedureRequestMapperTest {
             ENCOUNTERS,
             PRACTISE_CODE);
 
-        assertNotNull(procedureRequest);
         assertMetaSecurityNotPresent(procedureRequest);
     }
 

--- a/gp2gp-translator/src/test/java/uk/nhs/adaptors/pss/translator/mapper/ProcedureRequestMapperTest.java
+++ b/gp2gp-translator/src/test/java/uk/nhs/adaptors/pss/translator/mapper/ProcedureRequestMapperTest.java
@@ -3,6 +3,8 @@ package uk.nhs.adaptors.pss.translator.mapper;
 import static java.util.UUID.randomUUID;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.when;
 import static org.springframework.util.ResourceUtils.getFile;
@@ -31,6 +33,7 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 import lombok.SneakyThrows;
+import uk.nhs.adaptors.pss.translator.service.ConfidentialityService;
 import uk.nhs.adaptors.pss.translator.util.DateFormatUtil;
 import uk.nhs.adaptors.pss.translator.util.DegradedCodeableConcepts;
 import static uk.nhs.adaptors.common.util.CodeableConceptUtils.createCodeableConcept;
@@ -63,6 +66,9 @@ public class ProcedureRequestMapperTest {
                 Arguments.of(STATUS_SEEN, ProcedureRequestStatus.COMPLETED)
         );
     }
+
+    @Mock
+    private ConfidentialityService confidentialityService;
 
     @Mock
     private CodeableConceptMapper codeableConceptMapper;
@@ -113,7 +119,7 @@ public class ProcedureRequestMapperTest {
         ProcedureRequest procedureRequest = procedureRequestMapper.mapToProcedureRequest(getEhrComposition(ehrExtract),
                 planStatement, SUBJECT, ENCOUNTERS, PRACTISE_CODE);
 
-        assertThat(procedureRequest.getCode().getCodingFirstRep()).isNotNull();
+        assertNotNull(procedureRequest.getCode().getCodingFirstRep());
         assertThat(procedureRequest.getCode().getCodingFirstRep())
                 .isEqualTo(DegradedCodeableConcepts.DEGRADED_PLAN);
     }
@@ -127,9 +133,9 @@ public class ProcedureRequestMapperTest {
             planStatement, SUBJECT, ENCOUNTERS, PRACTISE_CODE);
 
         assertFixedValues(planStatement, procedureRequest);
-        assertThat(procedureRequest.getOccurrence()).isNull();
-        assertThat(procedureRequest.getAuthoredOn()).isNull();
-        assertThat(procedureRequest.getNoteFirstRep()).isNull();
+        assertNull(procedureRequest.getOccurrence());
+        assertNull(procedureRequest.getAuthoredOn());
+        assertNull(procedureRequest.getNoteFirstRep());
     }
 
     @Test
@@ -140,7 +146,7 @@ public class ProcedureRequestMapperTest {
         ProcedureRequest procedureRequest = procedureRequestMapper.mapToProcedureRequest(getEhrComposition(ehrExtract),
             planStatement, SUBJECT, ENCOUNTERS, PRACTISE_CODE);
 
-        assertThat(procedureRequest.getContext().getResource()).isNull();
+        assertNull(procedureRequest.getContext().getResource());
     }
 
     @Test


### PR DESCRIPTION
## What

Populate the "no disclosure to patient" label for ProcedureRequest

## Why

This is part of a bigger picture change that is aimed to introduce "confidentialityCode" fiield to different PS Adaptor modules. This particular PR takes care of ProcedureRequest mapper.

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Internal change (non-breaking change with no effect on the functionality affecting end users)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:

- [x] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have updated the [Changelog](/CHANGELOG.md) with details of my change in the UNRELEASED section if this change will affect end users
- [ ] A corresponding change has been made to the [Mapping Documentation repository][mapping-docs]

[mapping-docs]: https://github.com/NHSDigital/patient-switching-adaptors-mapping-documentation