### PR TITLE
Refactor: Rename mapSpecimen to mapSpecimens

### DIFF
--- a/gp2gp-translator/src/main/java/uk/nhs/adaptors/pss/translator/mapper/diagnosticreport/SpecimenMapper.java
+++ b/gp2gp-translator/src/main/java/uk/nhs/adaptors/pss/translator/mapper/diagnosticreport/SpecimenMapper.java
@@ -41,8 +41,8 @@ public class SpecimenMapper {
 
     private final DateTimeMapper dateTimeMapper;
 
-    public List<Specimen> mapSpecimen(RCMRMT030101UKEhrExtract ehrExtract, List<DiagnosticReport> diagnosticReports,
-                                      Patient patient, String practiceCode) {
+    public List<Specimen> mapSpecimens(RCMRMT030101UKEhrExtract ehrExtract, List<DiagnosticReport> diagnosticReports,
+                                       Patient patient, String practiceCode) {
 
         return diagnosticReports.stream()
             .flatMap(diagnosticReport -> diagnosticReport.getSpecimen().stream())

--- a/gp2gp-translator/src/main/java/uk/nhs/adaptors/pss/translator/service/BundleMapperService.java
+++ b/gp2gp-translator/src/main/java/uk/nhs/adaptors/pss/translator/service/BundleMapperService.java
@@ -170,9 +170,9 @@ public class BundleMapperService {
 
         diagnosticReportMapper.handleChildObservationComments(ehrExtract, observationComments);
 
-        var specimen = specimenMapper.mapSpecimen(ehrExtract, diagnosticReports, patient, practiceCode);
+        var specimens = specimenMapper.mapSpecimens(ehrExtract, diagnosticReports, patient, practiceCode);
         addEntries(bundle, diagnosticReports);
-        addEntries(bundle, specimen);
+        addEntries(bundle, specimens);
 
         observationComments = specimenMapper.removeSurplusObservationComments(ehrExtract, observationComments);
 

--- a/gp2gp-translator/src/test/java/uk/nhs/adaptors/pss/translator/mapper/diagnosticreport/SpecimenMapperTest.java
+++ b/gp2gp-translator/src/test/java/uk/nhs/adaptors/pss/translator/mapper/diagnosticreport/SpecimenMapperTest.java
@@ -58,7 +58,7 @@ public class SpecimenMapperTest {
     public void testSpecimenIsMapped() {
         when(dateTimeMapper.mapDateTime(any())).thenCallRealMethod();
         RCMRMT030101UKEhrExtract ehrExtract = unmarshallEhrExtract("specimen_valid.xml");
-        List<Specimen> specimenList = specimenMapper.mapSpecimen(
+        List<Specimen> specimenList = specimenMapper.mapSpecimens(
             ehrExtract, List.of(DIAGNOSTIC_REPORT_WITH_SPECIMEN), PATIENT, PRACTICE_CODE
         );
 
@@ -75,7 +75,7 @@ public class SpecimenMapperTest {
     @Test
     public void testSpecimenIsMappedWithNoOptionalFields() {
         RCMRMT030101UKEhrExtract ehrExtract = unmarshallEhrExtract("specimen_no_optional_fields.xml");
-        List<Specimen> specimenList = specimenMapper.mapSpecimen(
+        List<Specimen> specimenList = specimenMapper.mapSpecimens(
             ehrExtract, List.of(DIAGNOSTIC_REPORT_WITH_SPECIMEN), PATIENT, PRACTICE_CODE
         );
 
@@ -97,7 +97,7 @@ public class SpecimenMapperTest {
     @Test
     public void testInvalidSpecimenIsNotMapped() {
         RCMRMT030101UKEhrExtract ehrExtract = unmarshallEhrExtract("specimen_invalid.xml");
-        List<Specimen> specimenList = specimenMapper.mapSpecimen(
+        List<Specimen> specimenList = specimenMapper.mapSpecimens(
             ehrExtract, List.of(DIAGNOSTIC_REPORT_WITHOUT_SPECIMEN), PATIENT, PRACTICE_CODE
         );
 

--- a/gp2gp-translator/src/test/java/uk/nhs/adaptors/pss/translator/service/BundleMapperServiceTest.java
+++ b/gp2gp-translator/src/test/java/uk/nhs/adaptors/pss/translator/service/BundleMapperServiceTest.java
@@ -188,7 +188,7 @@ public class BundleMapperServiceTest {
         verify(allergyIntoleranceMapper).mapResources(any(RCMRMT030101UKEhrExtract.class), any(Patient.class), anyList(), anyString());
         verify(diagnosticReportMapper).mapResources(
             any(RCMRMT030101UKEhrExtract.class), any(Patient.class), anyList(), any(String.class), any(ArrayList.class));
-        verify(specimenMapper).mapSpecimen(any(RCMRMT030101UKEhrExtract.class), anyList(), any(Patient.class), anyString());
+        verify(specimenMapper).mapSpecimens(any(RCMRMT030101UKEhrExtract.class), anyList(), any(Patient.class), anyString());
         verify(diagnosticReportMapper).handleChildObservationComments(any(RCMRMT030101UKEhrExtract.class), anyList());
         verify(specimenCompoundsMapper).handleSpecimenChildComponents(
             any(RCMRMT030101UKEhrExtract.class), anyList(), anyList(), anyList(), any(Patient.class), anyList(), anyString()


### PR DESCRIPTION
## Why

Misleading name!

## Type of change

Internal change (non-breaking change with no effect on the functionality affecting end users)

## Checklist:

- [x] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I have updated the [Changelog](/CHANGELOG.md) with details of my change in the UNRELEASED section if this change will affect end users
- [ ] A corresponding change has been made to the [Mapping Documentation repository][mapping-docs]

[mapping-docs]: https://github.com/NHSDigital/patient-switching-adaptors-mapping-documentation