### PR TITLE
NIAD-3133: Populate the "no disclosure to patient" label for Immunization

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@ corresponding FHIR resource will now be [appropriately populated][nopat-docs].
     corresponding FHIR resource will now be [appropriately populated][nopat-docs].
 * If a `linkset` record includes a `confidentialityCode`, the `meta.security` field of the
   corresponding FHIR resource will now be [appropriately populated][nopat-docs].
+* If an `immunization` record includes a `confidentialityCode`, the `meta.security` field of the
+    corresponding FHIR resource will now be [appropriately populated][nopat-docs].
 
 ### Fixed
 * Resolved issue where the SNOMED import script would reject a password containing a '%' character.

--- a/gp2gp-translator/src/test/resources/xml/Immunization/immunization_with_ehrComposition_nopat_confidentiality_code.xml
+++ b/gp2gp-translator/src/test/resources/xml/Immunization/immunization_with_ehrComposition_nopat_confidentiality_code.xml
@@ -1,0 +1,22 @@
+<EhrExtract xmlns="urn:hl7-org:v3">
+    <component>
+        <ehrFolder>
+            <component>
+                <ehrComposition>
+                    <id root="62A39454-299F-432E-993E-5A6232B4E099" />
+                    <confidentialityCode
+                            code="NOPAT"
+                            codeSystem="2.16.840.1.113883.4.642.3.47"
+                            displayName="no disclosure to patient, family or caregivers without attending provider's authorization"
+                    />
+                    <component>
+                        <ObservationStatement xmlns="urn:hl7-org:v3">
+                            <id root="82A39454-299F-432E-993E-5A6232B4E099" />
+                            <code code="code" codeSystem="CodeSystem" displayName="DisplayName" />
+                        </ObservationStatement>
+                    </component>
+                </ehrComposition>
+            </component>
+        </ehrFolder>
+    </component>
+</EhrExtract>

--- a/gp2gp-translator/src/test/resources/xml/Immunization/immunization_with_observation_nopat_confidentiality_code.xml
+++ b/gp2gp-translator/src/test/resources/xml/Immunization/immunization_with_observation_nopat_confidentiality_code.xml
@@ -1,0 +1,22 @@
+<EhrExtract xmlns="urn:hl7-org:v3">
+    <component>
+        <ehrFolder>
+            <component>
+                <ehrComposition>
+                    <id root="62A39454-299F-432E-993E-5A6232B4E099" />
+                    <component>
+                        <ObservationStatement xmlns="urn:hl7-org:v3">
+                            <id root="82A39454-299F-432E-993E-5A6232B4E099" />
+                            <code code="code" codeSystem="CodeSystem" displayName="DisplayName" />
+                            <confidentialityCode
+                                    code="NOPAT"
+                                    codeSystem="2.16.840.1.113883.4.642.3.47"
+                                    displayName="no disclosure to patient, family or caregivers without attending provider's authorization"
+                            />
+                        </ObservationStatement>
+                    </component>
+                </ehrComposition>
+            </component>
+        </ehrFolder>
+    </component>
+</EhrExtract>


### PR DESCRIPTION
## What

* Updated ImmunizationMapper to use the confidentiality service when generating the Meta by checking if a `NOPAT` confidentiality code is populated in either the `ehrComposition` or the `ObservationStatement`.
* Create new tests to cover the above scenario.
* Add additional test xml files for the new tests.

## Why

When provided with the following `confidentialityCode` element in either the `ehrComposition` or the `ObservationStatement` when mapping immunizations:

```xml
<confidentialityCode
  code="NOPAT"
  codeSystem="2.16.840.1.113883.4.642.3.47"
  displayName="no disclosure to patient, family or caregivers without attending provider's authorization" />
```

The produced immunization will contain the following JSON Element:

```json
{
  "meta": {
    "security": [{
      "system":"http://hl7.org/fhir/v3/ActCode",
      "code":"NOPAT",
      "display":"no disclosure to patient, family or caregivers without attending provider's authorization"
    }]
  }
}
```

This is needed to satisfy the requirements for Redaction Changes.

## Type of change

- [x] New feature (non-breaking change which adds functionality)

## Checklist:

- [x] I have performed a self-review of my code
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have updated the [Changelog](/CHANGELOG.md) with details of my change in the UNRELEASED section if this change will affect end users
- [x] A corresponding change has been made to the [Mapping Documentation repository][mapping-docs]

[mapping-docs]: https://github.com/NHSDigital/patient-switching-adaptors-mapping-documentation