### PR TITLE
NIAD-2394: Populate the "no disclosure to patient" label for `BloodPressure`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,8 @@ corresponding FHIR resource will now be [appropriately populated][nopat-docs].
   corresponding FHIR resource will now be [appropriately populated][nopat-docs].
 * If an `immunization` record includes a `confidentialityCode`, the `meta.security` field of the
     corresponding FHIR resource will now be [appropriately populated][nopat-docs].
+* If a `bloodPressure` record includes a `confidentialityCode`, the `meta.security` field of the
+    corresponding FHIR resource will now be [appropriately populated][nopat-docs].
 
 ### Fixed
 * Resolved issue where the SNOMED import script would reject a password containing a '%' character.

--- a/gp2gp-translator/src/main/java/uk/nhs/adaptors/pss/translator/mapper/BloodPressureMapper.java
+++ b/gp2gp-translator/src/main/java/uk/nhs/adaptors/pss/translator/mapper/BloodPressureMapper.java
@@ -80,16 +80,10 @@ public class BloodPressureMapper extends AbstractMapper<Observation> {
         var id = compoundStatement.getId().get(0);
 
         @SuppressWarnings("unchecked")
-        final Optional<CV>[] confidentialityCodes = Stream.of(
-                Stream.of(ehrComposition.getConfidentialityCode()),
-                Stream.of(compoundStatement.getConfidentialityCode()),
-                observationStatements
-                    .stream()
-                    .map(RCMRMT030101UKObservationStatement::getConfidentialityCode)
-            )
-            .flatMap(cv -> cv)
-            .filter(Optional::isPresent)
-            .toArray(Optional[]::new);
+        final Optional<CV>[] confidentialityCodes = Stream.concat(
+            Stream.of(ehrComposition.getConfidentialityCode(), compoundStatement.getConfidentialityCode()),
+            observationStatements.stream().map(RCMRMT030101UKObservationStatement::getConfidentialityCode)
+        ).toArray(Optional[]::new);
 
         var meta = confidentialityService.createMetaAndAddSecurityIfConfidentialityCodesPresent(
             META_PROFILE,

--- a/gp2gp-translator/src/main/java/uk/nhs/adaptors/pss/translator/mapper/BloodPressureMapper.java
+++ b/gp2gp-translator/src/main/java/uk/nhs/adaptors/pss/translator/mapper/BloodPressureMapper.java
@@ -53,7 +53,7 @@ import uk.nhs.adaptors.pss.translator.util.DegradedCodeableConcepts;
 @Service
 @AllArgsConstructor
 public class BloodPressureMapper extends AbstractMapper<Observation> {
-    private static final String META_PROFILE = "https://fhir.nhs.uk/STU3/StructureDefinition/CareConnect-GPC-Observation-1";
+    private static final String META_PROFILE = "Observation-1";
     private static final String SYSTOLIC_NOTE = "Systolic Note: ";
     private static final String DIASTOLIC_NOTE = "Diastolic Note: ";
     private static final String BP_NOTE = "BP Note: ";

--- a/gp2gp-translator/src/test/java/uk/nhs/adaptors/pss/translator/mapper/BloodPressureMapperTest.java
+++ b/gp2gp-translator/src/test/java/uk/nhs/adaptors/pss/translator/mapper/BloodPressureMapperTest.java
@@ -1,16 +1,22 @@
 package uk.nhs.adaptors.pss.translator.mapper;
 
+import static java.math.RoundingMode.DOWN;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertAll;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.when;
 import static org.springframework.util.ResourceUtils.getFile;
 
+import static uk.nhs.adaptors.pss.translator.MetaFactory.MetaType.META_WITHOUT_SECURITY;
+import static uk.nhs.adaptors.pss.translator.MetaFactory.MetaType.META_WITH_SECURITY;
 import static uk.nhs.adaptors.pss.translator.util.XmlUnmarshallUtil.unmarshallFile;
 
 import java.math.BigDecimal;
 import java.util.List;
+import java.util.Optional;
 
 import org.apache.commons.lang3.StringUtils;
 import org.hl7.fhir.dstu3.model.CodeableConcept;
@@ -19,15 +25,24 @@ import org.hl7.fhir.dstu3.model.Encounter;
 import org.hl7.fhir.dstu3.model.Observation;
 import org.hl7.fhir.dstu3.model.Patient;
 import org.hl7.fhir.dstu3.model.Period;
+import org.hl7.v3.CV;
 import org.hl7.v3.RCMRMT030101UKEhrExtract;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 import lombok.SneakyThrows;
+import uk.nhs.adaptors.pss.translator.MetaFactory;
+import uk.nhs.adaptors.pss.translator.TestUtility;
+import uk.nhs.adaptors.pss.translator.service.ConfidentialityService;
 import uk.nhs.adaptors.pss.translator.util.DateFormatUtil;
 import uk.nhs.adaptors.pss.translator.util.DegradedCodeableConcepts;
 
@@ -52,13 +67,20 @@ public class BloodPressureMapperTest {
     private static final String COMMENT_EXAMPLE_3 = "Diastolic Note: Test diastolic pressure text";
     private static final String COMMENT_EXAMPLE_4 = "BP Note: Systolic Measurement Absent: Unknown";
     private static final BigDecimal COMPONENT_1_VALUE_QUANTITY_VALUE_BASE = new BigDecimal(80);
-    private static final BigDecimal COMPONENT_1_VALUE_QUANTITY_VALUE = COMPONENT_1_VALUE_QUANTITY_VALUE_BASE.setScale(3);
+    private static final BigDecimal COMPONENT_1_VALUE_QUANTITY_VALUE = COMPONENT_1_VALUE_QUANTITY_VALUE_BASE.
+        setScale(3, DOWN);
     private static final String COMPONENT_1_INTERPRETATION_TEXT = "High Text";
     private static final String COMPONENT_1_REFERENCE_RANGE_TEXT = "Test Range 1";
     private static final BigDecimal COMPONENT_2_VALUE_QUANTITY_VALUE_BASE = new BigDecimal(90);
-    private static final BigDecimal COMPONENT_2_VALUE_QUANTITY_VALUE = COMPONENT_2_VALUE_QUANTITY_VALUE_BASE.setScale(3);
+    private static final BigDecimal COMPONENT_2_VALUE_QUANTITY_VALUE = COMPONENT_2_VALUE_QUANTITY_VALUE_BASE
+        .setScale(3, DOWN);
     private static final String COMPONENT_2_INTERPRETATION_TEXT = "Low Text";
     private static final String COMPONENT_2_REFERENCE_RANGE_TEXT = "Test Range 2";
+    public static final String NOPAT_CODE = "NOPAT";
+    public static final String NOPAT_URL_CODESYSTEM = "http://hl7.org/fhir/v3/ActCode";
+    public static final String NOPAT_DISPLAY =
+        "no disclosure to patient, family or caregivers without attending provider's authorization";
+    public static final String NOPAT_OID_CODESYSTEM = "2.16.840.1.113883.4.642.3.47";
 
     private static final CodeableConcept CODEABLE_CONCEPT = createCodeableConcept(null, null, CODING_DISPLAY_MOCK);
     private static final List<Encounter> ENCOUNTER_LIST = List.of(
@@ -71,25 +93,30 @@ public class BloodPressureMapperTest {
     @Mock
     private Patient patient;
 
+    @Mock
+    private ConfidentialityService confidentialityService;
+
     @InjectMocks
     private BloodPressureMapper bloodPressureMapper;
 
-    @SneakyThrows
-    private RCMRMT030101UKEhrExtract unmarshallEhrExtractElement(String fileName) {
-        return unmarshallFile(getFile("classpath:" + XML_RESOURCES_BASE + fileName), RCMRMT030101UKEhrExtract.class);
-    }
+    @Captor
+    private ArgumentCaptor<Optional<CV>> confidentialityCodesCaptor;
 
-    private void assertFixedValues(Observation bloodPressure) {
-        assertThat(bloodPressure.getMeta().getProfile().get(0).getValue()).isEqualTo(META_PROFILE);
-        assertThat(bloodPressure.getIdentifier().get(0).getSystem()).isEqualTo(IDENTIFIER_SYSTEM);
-        assertThat(bloodPressure.getIdentifier().get(0).getValue()).isEqualTo(EXAMPLE_ID);
-        assertThat(bloodPressure.getStatus()).isEqualTo(Observation.ObservationStatus.FINAL);
+    @BeforeEach
+    @SuppressWarnings("unchecked")
+    public void setupDefaultStubs() {
+        lenient()
+            .when(codeableConceptMapper.mapToCodeableConcept(any()))
+            .thenReturn(CODEABLE_CONCEPT);
+        lenient()
+            .when(confidentialityService.createMetaAndAddSecurityIfConfidentialityCodesPresent(
+                any(),
+                any(Optional[].class)))
+            .thenReturn(MetaFactory.getMetaFor(META_WITHOUT_SECURITY, META_PROFILE));
     }
 
     @Test
     public void mapBloodPressureObservationWithValidData() {
-        when(codeableConceptMapper.mapToCodeableConcept(any())).thenReturn(CODEABLE_CONCEPT);
-
         var ehrExtract = unmarshallEhrExtractElement("full_valid_data_bp_example.xml");
 
         var bloodPressure = bloodPressureMapper.mapResources(ehrExtract, patient, ENCOUNTER_LIST, PRACTISE_CODE).get(0);
@@ -125,8 +152,6 @@ public class BloodPressureMapperTest {
 
     @Test
     public void mapBloodPressureWithNoOptionalData() {
-        when(codeableConceptMapper.mapToCodeableConcept(any())).thenReturn(CODEABLE_CONCEPT);
-
         var ehrExtract = unmarshallEhrExtractElement("no_optional_data_bp_example.xml");
 
         var bloodPressure = bloodPressureMapper.mapResources(ehrExtract, patient, ENCOUNTER_LIST, PRACTISE_CODE).get(0);
@@ -157,6 +182,47 @@ public class BloodPressureMapperTest {
         assertThat(bloodPressure.getComponent().get(1).getValueQuantity()).isNull();
         assertThat(bloodPressure.getComponent().get(1).getInterpretation().getCoding()).isEmpty();
         assertThat(bloodPressure.getComponent().get(1).getReferenceRange()).isEmpty();
+    }
+
+    @ParameterizedTest(name = "[{index}] {0}")
+    @ValueSource(strings = {
+        "ehr_composition_containing_confidentiality_code",
+        "battery_compound_statement_containing_confidentiality_code",
+        "systolic_observation_containing_confidentiality_code",
+        "diastolic_observation_containing_confidentiality_code"
+    })
+    public void When_MappingBloodPressureWithConfidentialityCodes_Expect_BloodPressureObservationContainsSecurityMeta(
+        String inputXml
+    ) {
+        final var metaWithSecurity = MetaFactory.getMetaFor(META_WITH_SECURITY, META_PROFILE);
+        when(
+            confidentialityService.createMetaAndAddSecurityIfConfidentialityCodesPresent(
+                eq("https://fhir.nhs.uk/STU3/StructureDefinition/CareConnect-GPC-Observation-1"),
+                confidentialityCodesCaptor.capture()
+            )
+        ).thenReturn(metaWithSecurity);
+        final var ehrExtract = unmarshallEhrExtractElement(inputXml + ".xml");
+
+        final var bloodPressure = bloodPressureMapper
+            .mapResources(ehrExtract, patient, ENCOUNTER_LIST, PRACTISE_CODE)
+            .get(0);
+        final var confidentialityCode = confidentialityCodesCaptor
+            .getAllValues()
+            .get(0);
+        final var securityMeta = bloodPressure
+            .getMeta()
+            .getSecurity(NOPAT_URL_CODESYSTEM, NOPAT_CODE);
+
+        assertThat(confidentialityCode).isPresent();
+        assertAll(
+            () -> assertThat(confidentialityCode.get())
+                .usingRecursiveComparison()
+                .isEqualTo(
+                    TestUtility.createCv(NOPAT_CODE, NOPAT_OID_CODESYSTEM, NOPAT_DISPLAY)
+                ),
+            () -> assertThat(securityMeta.getDisplay())
+                .isEqualTo(NOPAT_DISPLAY)
+        );
     }
 
     @Test
@@ -229,12 +295,9 @@ public class BloodPressureMapperTest {
 
     @Test
     public void mapBloodPressureWithNoSnomedCodeInCoding() {
-        when(codeableConceptMapper.mapToCodeableConcept(any())).thenReturn(CODEABLE_CONCEPT);
-
         var ehrExtract = unmarshallEhrExtractElement("full_valid_data_bp_example.xml");
 
         var bloodPressure = bloodPressureMapper.mapResources(ehrExtract, patient, ENCOUNTER_LIST, PRACTISE_CODE).get(0);
-
 
         assertThat(bloodPressure.getCode().getCodingFirstRep())
             .isEqualTo(DegradedCodeableConcepts.DEGRADED_OTHER);
@@ -252,7 +315,6 @@ public class BloodPressureMapperTest {
 
     @Test
     public void mapBloodPressureWithSnomedCodeInCoding() {
-
         var codeableConcept = createCodeableConcept("http://snomed.info/sct", "123456", "Display");
         when(codeableConceptMapper.mapToCodeableConcept(any())).thenReturn(codeableConcept);
 
@@ -266,4 +328,17 @@ public class BloodPressureMapperTest {
             () -> assertEquals(codeableConcept, bloodPressure.getComponent().get(1).getCode())
         );
     }
+
+    private void assertFixedValues(Observation bloodPressure) {
+        assertThat(bloodPressure.getMeta().getProfile().get(0).getValue()).isEqualTo(META_PROFILE);
+        assertThat(bloodPressure.getIdentifier().get(0).getSystem()).isEqualTo(IDENTIFIER_SYSTEM);
+        assertThat(bloodPressure.getIdentifier().get(0).getValue()).isEqualTo(EXAMPLE_ID);
+        assertThat(bloodPressure.getStatus()).isEqualTo(Observation.ObservationStatus.FINAL);
+    }
+
+    @SneakyThrows
+    private RCMRMT030101UKEhrExtract unmarshallEhrExtractElement(String fileName) {
+        return unmarshallFile(getFile("classpath:" + XML_RESOURCES_BASE + fileName), RCMRMT030101UKEhrExtract.class);
+    }
+
 }

--- a/gp2gp-translator/src/test/java/uk/nhs/adaptors/pss/translator/mapper/BloodPressureMapperTest.java
+++ b/gp2gp-translator/src/test/java/uk/nhs/adaptors/pss/translator/mapper/BloodPressureMapperTest.java
@@ -55,7 +55,7 @@ public class BloodPressureMapperTest {
 
     private static final String XML_RESOURCES_BASE = "xml/BloodPressure/";
     private static final String EXAMPLE_ID = "FE739904-2AAB-4B3F-9718-84BE019FD483";
-    private static final String META_PROFILE = "https://fhir.nhs.uk/STU3/StructureDefinition/CareConnect-GPC-Observation-1";
+    private static final String META_PROFILE = "Observation-1";
     private static final String PRACTISE_CODE = "TESTPRACTISECODE";
     private static final String IDENTIFIER_SYSTEM = "https://PSSAdaptor/TESTPRACTISECODE";
     private static final String CODING_DISPLAY_MOCK = "Test Display";

--- a/gp2gp-translator/src/test/resources/xml/BloodPressure/battery_compound_statement_containing_confidentiality_code.xml
+++ b/gp2gp-translator/src/test/resources/xml/BloodPressure/battery_compound_statement_containing_confidentiality_code.xml
@@ -1,0 +1,43 @@
+<EhrExtract xmlns="urn:hl7-org:v3" classCode="EXTRACT" moodCode="EVN">
+    <component typeCode="COMP">
+        <ehrFolder classCode="FOLDER" moodCode="EVN">
+            <component typeCode="COMP">
+                <ehrComposition classCode="COMPOSITION" moodCode="EVN">
+                    <id root="TEST_ID_MATCHING_ENCOUNTER"/>
+                    <component typeCode="COMP">
+                        <CompoundStatement classCode="BATTERY" moodCode="EVN">
+                            <id root="FE739904-2AAB-4B3F-9718-84BE019FD483"/>
+                            <confidentialityCode
+                                    code="NOPAT"
+                                    codeSystem="2.16.840.1.113883.4.642.3.47"
+                                    displayName="no disclosure to patient, family or caregivers without attending provider's authorization"
+                            />
+                            <code code="163020007" codeSystem="2.16.840.1.113883.2.1.3.2.4.15"
+                                  displayName="O/E - blood pressure reading">
+                                <originalText>O/E - blood pressure reading</originalText>
+                            </code>
+                            <component typeCode="COMP" contextConductionInd="true">
+                                <ObservationStatement classCode="OBS" moodCode="EVN">
+                                    <id root="38324DDE-7ABE-4039-BF78-8E9D334FCA8F"/>
+                                    <code code="72313002" codeSystem="2.16.840.1.113883.2.1.3.2.4.15"
+                                          displayName="Systolic arterial pressure">
+                                        <originalText>Systolic arterial pressure</originalText>
+                                    </code>
+                                </ObservationStatement>
+                            </component>
+                            <component typeCode="COMP" contextConductionInd="true">
+                                <ObservationStatement classCode="OBS" moodCode="EVN">
+                                    <id root="041E16C5-CB96-4A2C-A8D8-BF6CD904671E"/>
+                                    <code code="1091811000000102" codeSystem="2.16.840.1.113883.2.1.3.2.4.15"
+                                          displayName="Diastolic arterial pressure">
+                                        <originalText>Diastolic arterial pressure</originalText>
+                                    </code>
+                                </ObservationStatement>
+                            </component>
+                        </CompoundStatement>
+                    </component>
+                </ehrComposition>
+            </component>
+        </ehrFolder>
+    </component>
+</EhrExtract>

--- a/gp2gp-translator/src/test/resources/xml/BloodPressure/diastolic_observation_containing_confidentiality_code.xml
+++ b/gp2gp-translator/src/test/resources/xml/BloodPressure/diastolic_observation_containing_confidentiality_code.xml
@@ -1,0 +1,43 @@
+<EhrExtract xmlns="urn:hl7-org:v3" classCode="EXTRACT" moodCode="EVN">
+    <component typeCode="COMP">
+        <ehrFolder classCode="FOLDER" moodCode="EVN">
+            <component typeCode="COMP">
+                <ehrComposition classCode="COMPOSITION" moodCode="EVN">
+                    <id root="TEST_ID_MATCHING_ENCOUNTER"/>
+                    <component typeCode="COMP">
+                        <CompoundStatement classCode="BATTERY" moodCode="EVN">
+                            <id root="FE739904-2AAB-4B3F-9718-84BE019FD483"/>
+                            <code code="163020007" codeSystem="2.16.840.1.113883.2.1.3.2.4.15"
+                                  displayName="O/E - blood pressure reading">
+                                <originalText>O/E - blood pressure reading</originalText>
+                            </code>
+                            <component typeCode="COMP" contextConductionInd="true">
+                                <ObservationStatement classCode="OBS" moodCode="EVN">
+                                    <id root="38324DDE-7ABE-4039-BF78-8E9D334FCA8F"/>
+                                    <code code="72313002" codeSystem="2.16.840.1.113883.2.1.3.2.4.15"
+                                          displayName="Systolic arterial pressure">
+                                        <originalText>Systolic arterial pressure</originalText>
+                                    </code>
+                                </ObservationStatement>
+                            </component>
+                            <component typeCode="COMP" contextConductionInd="true">
+                                <ObservationStatement classCode="OBS" moodCode="EVN">
+                                    <id root="041E16C5-CB96-4A2C-A8D8-BF6CD904671E"/>
+                                    <confidentialityCode
+                                            code="NOPAT"
+                                            codeSystem="2.16.840.1.113883.4.642.3.47"
+                                            displayName="no disclosure to patient, family or caregivers without attending provider's authorization"
+                                    />
+                                    <code code="1091811000000102" codeSystem="2.16.840.1.113883.2.1.3.2.4.15"
+                                          displayName="Diastolic arterial pressure">
+                                        <originalText>Diastolic arterial pressure</originalText>
+                                    </code>
+                                </ObservationStatement>
+                            </component>
+                        </CompoundStatement>
+                    </component>
+                </ehrComposition>
+            </component>
+        </ehrFolder>
+    </component>
+</EhrExtract>

--- a/gp2gp-translator/src/test/resources/xml/BloodPressure/ehr_composition_containing_confidentiality_code.xml
+++ b/gp2gp-translator/src/test/resources/xml/BloodPressure/ehr_composition_containing_confidentiality_code.xml
@@ -1,0 +1,43 @@
+<EhrExtract xmlns="urn:hl7-org:v3" classCode="EXTRACT" moodCode="EVN">
+    <component typeCode="COMP">
+        <ehrFolder classCode="FOLDER" moodCode="EVN">
+            <component typeCode="COMP">
+                <ehrComposition classCode="COMPOSITION" moodCode="EVN">
+                    <id root="TEST_ID_MATCHING_ENCOUNTER"/>
+                    <confidentialityCode
+                            code="NOPAT"
+                            codeSystem="2.16.840.1.113883.4.642.3.47"
+                            displayName="no disclosure to patient, family or caregivers without attending provider's authorization"
+                    />
+                    <component typeCode="COMP">
+                        <CompoundStatement classCode="BATTERY" moodCode="EVN">
+                            <id root="FE739904-2AAB-4B3F-9718-84BE019FD483"/>
+                            <code code="163020007" codeSystem="2.16.840.1.113883.2.1.3.2.4.15"
+                                  displayName="O/E - blood pressure reading">
+                                <originalText>O/E - blood pressure reading</originalText>
+                            </code>
+                            <component typeCode="COMP" contextConductionInd="true">
+                                <ObservationStatement classCode="OBS" moodCode="EVN">
+                                    <id root="38324DDE-7ABE-4039-BF78-8E9D334FCA8F"/>
+                                    <code code="72313002" codeSystem="2.16.840.1.113883.2.1.3.2.4.15"
+                                          displayName="Systolic arterial pressure">
+                                        <originalText>Systolic arterial pressure</originalText>
+                                    </code>
+                                </ObservationStatement>
+                            </component>
+                            <component typeCode="COMP" contextConductionInd="true">
+                                <ObservationStatement classCode="OBS" moodCode="EVN">
+                                    <id root="041E16C5-CB96-4A2C-A8D8-BF6CD904671E"/>
+                                    <code code="1091811000000102" codeSystem="2.16.840.1.113883.2.1.3.2.4.15"
+                                          displayName="Diastolic arterial pressure">
+                                        <originalText>Diastolic arterial pressure</originalText>
+                                    </code>
+                                </ObservationStatement>
+                            </component>
+                        </CompoundStatement>
+                    </component>
+                </ehrComposition>
+            </component>
+        </ehrFolder>
+    </component>
+</EhrExtract>

--- a/gp2gp-translator/src/test/resources/xml/BloodPressure/systolic_observation_containing_confidentiality_code.xml
+++ b/gp2gp-translator/src/test/resources/xml/BloodPressure/systolic_observation_containing_confidentiality_code.xml
@@ -1,0 +1,43 @@
+<EhrExtract xmlns="urn:hl7-org:v3" classCode="EXTRACT" moodCode="EVN">
+    <component typeCode="COMP">
+        <ehrFolder classCode="FOLDER" moodCode="EVN">
+            <component typeCode="COMP">
+                <ehrComposition classCode="COMPOSITION" moodCode="EVN">
+                    <id root="TEST_ID_MATCHING_ENCOUNTER"/>
+                    <component typeCode="COMP">
+                        <CompoundStatement classCode="BATTERY" moodCode="EVN">
+                            <id root="FE739904-2AAB-4B3F-9718-84BE019FD483"/>
+                            <code code="163020007" codeSystem="2.16.840.1.113883.2.1.3.2.4.15"
+                                  displayName="O/E - blood pressure reading">
+                                <originalText>O/E - blood pressure reading</originalText>
+                            </code>
+                            <component typeCode="COMP" contextConductionInd="true">
+                                <ObservationStatement classCode="OBS" moodCode="EVN">
+                                    <id root="38324DDE-7ABE-4039-BF78-8E9D334FCA8F"/>
+                                    <confidentialityCode
+                                            code="NOPAT"
+                                            codeSystem="2.16.840.1.113883.4.642.3.47"
+                                            displayName="no disclosure to patient, family or caregivers without attending provider's authorization"
+                                    />
+                                    <code code="72313002" codeSystem="2.16.840.1.113883.2.1.3.2.4.15"
+                                          displayName="Systolic arterial pressure">
+                                        <originalText>Systolic arterial pressure</originalText>
+                                    </code>
+                                </ObservationStatement>
+                            </component>
+                            <component typeCode="COMP" contextConductionInd="true">
+                                <ObservationStatement classCode="OBS" moodCode="EVN">
+                                    <id root="041E16C5-CB96-4A2C-A8D8-BF6CD904671E"/>
+                                    <code code="1091811000000102" codeSystem="2.16.840.1.113883.2.1.3.2.4.15"
+                                          displayName="Diastolic arterial pressure">
+                                        <originalText>Diastolic arterial pressure</originalText>
+                                    </code>
+                                </ObservationStatement>
+                            </component>
+                        </CompoundStatement>
+                    </component>
+                </ehrComposition>
+            </component>
+        </ehrFolder>
+    </component>
+</EhrExtract>


### PR DESCRIPTION
## What

Add `ConfidentialityService` to `BloodPressureMapper`. 
Add functionality to populate the security meta when the provided `ehrComposition` contains a "NOPAT" `confidentialityCode`. 
Add functionality to populate the security meta when the provided `compoundStatement` contains a "NOPAT" `confidentialityCode`. 
Add functionality to populate the security meta when the diastolic or systolic `ObservationStatement` contains a "NOPAT" `confidentialityCode`. 
Add Unit Tests for the above functionality.
Add Unit Test xml files for the above tests.

## Why

When provided with the following `confidentialityCode` element in either the `ehrComposition`, `compoundStatement` or within any if the diastolic or systolic `ObservationStatements`

```xml
<confidentialityCode
    code="NOPAT"
    codeSystem="2.16.840.1.113883.4.642.3.47"
   displayName="no disclosure to patient, family or caregivers without attending provider's authorization" 
/>
```
The produced `Observation (Blood Pressure)` will contain the following JSON Element:

```json
{
  "meta": {
    "security": [{
      "system":"http://hl7.org/fhir/v3/ActCode",
      "code":"NOPAT",
      "display":"no disclosure to patient, family or caregivers without attending provider's authorization"
    }]
  }
}
```

This is needed to satisfy the requirements for Redaction Changes.

## Type of change

- [x] New feature (non-breaking change which adds functionality)

## Checklist:

- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have updated the [Changelog](/CHANGELOG.md) with details of my change in the UNRELEASED section if this change will affect end users
- [x] A corresponding change has been made to the [Mapping Documentation repository][mapping-docs]

[mapping-docs]: https://github.com/NHSDigital/patient-switching-adaptors-mapping-documentation