### PR TITLE
[NIAD-3131] Add ConfidentialityCode support for `Conditions`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@ corresponding FHIR resource will now be [appropriately populated][nopat-docs].
   corresponding FHIR resource will now be [appropriately populated][nopat-docs].
 * If a `procedureRequest` record includes a `confidentialityCode`, the `meta.security` field of the
     corresponding FHIR resource will now be [appropriately populated][nopat-docs].
+* If a `linkset` record includes a `confidentialityCode`, the `meta.security` field of the
+  corresponding FHIR resource will now be [appropriately populated][nopat-docs].
 
 ### Fixed
 * Resolved issue where the SNOMED import script would reject a password containing a '%' character.

--- a/gp2gp-translator/src/main/java/uk/nhs/adaptors/pss/translator/mapper/ConditionMapper.java
+++ b/gp2gp-translator/src/main/java/uk/nhs/adaptors/pss/translator/mapper/ConditionMapper.java
@@ -85,6 +85,7 @@ public class ConditionMapper extends AbstractMapper<Condition> {
     public static final String CARE_CONNECT_URL = "https://fhir.hl7.org.uk/STU3/CodeSystem/CareConnect-ConditionCategory-1";
     public static final String PROBLEM_LIST_ITEM_CODE = "problem-list-item";
     public static final String PROBLEM_LIST_ITEM_DISPLAY = "Problem List Item";
+
     private final CodeableConceptMapper codeableConceptMapper;
     private final DateTimeMapper dateTimeMapper;
     private final ConfidentialityService confidentialityService;

--- a/gp2gp-translator/src/main/java/uk/nhs/adaptors/pss/translator/mapper/ConditionMapper.java
+++ b/gp2gp-translator/src/main/java/uk/nhs/adaptors/pss/translator/mapper/ConditionMapper.java
@@ -7,7 +7,6 @@ import static uk.nhs.adaptors.pss.translator.mapper.medication.MedicationMapperU
 import static uk.nhs.adaptors.pss.translator.util.CompoundStatementResourceExtractors.extractAllLinkSets;
 import static uk.nhs.adaptors.pss.translator.util.ResourceUtil.buildIdentifier;
 import static uk.nhs.adaptors.pss.translator.util.ResourceUtil.buildReferenceExtension;
-import static uk.nhs.adaptors.pss.translator.util.ResourceUtil.generateMeta;
 
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -30,6 +29,7 @@ import org.hl7.fhir.dstu3.model.DateTimeType;
 import org.hl7.fhir.dstu3.model.Encounter;
 import org.hl7.fhir.dstu3.model.Extension;
 import org.hl7.fhir.dstu3.model.IdType;
+import org.hl7.fhir.dstu3.model.Meta;
 import org.hl7.fhir.dstu3.model.Patient;
 import org.hl7.fhir.dstu3.model.Reference;
 import org.hl7.fhir.dstu3.model.ResourceType;
@@ -55,6 +55,7 @@ import org.springframework.stereotype.Service;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import uk.nhs.adaptors.pss.translator.service.ConfidentialityService;
 import uk.nhs.adaptors.pss.translator.util.CompoundStatementResourceExtractors;
 import uk.nhs.adaptors.pss.translator.util.DegradedCodeableConcepts;
 import static uk.nhs.adaptors.common.util.CodeableConceptUtils.createCodeableConcept;
@@ -86,6 +87,7 @@ public class ConditionMapper extends AbstractMapper<Condition> {
     public static final String PROBLEM_LIST_ITEM_DISPLAY = "Problem List Item";
     private final CodeableConceptMapper codeableConceptMapper;
     private final DateTimeMapper dateTimeMapper;
+    private final ConfidentialityService confidentialityService;
 
     public List<Condition> mapResources(RCMRMT030101UKEhrExtract ehrExtract, Patient patient, List<Encounter> encounters,
                                         String practiseCode) {
@@ -107,11 +109,18 @@ public class ConditionMapper extends AbstractMapper<Condition> {
                                    RCMRMT030101UKLinkSet linkSet, String practiseCode) {
 
         String id = linkSet.getId().getRoot();
+
+        final Meta meta = confidentialityService.createMetaAndAddSecurityIfConfidentialityCodesPresent(
+            META_PROFILE,
+            linkSet.getConfidentialityCode(),
+            composition.getConfidentialityCode()
+        );
+
         Condition condition = (Condition) new Condition()
             .addIdentifier(buildIdentifier(id, practiseCode))
             .addCategory(generateCategory())
             .setId(id)
-            .setMeta(generateMeta(META_PROFILE));
+            .setMeta(meta);
 
         buildClinicalStatus(linkSet.getCode()).ifPresentOrElse(
             condition::setClinicalStatus,

--- a/gp2gp-translator/src/test/java/uk/nhs/adaptors/pss/translator/mapper/ConditionMapperTest.java
+++ b/gp2gp-translator/src/test/java/uk/nhs/adaptors/pss/translator/mapper/ConditionMapperTest.java
@@ -327,7 +327,7 @@ class ConditionMapperTest {
             .get(0) // linkSet.getConfidentialityCode()
             .orElseThrow();
 
-        assertConditionsMetaIsExpected(conditions, metaWithSecurity);
+        assertAllConditionsHaveMeta(conditions, metaWithSecurity);
         assertAll(
             () -> assertThat(linksetConfidentialityCode.getCode()).isEqualTo(NOPAT),
             () -> assertThat(confidentialityCodeCaptor.getAllValues().get(1)).isNotPresent()
@@ -354,7 +354,7 @@ class ConditionMapperTest {
             .get(1) // ehrComposition.getConfidentialityCode()
             .orElseThrow();
 
-        assertConditionsMetaIsExpected(conditions, metaWithSecurity);
+        assertAllConditionsHaveMeta(conditions, metaWithSecurity);
         assertAll(
             () -> assertThat(ehrCompositionConfidentialityCode.getCode()).isEqualTo(NOPAT),
             () -> assertThat(confidentialityCodeCaptor.getAllValues().get(0)).isNotPresent()
@@ -439,7 +439,7 @@ class ConditionMapperTest {
                 .setResource(new Observation().setId(STATEMENT_REF_ID_1)));
     }
 
-    private void assertConditionsMetaIsExpected(List<Condition> conditions, Meta expectedMeta) {
+    private void assertAllConditionsHaveMeta(List<Condition> conditions, Meta expectedMeta) {
         conditions.forEach(condition -> assertThat(condition.getMeta()).usingRecursiveComparison().isEqualTo(expectedMeta));
     }
 

--- a/gp2gp-translator/src/test/java/uk/nhs/adaptors/pss/translator/mapper/ConditionMapperTest.java
+++ b/gp2gp-translator/src/test/java/uk/nhs/adaptors/pss/translator/mapper/ConditionMapperTest.java
@@ -326,8 +326,6 @@ class ConditionMapperTest {
         final List<Condition> conditions = conditionMapper
             .mapResources(ehrExtract, patient, Collections.emptyList(), PRACTISE_CODE);
 
-        conditionMapper.addReferences(buildBundleWithNamedStatementObservation(), conditions, ehrExtract);
-
         final CV linksetConfidentialityCode = confidentialityCodeCaptor
             .getAllValues()
             .get(0) // linkSet.getConfidentialityCode()
@@ -358,8 +356,6 @@ class ConditionMapperTest {
 
         final List<Condition> conditions = conditionMapper
             .mapResources(ehrExtract, patient, Collections.emptyList(), PRACTISE_CODE);
-
-        conditionMapper.addReferences(buildBundleWithNamedStatementObservation(), conditions, ehrExtract);
 
         final CV ehrCompositionConfidentialityCode = confidentialityCodeCaptor
             .getAllValues()

--- a/gp2gp-translator/src/test/java/uk/nhs/adaptors/pss/translator/mapper/ConditionMapperTest.java
+++ b/gp2gp-translator/src/test/java/uk/nhs/adaptors/pss/translator/mapper/ConditionMapperTest.java
@@ -313,10 +313,6 @@ class ConditionMapperTest {
         final RCMRMT030101UKEhrExtract ehrExtract =
             unmarshallEhrExtract("linkset_valid_nopat_confidentiality_code.xml");
 
-        when(dateTimeMapper.mapDateTime(
-            any(String.class)
-        )).thenReturn(EHR_EXTRACT_AVAILABILITY_DATETIME);
-
         when(confidentialityService.createMetaAndAddSecurityIfConfidentialityCodesPresent(
             eq(META_PROFILE),
             confidentialityCodeCaptor.capture(),
@@ -343,10 +339,6 @@ class ConditionMapperTest {
         final Meta metaWithSecurity = MetaFactory.getMetaFor(META_WITH_SECURITY, META_PROFILE);
         final RCMRMT030101UKEhrExtract ehrExtract =
             unmarshallEhrExtract("linkset_valid_ehr_composition_nopat_confidentiality_code.xml");
-
-        when(dateTimeMapper.mapDateTime(
-            any(String.class)
-        )).thenReturn(EHR_EXTRACT_AVAILABILITY_DATETIME);
 
         when(confidentialityService.createMetaAndAddSecurityIfConfidentialityCodesPresent(
             eq(META_PROFILE),
@@ -458,6 +450,10 @@ class ConditionMapperTest {
     }
 
     private void configureCommonStubs() {
+        Mockito.lenient().when(dateTimeMapper.mapDateTime(
+            any(String.class)
+        )).thenReturn(EHR_EXTRACT_AVAILABILITY_DATETIME);
+
         Mockito.lenient().when(confidentialityService.createMetaAndAddSecurityIfConfidentialityCodesPresent(
             eq(META_PROFILE),
             confidentialityCodeCaptor.capture(),

--- a/gp2gp-translator/src/test/java/uk/nhs/adaptors/pss/translator/service/ConfidentialityServiceTest.java
+++ b/gp2gp-translator/src/test/java/uk/nhs/adaptors/pss/translator/service/ConfidentialityServiceTest.java
@@ -3,11 +3,13 @@ package uk.nhs.adaptors.pss.translator.service;
 import org.hl7.fhir.dstu3.model.Coding;
 import org.hl7.fhir.dstu3.model.Meta;
 import org.hl7.fhir.dstu3.model.UriType;
+
 import org.hl7.v3.CV;
 import org.hl7.v3.RCMRMT030101UKEhrComposition;
+import org.hl7.v3.RCMRMT030101UKLinkSet;
 import org.hl7.v3.RCMRMT030101UKMedicationStatement;
 import org.hl7.v3.RCMRMT030101UKObservationStatement;
-
+import org.hl7.v3.RCMRMT030101UKRequestStatement;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import uk.nhs.adaptors.pss.translator.TestUtility;
@@ -152,6 +154,82 @@ class ConfidentialityServiceTest {
         );
 
         assertMetaSecurityIsNotPresent(result);
+    }
+
+    @Test
+    void When_LinksetWithNopatConfidentialityCodePresent_Expect_SecurityAddedToMeta() {
+        final RCMRMT030101UKLinkSet linkSet = new RCMRMT030101UKLinkSet();
+        linkSet.setConfidentialityCode(NOPAT_CV);
+
+        final Meta result = confidentialityService.createMetaAndAddSecurityIfConfidentialityCodesPresent(
+            DUMMY_PROFILE,
+            linkSet.getConfidentialityCode()
+        );
+
+        assertMetaSecurityIsPresent(result);
+    }
+
+    @Test
+    void When_LinksetWithConfidentialityCodeOtherThanNopatPresent_Expect_SecurityNotAddedToMeta() {
+        final RCMRMT030101UKLinkSet linkSet = new RCMRMT030101UKLinkSet();
+        linkSet.setConfidentialityCode(ALTERNATIVE_CV);
+
+        final Meta result = confidentialityService.createMetaAndAddSecurityIfConfidentialityCodesPresent(
+            DUMMY_PROFILE,
+            linkSet.getConfidentialityCode()
+        );
+
+        assertMetaSecurityIsNotPresent(result);
+    }
+
+    @Test
+    void When_LinksetWithoutConfidentialityCodePresent_Expect_SecurityNotAddedToMeta() {
+        final RCMRMT030101UKLinkSet linkSet = new RCMRMT030101UKLinkSet();
+
+        final Meta result = confidentialityService.createMetaAndAddSecurityIfConfidentialityCodesPresent(
+            DUMMY_PROFILE,
+            linkSet.getConfidentialityCode()
+        );
+
+        assertMetaSecurityIsNotPresent(result);
+    }
+
+    @Test
+    void When_RequestStatementWithNopatConfidentialityCodePresent_Expect_SecurityAddedToMeta() {
+        final RCMRMT030101UKRequestStatement requestStatement = new RCMRMT030101UKRequestStatement();
+        requestStatement.setConfidentialityCode(NOPAT_CV);
+
+        final Meta meta = confidentialityService.createMetaAndAddSecurityIfConfidentialityCodesPresent(
+            DUMMY_PROFILE,
+            requestStatement.getConfidentialityCode()
+        );
+
+        assertMetaSecurityIsPresent(meta);
+    }
+
+    @Test
+    void When_RequestStatementWithConfidentialityCodeOtherThanNopatPresent_Expect_SecurityNotAddedToMeta() {
+        final RCMRMT030101UKRequestStatement requestStatement = new RCMRMT030101UKRequestStatement();
+        requestStatement.setConfidentialityCode(ALTERNATIVE_CV);
+
+        final Meta meta = confidentialityService.createMetaAndAddSecurityIfConfidentialityCodesPresent(
+            DUMMY_PROFILE,
+            requestStatement.getConfidentialityCode()
+        );
+
+        assertMetaSecurityIsNotPresent(meta);
+    }
+
+    @Test
+    void When_RequestStatementWithoutConfidentialityCodePresent_Expect_SecurityNotAddedToMeta() {
+        final RCMRMT030101UKRequestStatement requestStatement = new RCMRMT030101UKRequestStatement();
+
+        final Meta meta = confidentialityService.createMetaAndAddSecurityIfConfidentialityCodesPresent(
+            DUMMY_PROFILE,
+            requestStatement.getConfidentialityCode()
+        );
+
+        assertMetaSecurityIsNotPresent(meta);
     }
 
     private void assertMetaSecurityIsPresent(final Meta meta) {

--- a/gp2gp-translator/src/test/resources/xml/Condition/linkset_valid_ehr_composition_nopat_confidentiality_code.xml
+++ b/gp2gp-translator/src/test/resources/xml/Condition/linkset_valid_ehr_composition_nopat_confidentiality_code.xml
@@ -1,0 +1,53 @@
+<EhrExtract xmlns="urn:hl7-org:v3" classCode="EXTRACT" moodCode="EVN">
+    <availabilityTime value="20101209114846"/>
+    <component typeCode="COMP">
+        <ehrFolder classCode="FOLDER" moodCode="EVN">
+            <component typeCode="COMP">
+                <ehrComposition classCode="COMPOSITION" moodCode="EVN">
+                    <id root="EHR_COMPOSITION_ENCOUNTER_ID"/>
+                    <confidentialityCode
+                            code="NOPAT"
+                            codeSystem="2.16.840.1.113883.4.642.3.47"
+                            displayName="no disclosure to patient, family or caregivers without attending provider's authorization" />
+                    <Participant2 typeCode="PRF" contextControlCode="OP">
+                        <agentRef classCode="AGNT">
+                            <id root="ASSERTER_ID"/>
+                        </agentRef>
+                    </Participant2>
+                    <component typeCode="COMP">
+                        <LinkSet classCode="OBS" moodCode="EVN">
+                            <id root="LINKSET_ID"/>
+                            <code code="394774009" codeSystem="2.16.840.1.113883.2.1.3.2.4.15" displayName="Active problem">
+                                <originalText>Active Problem, Significant</originalText>
+                                <qualifier inverted="false">
+                                    <name code="386134007" codeSystem="2.16.840.1.113883.2.1.3.2.4.15" displayName="Significant" />
+                                </qualifier>
+                            </code>
+                            <statusCode code="COMPLETE"/>
+                            <effectiveTime>
+                                <low value="20101209000000"/>
+                                <high value="20101209000000"/>
+                            </effectiveTime>
+                            <availabilityTime value="20101209114846"/>
+                            <component typeCode="COMP">
+                                <statementRef classCode="OBS" moodCode="EVN">
+                                    <id root="STATEMENT_REF_ID"/>
+                                </statementRef>
+                            </component>
+                            <component typeCode="COMP">
+                                <statementRef classCode="OBS" moodCode="EVN">
+                                    <id root="STATEMENT_REF_ID_1"/>
+                                </statementRef>
+                            </component>
+                            <conditionNamed typeCode="NAME" inversionInd="true">
+                                <namedStatementRef classCode="OBS" moodCode="EVN">
+                                    <id root="NAMED_STATEMENT_REF_ID"/>
+                                </namedStatementRef>
+                            </conditionNamed>
+                        </LinkSet>
+                    </component>
+                </ehrComposition>
+            </component>
+        </ehrFolder>
+    </component>
+</EhrExtract>

--- a/gp2gp-translator/src/test/resources/xml/Condition/linkset_valid_nopat_confidentiality_code.xml
+++ b/gp2gp-translator/src/test/resources/xml/Condition/linkset_valid_nopat_confidentiality_code.xml
@@ -1,0 +1,53 @@
+<EhrExtract xmlns="urn:hl7-org:v3" classCode="EXTRACT" moodCode="EVN">
+    <availabilityTime value="20101209114846"/>
+    <component typeCode="COMP">
+        <ehrFolder classCode="FOLDER" moodCode="EVN">
+            <component typeCode="COMP">
+                <ehrComposition classCode="COMPOSITION" moodCode="EVN">
+                    <id root="EHR_COMPOSITION_ENCOUNTER_ID"/>
+                    <Participant2 typeCode="PRF" contextControlCode="OP">
+                        <agentRef classCode="AGNT">
+                            <id root="ASSERTER_ID"/>
+                        </agentRef>
+                    </Participant2>
+                    <component typeCode="COMP">
+                        <LinkSet classCode="OBS" moodCode="EVN">
+                            <id root="LINKSET_ID"/>
+                            <code code="394774009" codeSystem="2.16.840.1.113883.2.1.3.2.4.15" displayName="Active problem">
+                                <originalText>Active Problem, Significant</originalText>
+                                <qualifier inverted="false">
+                                    <name code="386134007" codeSystem="2.16.840.1.113883.2.1.3.2.4.15" displayName="Significant" />
+                                </qualifier>
+                            </code>
+                            <statusCode code="COMPLETE"/>
+                            <effectiveTime>
+                                <low value="20101209000000"/>
+                                <high value="20101209000000"/>
+                            </effectiveTime>
+                            <availabilityTime value="20101209114846"/>
+                            <confidentialityCode
+                                    code="NOPAT"
+                                    codeSystem="2.16.840.1.113883.4.642.3.47"
+                                    displayName="no disclosure to patient, family or caregivers without attending provider's authorization" />
+                            <component typeCode="COMP">
+                                <statementRef classCode="OBS" moodCode="EVN">
+                                    <id root="STATEMENT_REF_ID"/>
+                                </statementRef>
+                            </component>
+                            <component typeCode="COMP">
+                                <statementRef classCode="OBS" moodCode="EVN">
+                                    <id root="STATEMENT_REF_ID_1"/>
+                                </statementRef>
+                            </component>
+                            <conditionNamed typeCode="NAME" inversionInd="true">
+                                <namedStatementRef classCode="OBS" moodCode="EVN">
+                                    <id root="NAMED_STATEMENT_REF_ID"/>
+                                </namedStatementRef>
+                            </conditionNamed>
+                        </LinkSet>
+                    </component>
+                </ehrComposition>
+            </component>
+        </ehrFolder>
+    </component>
+</EhrExtract>


### PR DESCRIPTION
## What

This PR introduces the capability to handle `confidentialityCodes` for` Conditions`. The implementation checks if a `Linkset` or `EhrComposition` contains a confidentiality code with the value `NOPAT`. If this code is present, meta security is added to the resource; otherwise, the code is ignored.

## Why

More details can be found on the [ticket](https://nhse-dsic.atlassian.net/browse/NIAD-3131).

## Type of change

- [x] New feature (non-breaking change which adds functionality)

## Checklist:

- [x] I have performed a self-review of my code
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have updated the [Changelog](/CHANGELOG.md) with details of my change in the UNRELEASED section if this change will affect end users
- [ ] A corresponding change has been made to the [Mapping Documentation repository][mapping-docs]

[mapping-docs]: https://github.com/NHSDigital/patient-switching-adaptors-mapping-documentation