### PR TITLE
NIAD-3146: Incorrect filing date and performer on Filing Comments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,10 +26,13 @@ corresponding FHIR resource will now be [appropriately populated][nopat-docs].
 The adaptor now verifies the Snomed CT ID against both the Concept ID and the Description ID, ensuring 
 that immunizations are correctly identified when a match is found.
 
-
 ### Fixed
 * Resolved issue where the SNOMED import script would reject a password containing a '%' character.
 * Fixed some Test Results being given a duplicated `Observation.category` entries for `Laboratory`.
+* Filing Comments were creating with incorrect `effectiveDateTime`, this is now set from the 
+`ehrComposition /author / time` instead.
+* Filing Comments were creating with an incorrect `performer`, this now references the 
+`ehrComposition / author / agentRef` instead.
 
 ## [3.0.2] - 2024-07-18
 

--- a/gp2gp-translator/src/integrationTest/resources/e2e-mapping/output-json/PWTP9-output.json
+++ b/gp2gp-translator/src/integrationTest/resources/e2e-mapping/output-json/PWTP9-output.json
@@ -15090,10 +15090,10 @@
       "context": {
         "reference": "Encounter/DD64A383-7DC5-4E15-A0FF-20F2C4D195A5"
       },
-      "effectiveDateTime": "2010-01-20T16:27:23+00:00",
+      "effectiveDateTime": "2010-03-26T14:04:43+00:00",
       "issued": "2010-01-20T16:27:23.000+00:00",
       "performer": [ {
-        "reference": "Practitioner/C5DEFBF3-0174-BC6F-182C-B777B9C6FF43"
+        "reference": "Practitioner/1E473786-E7FA-785E-C911-A8D38FB56F20"
       } ]
     }
   }, {
@@ -15121,7 +15121,7 @@
       "context": {
         "reference": "Encounter/9096889B-4D56-4668-86F7-1E1C63011A46"
       },
-      "effectiveDateTime": "2010-01-20T10:46:22+00:00",
+      "effectiveDateTime": "2010-03-26T13:45:44+00:00",
       "issued": "2010-01-20T10:46:22.000+00:00",
       "performer": [ {
         "reference": "Practitioner/1E473786-E7FA-785E-C911-A8D38FB56F20"
@@ -15152,7 +15152,7 @@
       "context": {
         "reference": "Encounter/730C507B-32CE-4270-80BA-42F4B62BA064"
       },
-      "effectiveDateTime": "2010-01-20T10:46:22+00:00",
+      "effectiveDateTime": "2010-02-09T12:21:06+00:00",
       "issued": "2010-01-20T10:46:22.000+00:00",
       "performer": [ {
         "reference": "Practitioner/1E473786-E7FA-785E-C911-A8D38FB56F20"
@@ -15183,7 +15183,7 @@
       "context": {
         "reference": "Encounter/B0696913-F11D-4EAA-8BB7-41350B296F3F"
       },
-      "effectiveDateTime": "2010-01-20T16:27:23+00:00",
+      "effectiveDateTime": "2010-02-01T09:33:13+00:00",
       "issued": "2010-01-20T16:27:23.000+00:00",
       "performer": [ {
         "reference": "Practitioner/1E473786-E7FA-785E-C911-A8D38FB56F20"

--- a/gp2gp-translator/src/main/java/uk/nhs/adaptors/pss/translator/mapper/diagnosticreport/DiagnosticReportMapper.java
+++ b/gp2gp-translator/src/main/java/uk/nhs/adaptors/pss/translator/mapper/diagnosticreport/DiagnosticReportMapper.java
@@ -4,11 +4,13 @@ import static java.util.stream.Collectors.toCollection;
 
 import static org.hl7.fhir.dstu3.model.Observation.ObservationStatus.UNKNOWN;
 import static uk.nhs.adaptors.pss.translator.util.CompoundStatementResourceExtractors.extractAllCompoundStatements;
+import static uk.nhs.adaptors.pss.translator.util.DateFormatUtil.parseToDateTimeType;
 import static uk.nhs.adaptors.pss.translator.util.DateFormatUtil.parseToInstantType;
 import static uk.nhs.adaptors.pss.translator.util.ResourceUtil.buildIdentifier;
 import static uk.nhs.adaptors.pss.translator.util.TextUtil.extractPmipComment;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
@@ -95,7 +97,7 @@ public class DiagnosticReportMapper extends AbstractMapper<DiagnosticReport> {
 
         List<Observation> conclusionComments = new ArrayList<>();
 
-        ehrExtract.getComponent().get(0).getEhrFolder().getComponent()
+        ehrExtract.getComponent().getFirst().getEhrFolder().getComponent()
                 .stream()
                 .flatMap(e -> e.getEhrComposition().getComponent().stream())
                 .flatMap(CompoundStatementResourceExtractors::extractAllCompoundStatements)
@@ -107,7 +109,6 @@ public class DiagnosticReportMapper extends AbstractMapper<DiagnosticReport> {
                 .map(narrativeStatement -> getObservationCommentById(observationComments, narrativeStatement.getId().getRoot()))
                 .flatMap(Optional::stream)
                 .forEach(observationComment -> {
-
                     if (observationComment.getComment().contains(LAB_REPORT_COMMENT_TYPE)) {
                         conclusionComments.add(observationComment);
                     }
@@ -119,17 +120,19 @@ public class DiagnosticReportMapper extends AbstractMapper<DiagnosticReport> {
         observationComments.removeAll(conclusionComments);
     }
 
-    private DiagnosticReport createDiagnosticReport(RCMRMT030101UKCompoundStatement compoundStatement, Patient patient,
-                                                    RCMRMT030101UKEhrComposition composition, List<Encounter> encounters,
+    private DiagnosticReport createDiagnosticReport(RCMRMT030101UKCompoundStatement compoundStatement,
+                                                    Patient patient,
+                                                    RCMRMT030101UKEhrComposition ehrComposition,
+                                                    List<Encounter> encounters,
                                                     List<Observation> observationComments,
-                                                    String practiceCode) {
-
+                                                    String practiceCode
+    ) {
         final DiagnosticReport diagnosticReport = new DiagnosticReport();
-        final String id = compoundStatement.getId().get(0).getRoot();
+        final String id = compoundStatement.getId().getFirst().getRoot();
 
         var meta = confidentialityService.createMetaAndAddSecurityIfConfidentialityCodesPresent(
             META_PROFILE,
-            composition.getConfidentialityCode(),
+            ehrComposition.getConfidentialityCode(),
             compoundStatement.getConfidentialityCode());
 
         diagnosticReport.setMeta(meta);
@@ -140,8 +143,8 @@ public class DiagnosticReportMapper extends AbstractMapper<DiagnosticReport> {
         diagnosticReport.setSubject(new Reference(patient));
         diagnosticReport.setSpecimen(getSpecimenReferences(compoundStatement));
         createIdentifierExtension(compoundStatement.getId()).ifPresent(diagnosticReport::addIdentifier);
-        buildContext(composition, encounters).ifPresent(diagnosticReport::setContext);
-        setResultReferences(compoundStatement, diagnosticReport, observationComments);
+        buildContext(ehrComposition, encounters).ifPresent(diagnosticReport::setContext);
+        setResultReferences(ehrComposition, compoundStatement, diagnosticReport, observationComments);
 
         var conclusion = getConclusion(compoundStatement);
 
@@ -172,14 +175,16 @@ public class DiagnosticReportMapper extends AbstractMapper<DiagnosticReport> {
                 .map(RCMRMT030101UKComponent02::getCompoundStatement)
                 .filter(ResourceFilterUtil::isSpecimen)
                 .map(compoundStatement1 -> new Reference(
-                        new IdType(ResourceType.Specimen.name(), compoundStatement1.getId().get(0).getRoot())))
+                        new IdType(ResourceType.Specimen.name(), compoundStatement1.getId().getFirst().getRoot())))
                 .toList();
     }
 
-    private void setResultReferences(RCMRMT030101UKCompoundStatement compoundStatement,
-                                     DiagnosticReport diagnosticReport,
-                                     List<Observation> observationComments) {
-
+    private void setResultReferences(
+        RCMRMT030101UKEhrComposition ehrComposition,
+        RCMRMT030101UKCompoundStatement compoundStatement,
+        DiagnosticReport diagnosticReport,
+        List<Observation> observationComments
+    ) {
         var resultReferences = getDirectResultReferences(compoundStatement);
         diagnosticReport.setResult(resultReferences);
 
@@ -193,23 +198,33 @@ public class DiagnosticReportMapper extends AbstractMapper<DiagnosticReport> {
                 getObservationCommentById(observationComments, batteryLevelFilingCommentId.get());
 
         if (existingObservationComment.isPresent()) {
-            var filingCommentObservation = buildFilingComment(existingObservationComment.get());
+            var filingCommentObservation = buildFilingComment(ehrComposition, existingObservationComment.get());
 
             diagnosticReport.getResult().add(buildFilingCommentReference(filingCommentObservation));
             observationComments.add(filingCommentObservation);
         }
     }
 
-    private Observation buildFilingComment(Observation existingObservationComment) {
+    private Observation buildFilingComment(
+        RCMRMT030101UKEhrComposition ehrComposition,
+        Observation existingObservationComment) {
         var filingCommentObservation = existingObservationComment.copy();
         var filingCommentObservationId = idGeneratorService.generateUuid().toUpperCase();
         filingCommentObservation.setId(filingCommentObservationId);
         filingCommentObservation.getIdentifierFirstRep().setValue(filingCommentObservationId);
         filingCommentObservation.setComment(null);
         filingCommentObservation.setStatus(UNKNOWN);
-
+        filingCommentObservation.setEffective(
+            parseToDateTimeType(ehrComposition.getAuthor().getTime().getValue())
+        );
+        filingCommentObservation.setPerformer(
+            Collections.singletonList(
+                new Reference("Practitioner/" + ehrComposition.getAuthor().getAgentRef().getId().getRoot())
+            )
+        );
         return filingCommentObservation;
     }
+
     @NotNull
     private Optional<String> getBatteryLevelFilingCommentId(RCMRMT030101UKCompoundStatement compoundStatement) {
         return compoundStatement.getComponent()
@@ -219,7 +234,7 @@ public class DiagnosticReportMapper extends AbstractMapper<DiagnosticReport> {
                 .filter(RCMRMT030101UKComponent02::hasNarrativeStatement)
                 .map(RCMRMT030101UKComponent02::getNarrativeStatement)
                 .filter(this::isUserCommentType)
-                .map(ns -> ns.getId().getRoot())
+                .map(narrativeStatement -> narrativeStatement.getId().getRoot())
                 .findFirst();
     }
 
@@ -248,7 +263,7 @@ public class DiagnosticReportMapper extends AbstractMapper<DiagnosticReport> {
             RCMRMT030101UKComponent02 component,
             String classCode) {
         return Optional.ofNullable(component.getCompoundStatement())
-                .filter(compoundStatement -> classCode.equals(compoundStatement.getClassCode().get(0)))
+                .filter(compoundStatement -> classCode.equals(compoundStatement.getClassCode().getFirst()))
                 .map(compoundStatement -> compoundStatement.getComponent().stream())
                 .orElse(Stream.empty());
     }

--- a/gp2gp-translator/src/test/java/uk/nhs/adaptors/pss/translator/mapper/diagnosticreport/DiagnosticReportMapperTest.java
+++ b/gp2gp-translator/src/test/java/uk/nhs/adaptors/pss/translator/mapper/diagnosticreport/DiagnosticReportMapperTest.java
@@ -610,8 +610,6 @@ TEST COMMENT
         );
     }
 
-
-
     private List<Observation> createObservationCommentList() {
         return new ArrayList<>(Arrays.asList(
                 (Observation) new Observation()
@@ -630,7 +628,7 @@ TEST COMMENT
         identifier.setSystem("https://PSSAdaptor/" + PRACTICE_CODE);
         identifier.setValue("C515E722-2473-11EE-808B-AC162D1F16F0");
         return (Observation) new Observation()
-                        .setEffective(new DateTimeType())
+                        .setIssuedElement(DateFormatUtil.parseToInstantType("20240102"))
                         .setComment("This is a comment from the doctor")
                         .setEffective(DateFormatUtil.parseToDateTimeType("20240101"))
                         .setId("C515E722-2473-11EE-808B-AC162D1F16F0");


### PR DESCRIPTION
## What

Updated DiagnosticReportMapper to set the effective time and performer values based on those found in `ehrComposition / author`.
Added unit test for this functionality.
Updated test XML file for unit test to reflect change.

## Why

### Acceptance Criteria

* When mapping `filing comments` the resultant `Observation.effectiveDateTime` should be the value found in the source xml `ehrComposition / author / time @[value]`
* When mapping `filing comments` the resultant `Observation.issued` should be the `availabilityTime` value found in the associated `User Comment NarrativeStatement` from which the `filing comment` is built.
* When mapping `filing comments` the resultant `Observation.performer.reference` should contain a practitioner reference to the value found in `ehrComposition / author / agentRef / id @[root]`

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [x] I have performed a self-review of my code
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have updated the [Changelog](/CHANGELOG.md) with details of my change in the UNRELEASED section if this change will affect end users
- [x] A corresponding change has been made to the [Mapping Documentation repository][mapping-docs]

[mapping-docs]: https://github.com/NHSDigital/patient-switching-adaptors-mapping-documentation