### PR TITLE
Post NIAD-3114 refactoring: Better list first element reference

### DIFF
--- a/gp2gp-translator/src/integrationTest/java/uk/nhs/adaptors/pss/translator/FailedProcessHandingIT.java
+++ b/gp2gp-translator/src/integrationTest/java/uk/nhs/adaptors/pss/translator/FailedProcessHandingIT.java
@@ -198,7 +198,7 @@ public class FailedProcessHandingIT extends BaseEhrHandler {
 
         requests.sort(Comparator.comparing(Request::getLoggedDate).reversed());
 
-        var mostRecentRequest = requests.get(0);
+        var mostRecentRequest = requests.getFirst();
 
         return mostRecentRequest.getHeaders().getInteractionId().equals(ACK_INTERACTION_ID)
             && mostRecentRequest.getBody()

--- a/gp2gp-translator/src/integrationTest/java/uk/nhs/adaptors/pss/translator/mapper/ConditionMapperIT.java
+++ b/gp2gp-translator/src/integrationTest/java/uk/nhs/adaptors/pss/translator/mapper/ConditionMapperIT.java
@@ -68,7 +68,7 @@ public class ConditionMapperIT {
 
         conditionMapper.addReferences(buildBundleWithNamedStatementObservation(), conditions, ehrExtract);
 
-        var code = conditions.get(0).getCode().getCodingFirstRep();
+        var code = conditions.getFirst().getCode().getCodingFirstRep();
 
         assertEquals(OBSERVATION_CONCEPT_DESCRIPTION, code.getDisplay());
         assertEquals(OBSERVATION_CONCEPT_ID, code.getCode());
@@ -92,7 +92,7 @@ public class ConditionMapperIT {
 
         conditionMapper.addReferences(buildBundleWithNamedStatementAllergy(), conditions, ehrExtract);
 
-        var code = conditions.get(0).getCode().getCoding().get(1);
+        var code = conditions.getFirst().getCode().getCoding().get(1);
 
         assertEquals(ALLERGY_CONCEPT_DESCRIPTION, code.getDisplay());
         assertEquals(ALLERGY_CONCEPT_ID, code.getCode());

--- a/gp2gp-translator/src/integrationTest/java/uk/nhs/adaptors/pss/translator/service/BundleMapperServiceIT.java
+++ b/gp2gp-translator/src/integrationTest/java/uk/nhs/adaptors/pss/translator/service/BundleMapperServiceIT.java
@@ -53,9 +53,9 @@ public class BundleMapperServiceIT {
         assertThat(practitioners.size()).isOne();
         assertThat(practitionerRoles.size()).isOne();
 
-        var organisationId = organisations.get(0).getId();
-        var practitionerId = practitioners.get(0).getId();
-        var practitionerRole = practitionerRoles.get(0);
+        var organisationId = organisations.getFirst().getId();
+        var practitionerId = practitioners.getFirst().getId();
+        var practitionerRole = practitionerRoles.getFirst();
 
         assertThat(practitionerRole.getPractitioner().getReferenceElement().getIdPart()).isEqualTo(practitionerId);
         assertThat(practitionerRole.getOrganization().getReferenceElement().getIdPart()).isEqualTo(organisationId);
@@ -74,9 +74,9 @@ public class BundleMapperServiceIT {
         assertThat(practitioners.size()).isEqualTo(2);
         assertThat(practitionerRoles.size()).isEqualTo(2);
 
-        var organisationId = organisations.get(0).getId();
+        var organisationId = organisations.getFirst().getId();
 
-        assertThat(practitionerRoles.get(0).getOrganization().getReferenceElement().getIdPart())
+        assertThat(practitionerRoles.getFirst().getOrganization().getReferenceElement().getIdPart())
             .isEqualTo(organisationId);
 
         assertThat(practitionerRoles.get(1).getOrganization().getReferenceElement().getIdPart())
@@ -98,10 +98,10 @@ public class BundleMapperServiceIT {
         assertThat(practitionerRoles.size()).isZero();
         assertThat(documentReferences.size()).isOne();
 
-        var organisationId = organisations.get(0)
+        var organisationId = organisations.getFirst()
             .getId();
 
-        var custodianId = documentReferences.get(0)
+        var custodianId = documentReferences.getFirst()
             .getCustodian()
             .getResource()
             .getIdElement()
@@ -142,10 +142,10 @@ public class BundleMapperServiceIT {
         assertThat(practitionerRoles.size()).isOne();
         assertThat(documentReferences.size()).isOne();
 
-        var organisationId = organisations.get(0)
+        var organisationId = organisations.getFirst()
             .getId();
 
-        var custodianId = documentReferences.get(0)
+        var custodianId = documentReferences.getFirst()
             .getCustodian()
             .getResource()
             .getIdElement()
@@ -153,10 +153,10 @@ public class BundleMapperServiceIT {
 
         assertThat(custodianId).isEqualTo(organisationId);
 
-        assertThat(practitionerRoles.get(0).getOrganization().getReferenceElement().getIdPart())
+        assertThat(practitionerRoles.getFirst().getOrganization().getReferenceElement().getIdPart())
             .isEqualTo(organisationId);
-        assertThat(practitionerRoles.get(0).getPractitioner().getReferenceElement().getIdPart())
-            .isEqualTo(practitioners.get(0).getId());
+        assertThat(practitionerRoles.getFirst().getPractitioner().getReferenceElement().getIdPart())
+            .isEqualTo(practitioners.getFirst().getId());
     }
 
     @SneakyThrows

--- a/gp2gp-translator/src/main/java/uk/nhs/adaptors/pss/translator/mapper/AgentDirectoryMapper.java
+++ b/gp2gp-translator/src/main/java/uk/nhs/adaptors/pss/translator/mapper/AgentDirectoryMapper.java
@@ -73,7 +73,7 @@ public class AgentDirectoryMapper {
         var agentPerson = agent.getAgentPerson();
         var agentOrganization = agent.getAgentOrganization();
         var representedOrganization = agent.getRepresentedOrganization();
-        var resourceId = agent.getId().get(0).getRoot();
+        var resourceId = agent.getId().getFirst().getRoot();
         var gpNumber = agent.getId().size() > 1 ? agent.getId().get(1).getExtension() : "";
 
         if (agentPerson != null && representedOrganization != null) {
@@ -198,7 +198,7 @@ public class AgentDirectoryMapper {
 
     private ContactPoint getOrganizationTelecom(List<TEL> telecomList) {
         if (!telecomList.isEmpty()) {
-            return TelecomUtil.mapTelecom(telecomList.get(0));
+            return TelecomUtil.mapTelecom(telecomList.getFirst());
         }
 
         return null;
@@ -206,7 +206,7 @@ public class AgentDirectoryMapper {
 
     private Address getOrganizationAddress(List<AD> addressList) {
         if (!addressList.isEmpty()) {
-            return AddressUtil.mapAddress(addressList.get(0));
+            return AddressUtil.mapAddress(addressList.getFirst());
         }
 
         return null;

--- a/gp2gp-translator/src/main/java/uk/nhs/adaptors/pss/translator/mapper/BloodPressureMapper.java
+++ b/gp2gp-translator/src/main/java/uk/nhs/adaptors/pss/translator/mapper/BloodPressureMapper.java
@@ -78,7 +78,7 @@ public class BloodPressureMapper extends AbstractMapper<Observation> {
                                        RCMRMT030101UKCompoundStatement compoundStatement, Patient patient, List<Encounter> encounters,
                                        String practiseCode) {
         var observationStatements = getObservationStatementsFromCompoundStatement(compoundStatement);
-        var id = compoundStatement.getId().get(0);
+        var id = compoundStatement.getId().getFirst();
 
         Observation observation = new Observation()
             .addIdentifier(buildIdentifier(id.getRoot(), practiseCode))

--- a/gp2gp-translator/src/main/java/uk/nhs/adaptors/pss/translator/mapper/ConditionMapper.java
+++ b/gp2gp-translator/src/main/java/uk/nhs/adaptors/pss/translator/mapper/ConditionMapper.java
@@ -291,7 +291,7 @@ public class ConditionMapper extends AbstractMapper<Condition> {
     }
 
     private boolean hasMajorCode(CD linkSetCode) {
-        return hasCode(linkSetCode) && MAJOR_CODE.equals(linkSetCode.getQualifier().get(0).getName().getCode());
+        return hasCode(linkSetCode) && MAJOR_CODE.equals(linkSetCode.getQualifier().getFirst().getName().getCode());
     }
 
     private Extension buildConditionReferenceExtension(String id, String heirarchyType) {
@@ -398,7 +398,7 @@ public class ConditionMapper extends AbstractMapper<Condition> {
 
         medicationStatements.forEach(medicationStatement -> {
             var medicationStatementId = medicationStatement.getId().getRoot();
-            var moodCode = medicationStatement.getMoodCode().get(0);
+            var moodCode = medicationStatement.getMoodCode().getFirst();
 
             switch (moodCode) {
                 case MEDICATION_MOOD_ORDER -> {

--- a/gp2gp-translator/src/main/java/uk/nhs/adaptors/pss/translator/mapper/ConsultationListMapper.java
+++ b/gp2gp-translator/src/main/java/uk/nhs/adaptors/pss/translator/mapper/ConsultationListMapper.java
@@ -65,7 +65,7 @@ public class ConsultationListMapper {
 
     private String getConsultationTitle(List<CodeableConcept> codeableConceptList) {
         if (!CollectionUtils.isEmpty(codeableConceptList)) {
-            var codeableConcept = codeableConceptList.get(0);
+            var codeableConcept = codeableConceptList.getFirst();
             if (codeableConcept.hasText()) {
                 return codeableConcept.getText();
             } else if (codeableConcept.getCodingFirstRep().hasDisplay()) {
@@ -110,7 +110,7 @@ public class ConsultationListMapper {
     }
 
     private String getTopicId(RCMRMT030101UKCompoundStatement compoundStatement) {
-        return compoundStatement != null ? compoundStatement.getId().get(0).getRoot() : idGenerator.generateUuid();
+        return compoundStatement != null ? compoundStatement.getId().getFirst().getRoot() : idGenerator.generateUuid();
     }
 
     public ListResource mapToCategory(ListResource topic, RCMRMT030101UKCompoundStatement compoundStatement) {
@@ -127,7 +127,7 @@ public class ConsultationListMapper {
             .setOrderedBy(CodeableConceptUtils.createCodeableConcept(LIST_ORDERED_BY_CODE, LIST_ORDERED_BY_SYSTEM,
                 LIST_ORDERED_BY_DISPLAY, null))
             .setMeta(generateMeta(LIST_META_PROFILE))
-            .setId(compoundStatement.getId().get(0).getRoot());
+            .setId(compoundStatement.getId().getFirst().getRoot());
 
         return category;
     }

--- a/gp2gp-translator/src/main/java/uk/nhs/adaptors/pss/translator/mapper/DocumentReferenceMapper.java
+++ b/gp2gp-translator/src/main/java/uk/nhs/adaptors/pss/translator/mapper/DocumentReferenceMapper.java
@@ -83,7 +83,7 @@ public class DocumentReferenceMapper extends AbstractMapper<DocumentReference> {
 
         // document references actually use the narrative statement id rather than the referenceDocument root id in EMIS data
         // if EMIS is incorrect, replace the id below with the following...
-        // narrativeStatement.getReference().get(0).getReferredToExternalDocument().getId().getRoot()
+        // narrativeStatement.getReference().getFirst().getReferredToExternalDocument().getId().getRoot()
         var id = narrativeStatement.getId().getRoot();
 
         documentReference.addIdentifier(buildIdentifier(id, organization.getIdentifierFirstRep().getValue()));

--- a/gp2gp-translator/src/main/java/uk/nhs/adaptors/pss/translator/mapper/DuplicateObservationStatementMapper.java
+++ b/gp2gp-translator/src/main/java/uk/nhs/adaptors/pss/translator/mapper/DuplicateObservationStatementMapper.java
@@ -109,12 +109,12 @@ public class DuplicateObservationStatementMapper {
     }
 
     private static RCMRMT030101UKAnnotation getPertinentAnnotation(RCMRMT030101UKObservationStatement linkedObservationStatement) {
-        return linkedObservationStatement.getPertinentInformation().get(0).getPertinentAnnotation();
+        return linkedObservationStatement.getPertinentInformation().getFirst().getPertinentAnnotation();
     }
 
     private static boolean hasSinglePertinentInformation(RCMRMT030101UKObservationStatement observation) {
         return observation.getPertinentInformation().size() == 1
-                && observation.getPertinentInformation().get(0).getSequenceNumber().getValue().intValueExact() == 1;
+                && observation.getPertinentInformation().getFirst().getSequenceNumber().getValue().intValueExact() == 1;
     }
 
     private static boolean doesTruncatedAnnotationMatchOtherAnnotation(

--- a/gp2gp-translator/src/main/java/uk/nhs/adaptors/pss/translator/mapper/EncounterMapper.java
+++ b/gp2gp-translator/src/main/java/uk/nhs/adaptors/pss/translator/mapper/EncounterMapper.java
@@ -242,7 +242,7 @@ public class EncounterMapper {
     }
 
     private boolean hasValidCategoryCompoundStatement(RCMRMT030101UKCompoundStatement compoundStatement) {
-        return compoundStatement != null && CATEGORY_CLASS_CODE.equals(compoundStatement.getClassCode().get(0));
+        return compoundStatement != null && CATEGORY_CLASS_CODE.equals(compoundStatement.getClassCode().getFirst());
     }
 
     private List<RCMRMT030101UKEhrComposition> getEncounterEhrCompositions(RCMRMT030101UKEhrExtract ehrExtract) {
@@ -278,7 +278,7 @@ public class EncounterMapper {
     }
 
     private boolean hasValidTopicCompoundStatement(RCMRMT030101UKCompoundStatement compoundStatement) {
-        return compoundStatement != null && TOPIC_CLASS_CODE.equals(compoundStatement.getClassCode().get(0));
+        return compoundStatement != null && TOPIC_CLASS_CODE.equals(compoundStatement.getClassCode().getFirst());
     }
 
     private Encounter mapToEncounter(

--- a/gp2gp-translator/src/main/java/uk/nhs/adaptors/pss/translator/mapper/ImmunizationMapper.java
+++ b/gp2gp-translator/src/main/java/uk/nhs/adaptors/pss/translator/mapper/ImmunizationMapper.java
@@ -106,9 +106,9 @@ public class ImmunizationMapper extends AbstractMapper<Immunization> {
         );
 
         immunization.setMeta(meta);
-        immunization.addIdentifier(buildIdentifier(id, practiseCode));
-        immunization.addExtension(createVaccineProcedureExtension(observationStatement));
-        immunization.addExtension(createRecordedTimeExtension(ehrComposition));
+        immunization.addIdentifier(buildIdentifier(id, practiseCode))
+                    .addExtension(createVaccineProcedureExtension(observationStatement))
+                    .addExtension(createRecordedTimeExtension(ehrComposition));
         immunization
             .setEncounter(encounter)
             .addPractitioner(recorder)

--- a/gp2gp-translator/src/main/java/uk/nhs/adaptors/pss/translator/mapper/ObservationMapper.java
+++ b/gp2gp-translator/src/main/java/uk/nhs/adaptors/pss/translator/mapper/ObservationMapper.java
@@ -164,7 +164,7 @@ public class ObservationMapper extends AbstractMapper<Observation> {
                                                            RCMRMT030101UKRequestStatement requestStatement, Patient patient,
                                                            List<Encounter> encounters, String practiseCode) {
 
-        var id = requestStatement.getId().get(0).getRoot();
+        var id = requestStatement.getId().getFirst().getRoot();
         var meta = confidentialityService.createMetaAndAddSecurityIfConfidentialityCodesPresent(
             META_PROFILE,
             ehrComposition.getConfidentialityCode(),

--- a/gp2gp-translator/src/main/java/uk/nhs/adaptors/pss/translator/mapper/QuantityMapper.java
+++ b/gp2gp-translator/src/main/java/uk/nhs/adaptors/pss/translator/mapper/QuantityMapper.java
@@ -56,12 +56,12 @@ public class QuantityMapper {
             if (translation != null && !translation.isEmpty()) {
                 //If the translation is found in the MeasurementUnitsMap then add unit using this.
                 // Also add code as translation text.
-                if (foundMeasurementMatch(translation.get(0).getOriginalText())) {
-                    quantity.setUnit(MeasurementUnitsUtil.getMeasurementUnitsMap().get(translation.get(0).getOriginalText()));
-                    quantity.setCode(translation.get(0).getOriginalText());
+                if (foundMeasurementMatch(translation.getFirst().getOriginalText())) {
+                    quantity.setUnit(MeasurementUnitsUtil.getMeasurementUnitsMap().get(translation.getFirst().getOriginalText()));
+                    quantity.setCode(translation.getFirst().getOriginalText());
                 } else {
                 //If not found then just set the unit as the translation text.
-                    quantity.setUnit(translation.get(0).getOriginalText());
+                    quantity.setUnit(translation.getFirst().getOriginalText());
                 }
             } else {
                 //Set the unit to its corresponding unit in the map if found.

--- a/gp2gp-translator/src/main/java/uk/nhs/adaptors/pss/translator/mapper/ReferralRequestMapper.java
+++ b/gp2gp-translator/src/main/java/uk/nhs/adaptors/pss/translator/mapper/ReferralRequestMapper.java
@@ -82,7 +82,7 @@ public class ReferralRequestMapper extends AbstractMapper<ReferralRequest> {
                                                 String practiseCode) {
 
         var referralRequest = new ReferralRequest();
-        var id = requestStatement.getId().get(0).getRoot();
+        var id = requestStatement.getId().getFirst().getRoot();
         var identifier = buildIdentifier(id, practiseCode);
         var agent = ParticipantReferenceUtil.getParticipantReference(requestStatement.getParticipant(), ehrComposition);
 
@@ -95,16 +95,16 @@ public class ReferralRequestMapper extends AbstractMapper<ReferralRequest> {
             ehrComposition.getConfidentialityCode()
         );
 
-        referralRequest.setId(id);
-        referralRequest.setMeta(meta);
+        referralRequest.setId(id)
+                       .setMeta(meta);
         referralRequest.getIdentifier().add(identifier);
-        referralRequest.setStatus(ReferralRequestStatus.UNKNOWN);
-        referralRequest.setIntent(ReferralCategory.ORDER);
-        referralRequest.getRequester().setAgent(agent);
-        referralRequest.setAuthoredOnElement(authoredOn);
-        referralRequest.setNote(getNotes(requestStatement));
-        referralRequest.setSubject(new Reference(patient));
-        referralRequest.setPriority(referralPriority);
+        referralRequest.setStatus(ReferralRequestStatus.UNKNOWN)
+                        .setIntent(ReferralCategory.ORDER)
+                        .setAuthoredOnElement(authoredOn)
+                        .setNote(getNotes(requestStatement))
+                        .setSubject(new Reference(patient))
+                        .setPriority(referralPriority)
+                        .getRequester().setAgent(agent);
 
         setReferralRequestContext(referralRequest, ehrComposition, encounters);
         setReferralRequestRecipient(ehrExtract, requestStatement, referralRequest);
@@ -130,7 +130,7 @@ public class ReferralRequestMapper extends AbstractMapper<ReferralRequest> {
     }
 
     private boolean isMatchingAgent(RCMRMT030101UKPart part, String requestAgentRoot) {
-        return part.getAgent().getId().get(0).getRoot().equals(requestAgentRoot)
+        return part.getAgent().getId().getFirst().getRoot().equals(requestAgentRoot)
                && part.getAgent().getAgentPerson() == null;
     }
 

--- a/gp2gp-translator/src/main/java/uk/nhs/adaptors/pss/translator/mapper/TemplateMapper.java
+++ b/gp2gp-translator/src/main/java/uk/nhs/adaptors/pss/translator/mapper/TemplateMapper.java
@@ -79,7 +79,7 @@ public class TemplateMapper extends AbstractMapper<DomainResource> {
 
             if (isObservationStatementTemplateParent(parentCompoundStatement)) {
                 Observation parentObservation = parentObservations.stream()
-                    .filter(observation -> observation.getId().equals(parentCompoundStatement.getId().get(0).getRoot()))
+                    .filter(observation -> observation.getId().equals(parentCompoundStatement.getId().getFirst().getRoot()))
                     .findFirst()
                     .orElseThrow();
 
@@ -135,7 +135,7 @@ public class TemplateMapper extends AbstractMapper<DomainResource> {
         Optional<Reference> encounter, RCMRMT030101UKEhrComposition ehrComposition) {
 
         var parentObservation = new Observation();
-        var id = compoundStatement.getId().get(0).getRoot();
+        var id = compoundStatement.getId().getFirst().getRoot();
 
         var codeableConcept = codeableConceptMapper.mapToCodeableConcept(compoundStatement.getCode());
         DegradedCodeableConcepts.addDegradedEntryIfRequired(codeableConcept, DegradedCodeableConcepts.DEGRADED_OTHER);
@@ -175,12 +175,12 @@ public class TemplateMapper extends AbstractMapper<DomainResource> {
 
     private List<RCMRMT030101UKCompoundStatement> getCompoundStatementsByIds(RCMRMT030101UKEhrExtract ehrExtract, List<String> ids) {
 
-        return ehrExtract.getComponent().get(0).getEhrFolder().getComponent()
+        return ehrExtract.getComponent().getFirst().getEhrFolder().getComponent()
             .stream()
             .flatMap(component3 -> component3.getEhrComposition().getComponent().stream())
             .flatMap(CompoundStatementResourceExtractors::extractAllCompoundStatements)
             .filter(Objects::nonNull)
-            .filter(compoundStatement -> ids.contains(compoundStatement.getId().get(0).getRoot()))
+            .filter(compoundStatement -> ids.contains(compoundStatement.getId().getFirst().getRoot()))
             .toList();
     }
 

--- a/gp2gp-translator/src/main/java/uk/nhs/adaptors/pss/translator/mapper/diagnosticreport/DiagnosticReportMapper.java
+++ b/gp2gp-translator/src/main/java/uk/nhs/adaptors/pss/translator/mapper/diagnosticreport/DiagnosticReportMapper.java
@@ -95,7 +95,7 @@ public class DiagnosticReportMapper extends AbstractMapper<DiagnosticReport> {
 
         List<Observation> conclusionComments = new ArrayList<>();
 
-        ehrExtract.getComponent().get(0).getEhrFolder().getComponent()
+        ehrExtract.getComponent().getFirst().getEhrFolder().getComponent()
                 .stream()
                 .flatMap(e -> e.getEhrComposition().getComponent().stream())
                 .flatMap(CompoundStatementResourceExtractors::extractAllCompoundStatements)
@@ -125,20 +125,20 @@ public class DiagnosticReportMapper extends AbstractMapper<DiagnosticReport> {
                                                     String practiceCode) {
 
         final DiagnosticReport diagnosticReport = new DiagnosticReport();
-        final String id = compoundStatement.getId().get(0).getRoot();
+        final String id = compoundStatement.getId().getFirst().getRoot();
 
         var meta = confidentialityService.createMetaAndAddSecurityIfConfidentialityCodesPresent(
             META_PROFILE,
             composition.getConfidentialityCode(),
             compoundStatement.getConfidentialityCode());
 
-        diagnosticReport.setMeta(meta);
-        diagnosticReport.setId(id);
-        diagnosticReport.addIdentifier(buildIdentifier(id, practiceCode));
-        diagnosticReport.setCode(createCode());
-        diagnosticReport.setStatus(DiagnosticReportStatus.UNKNOWN);
-        diagnosticReport.setSubject(new Reference(patient));
-        diagnosticReport.setSpecimen(getSpecimenReferences(compoundStatement));
+        diagnosticReport.setMeta(meta)
+                        .setId(id);
+        diagnosticReport.addIdentifier(buildIdentifier(id, practiceCode))
+                        .setCode(createCode())
+                        .setStatus(DiagnosticReportStatus.UNKNOWN)
+                        .setSubject(new Reference(patient))
+                        .setSpecimen(getSpecimenReferences(compoundStatement));
         createIdentifierExtension(compoundStatement.getId()).ifPresent(diagnosticReport::addIdentifier);
         buildContext(composition, encounters).ifPresent(diagnosticReport::setContext);
         setResultReferences(compoundStatement, diagnosticReport, observationComments);
@@ -172,7 +172,7 @@ public class DiagnosticReportMapper extends AbstractMapper<DiagnosticReport> {
                 .map(RCMRMT030101UKComponent02::getCompoundStatement)
                 .filter(ResourceFilterUtil::isSpecimen)
                 .map(compoundStatement1 -> new Reference(
-                        new IdType(ResourceType.Specimen.name(), compoundStatement1.getId().get(0).getRoot())))
+                        new IdType(ResourceType.Specimen.name(), compoundStatement1.getId().getFirst().getRoot())))
                 .toList();
     }
 
@@ -248,7 +248,7 @@ public class DiagnosticReportMapper extends AbstractMapper<DiagnosticReport> {
             RCMRMT030101UKComponent02 component,
             String classCode) {
         return Optional.ofNullable(component.getCompoundStatement())
-                .filter(compoundStatement -> classCode.equals(compoundStatement.getClassCode().get(0)))
+                .filter(compoundStatement -> classCode.equals(compoundStatement.getClassCode().getFirst()))
                 .map(compoundStatement -> compoundStatement.getComponent().stream())
                 .orElse(Stream.empty());
     }

--- a/gp2gp-translator/src/main/java/uk/nhs/adaptors/pss/translator/mapper/diagnosticreport/SpecimenBatteryMapper.java
+++ b/gp2gp-translator/src/main/java/uk/nhs/adaptors/pss/translator/mapper/diagnosticreport/SpecimenBatteryMapper.java
@@ -72,7 +72,7 @@ public class SpecimenBatteryMapper {
         final var ehrComposition = batteryParameters.getEhrComposition();
 
         final Observation observation = new Observation();
-        final String id = batteryParameters.getBatteryCompoundStatement().getId().get(0).getRoot();
+        final String id = batteryParameters.getBatteryCompoundStatement().getId().getFirst().getRoot();
         observation.setId(id);
         observation.setMeta(generateMeta(META_PROFILE_URL_SUFFIX));
         observation.addIdentifier(buildIdentifier(id, batteryParameters.getPractiseCode()));
@@ -208,7 +208,7 @@ public class SpecimenBatteryMapper {
     }
 
     private Reference createSpecimenReference(RCMRMT030101UKCompoundStatement specimenCompoundStatement) {
-        return new Reference(new IdType(Specimen.name(), specimenCompoundStatement.getId().get(0).getRoot()));
+        return new Reference(new IdType(Specimen.name(), specimenCompoundStatement.getId().getFirst().getRoot()));
     }
 
     private Optional<InstantType> getIssued(

--- a/gp2gp-translator/src/main/java/uk/nhs/adaptors/pss/translator/mapper/diagnosticreport/SpecimenCompoundsMapper.java
+++ b/gp2gp-translator/src/main/java/uk/nhs/adaptors/pss/translator/mapper/diagnosticreport/SpecimenCompoundsMapper.java
@@ -161,8 +161,9 @@ public class SpecimenCompoundsMapper {
 
         final Reference specimenReference = new Reference(new IdType(
             Specimen.name(),
-            specimenCompoundStatement.getId().get(0).getRoot()
+            specimenCompoundStatement.getId().getFirst().getRoot()
         ));
+
         if (observationStatement.getAvailabilityTime().hasValue()) {
             observation.setIssuedElement(
                 DateFormatUtil.parseToInstantType(
@@ -170,9 +171,10 @@ public class SpecimenCompoundsMapper {
                 )
             );
         }
-        observation.setSpecimen(specimenReference);
-        observation.addCategory(createCategory());
-        observation.setMeta(meta);
+
+        observation.setSpecimen(specimenReference)
+                   .addCategory(createCategory())
+                   .setMeta(meta);
     }
 
     private void handleNarrativeStatements(RCMRMT030101UKCompoundStatement compoundStatement,
@@ -249,7 +251,7 @@ public class SpecimenCompoundsMapper {
         batteryCompoundStatement.getComponent().stream()
             .filter(RCMRMT030101UKComponent02::hasCompoundStatement)
             .map(RCMRMT030101UKComponent02::getCompoundStatement)
-            .filter(compoundStatement -> CLUSTER_CLASSCODE.equals(compoundStatement.getClassCode().get(0)))
+            .filter(compoundStatement -> CLUSTER_CLASSCODE.equals(compoundStatement.getClassCode().getFirst()))
             .forEach(compoundStatement ->
                          handleClusterCompoundStatement(
                              ehrComposition,
@@ -271,12 +273,12 @@ public class SpecimenCompoundsMapper {
 
     private Optional<RCMRMT030101UKCompoundStatement> getCompoundStatementByDRId(RCMRMT030101UKEhrExtract ehrExtract, String id) {
 
-        return ehrExtract.getComponent().get(0).getEhrFolder().getComponent()
+        return ehrExtract.getComponent().getFirst().getEhrFolder().getComponent()
             .stream()
             .flatMap(component3 -> component3.getEhrComposition().getComponent().stream())
             .flatMap(CompoundStatementResourceExtractors::extractAllCompoundStatements)
             .filter(Objects::nonNull)
-            .filter(compoundStatement -> id.equals(compoundStatement.getId().get(0).getRoot()))
+            .filter(compoundStatement -> id.equals(compoundStatement.getId().getFirst().getRoot()))
             .findFirst();
     }
 
@@ -333,7 +335,7 @@ public class SpecimenCompoundsMapper {
     private RCMRMT030101UKEhrComposition getCurrentEhrComposition(RCMRMT030101UKEhrExtract ehrExtract,
                                                                   RCMRMT030101UKCompoundStatement parentCompoundStatement) {
 
-        return ehrExtract.getComponent().get(0).getEhrFolder().getComponent()
+        return ehrExtract.getComponent().getFirst().getEhrFolder().getComponent()
             .stream()
             .filter(RCMRMT030101UKComponent3::hasEhrComposition)
             .map(RCMRMT030101UKComponent3::getEhrComposition)
@@ -345,7 +347,7 @@ public class SpecimenCompoundsMapper {
     }
 
     private static boolean hasBatteryOrClusterClassCode(RCMRMT030101UKCompoundStatement compoundStatement) {
-        return CLUSTER_CLASSCODE.equals(compoundStatement.getClassCode().get(0))
-            || BATTERY_CLASSCODE.equals(compoundStatement.getClassCode().get(0));
+        return CLUSTER_CLASSCODE.equals(compoundStatement.getClassCode().getFirst())
+            || BATTERY_CLASSCODE.equals(compoundStatement.getClassCode().getFirst());
     }
 }

--- a/gp2gp-translator/src/main/java/uk/nhs/adaptors/pss/translator/mapper/medication/MedicationMapperUtils.java
+++ b/gp2gp-translator/src/main/java/uk/nhs/adaptors/pss/translator/mapper/medication/MedicationMapperUtils.java
@@ -97,8 +97,8 @@ public class MedicationMapperUtils {
         SimpleQuantity quantity = new SimpleQuantity();
         quantity.setValue(Double.parseDouble(quantitySupplied.getValue()));
         if (quantitySupplied.hasTranslation()
-            && quantitySupplied.getTranslation().get(0).hasOriginalText()) {
-            quantity.setUnit(quantitySupplied.getTranslation().get(0).getOriginalText());
+            && quantitySupplied.getTranslation().getFirst().hasOriginalText()) {
+            quantity.setUnit(quantitySupplied.getTranslation().getFirst().getOriginalText());
         }
         return Optional.of(quantity);
     }

--- a/gp2gp-translator/src/main/java/uk/nhs/adaptors/pss/translator/mapper/medication/MedicationRequestOrderMapper.java
+++ b/gp2gp-translator/src/main/java/uk/nhs/adaptors/pss/translator/mapper/medication/MedicationRequestOrderMapper.java
@@ -63,12 +63,11 @@ public class MedicationRequestOrderMapper {
                 .setMeta(meta)
                 .setId(ehrSupplyPrescribeId);
 
-            medicationRequest.addIdentifier(buildIdentifier(ehrSupplyPrescribeId, practiseCode));
-            medicationRequest.setStatus(COMPLETED);
-            medicationRequest.setIntent(ORDER);
-
-            medicationRequest.addDosageInstruction(buildDosage(medicationStatement.getPertinentInformation()));
-            medicationRequest.setDispenseRequest(buildDispenseRequestForPrescribe(supplyPrescribe));
+            medicationRequest.addIdentifier(buildIdentifier(ehrSupplyPrescribeId, practiseCode))
+                             .setStatus(COMPLETED)
+                             .setIntent(ORDER)
+                             .addDosageInstruction(buildDosage(medicationStatement.getPertinentInformation()))
+                             .setDispenseRequest(buildDispenseRequestForPrescribe(supplyPrescribe));
 
             buildNotesForPrescribe(supplyPrescribe).forEach(medicationRequest::addNote);
             medicationMapper.extractMedicationReference(medicationStatement).ifPresent(medicationRequest::setMedication);

--- a/gp2gp-translator/src/main/java/uk/nhs/adaptors/pss/translator/mapper/medication/MedicationRequestPlanMapper.java
+++ b/gp2gp-translator/src/main/java/uk/nhs/adaptors/pss/translator/mapper/medication/MedicationRequestPlanMapper.java
@@ -89,10 +89,10 @@ public class MedicationRequestPlanMapper {
                 .setMeta(meta)
                 .setId(ehrSupplyAuthoriseId);
 
-            medicationRequest.addIdentifier(buildIdentifier(ehrSupplyAuthoriseId, practiseCode));
-            medicationRequest.setIntent(PLAN);
-            medicationRequest.addDosageInstruction(buildDosage(medicationStatement.getPertinentInformation()));
-            medicationRequest.setDispenseRequest(buildDispenseRequestForAuthorise(supplyAuthorise, medicationStatement));
+            medicationRequest.addIdentifier(buildIdentifier(ehrSupplyAuthoriseId, practiseCode))
+                             .setIntent(PLAN)
+                             .addDosageInstruction(buildDosage(medicationStatement.getPertinentInformation()))
+                             .setDispenseRequest(buildDispenseRequestForAuthorise(supplyAuthorise, medicationStatement));
 
             List<Extension> repeatInformationExtensions = new ArrayList<>();
             extractSupplyAuthoriseRepeatInformation(supplyAuthorise).ifPresent(repeatInformationExtensions::add);

--- a/gp2gp-translator/src/main/java/uk/nhs/adaptors/pss/translator/mapper/medication/MedicationStatementMapper.java
+++ b/gp2gp-translator/src/main/java/uk/nhs/adaptors/pss/translator/mapper/medication/MedicationStatementMapper.java
@@ -86,17 +86,14 @@ public class MedicationStatementMapper {
                 ehrComposition.getConfidentialityCode()
             );
 
-            mappedMedicationStatement.setId(ehrSupplyAuthoriseId + MS_SUFFIX);
-            mappedMedicationStatement.setMeta(meta);
-            mappedMedicationStatement.addIdentifier(buildIdentifier(ehrSupplyAuthoriseId + MS_SUFFIX, practiseCode));
-            mappedMedicationStatement.setTaken(UNK);
-
-            mappedMedicationStatement.addBasedOn(new Reference(
-                new IdType(ResourceType.MedicationRequest.name(), ehrSupplyAuthoriseId)
-            ));
-            mappedMedicationStatement.addExtension(generatePrescribingAgencyExtension());
-
-            mappedMedicationStatement.addDosage(buildDosage(medicationStatement.getPertinentInformation()));
+            mappedMedicationStatement.setId(ehrSupplyAuthoriseId + MS_SUFFIX)
+                .setMeta(meta);
+            mappedMedicationStatement.addIdentifier(buildIdentifier(ehrSupplyAuthoriseId + MS_SUFFIX, practiseCode))
+                .setTaken(UNK)
+                .addBasedOn(new Reference(
+                    new IdType(ResourceType.MedicationRequest.name(), ehrSupplyAuthoriseId)))
+                .addDosage(buildDosage(medicationStatement.getPertinentInformation()))
+                .addExtension(generatePrescribingAgencyExtension());
 
             extractHighestSupplyPrescribeTime(ehrExtract, ehrSupplyAuthoriseId)
                 .map(dateTime -> new Extension(MS_LAST_ISSUE_DATE, dateTime))

--- a/gp2gp-translator/src/main/java/uk/nhs/adaptors/pss/translator/service/BundleMapperService.java
+++ b/gp2gp-translator/src/main/java/uk/nhs/adaptors/pss/translator/service/BundleMapperService.java
@@ -246,7 +246,7 @@ public class BundleMapperService {
     }
 
     private RCMRMT030101UKEhrFolder getEhrFolder(RCMRIN030000UKMessage xmlMessage) {
-        return getEhrExtract(xmlMessage).getComponent().get(0).getEhrFolder();
+        return getEhrExtract(xmlMessage).getComponent().getFirst().getEhrFolder();
     }
 
     private RCMRMT030101UKEhrExtract getEhrExtract(RCMRIN030000UKMessage xmlMessage) {

--- a/gp2gp-translator/src/main/java/uk/nhs/adaptors/pss/translator/service/SDSService.java
+++ b/gp2gp-translator/src/main/java/uk/nhs/adaptors/pss/translator/service/SDSService.java
@@ -124,7 +124,7 @@ public class SDSService {
             throw new SdsRetrievalException("sds response doesn't contain any results");
         }
 
-        Resource resource = entries.get(0).getResource();
+        Resource resource = entries.getFirst().getResource();
         return resource.getChildByName(resourceSubelement);
     }
 }

--- a/gp2gp-translator/src/main/java/uk/nhs/adaptors/pss/translator/task/COPCMessageHandler.java
+++ b/gp2gp-translator/src/main/java/uk/nhs/adaptors/pss/translator/task/COPCMessageHandler.java
@@ -110,7 +110,7 @@ public class COPCMessageHandler {
                     if (!inlineAttachments.isEmpty()) {
                         // we are expecting inline attachments to only have one attachment in the storeCOPCAttachment method below
                         // so use isBase64 flag of the first inline attachment
-                        patientAttachmentLog.setIsBase64(Boolean.valueOf(inlineAttachments.get(0).getIsBase64()));
+                        patientAttachmentLog.setIsBase64(Boolean.valueOf(inlineAttachments.getFirst().getIsBase64()));
                     }
 
                     storeCOPCAttachment(patientAttachmentLog, inboundMessage, conversationId);
@@ -195,7 +195,7 @@ public class COPCMessageHandler {
                 return;
             } else {
                 // otherwise let's select the first child fragment to run the process as normal
-                currentAttachmentLog = childFragments.get(0);
+                currentAttachmentLog = childFragments.getFirst();
             }
         }
 
@@ -293,7 +293,7 @@ public class COPCMessageHandler {
         Document ebXmlDocument, int patientId) throws ValidationException, InlineAttachmentProcessingException {
         String fragmentMid = getFragmentMidId(ebXmlDocument);
         String fileName = getFileNameForFragment(inboundMessage, payload);
-        var attachment = inboundMessage.getAttachments().get(0);
+        var attachment = inboundMessage.getAttachments().getFirst();
 
         PatientAttachmentLog fragmentAttachmentLog = buildFragmentAttachmentLog(attachment, fragmentMid,
             createFilenameForFragment(fileName), patientId);
@@ -315,12 +315,12 @@ public class COPCMessageHandler {
         if (fragmentAttachmentLog.getLargeAttachment() == null || fragmentAttachmentLog.getLargeAttachment()) {
 
             attachmentHandlerService.storeAttachmentWithoutProcessing(fragmentAttachmentLog.getFilename(),
-                inboundMessage.getAttachments().get(0).getPayload(), conversationId,
+                inboundMessage.getAttachments().getFirst().getPayload(), conversationId,
                 fragmentAttachmentLog.getContentType());
         } else {
             var attachment = attachmentHandlerService.buildInboundAttachmentsFromAttachmentLogs(
                 List.of(fragmentAttachmentLog),
-                List.of(inboundMessage.getAttachments().get(0).getPayload()),
+                List.of(inboundMessage.getAttachments().getFirst().getPayload()),
                 conversationId
             );
 
@@ -338,9 +338,9 @@ public class COPCMessageHandler {
 
     private String getFileNameForFragment(InboundMessage inboundMessage, COPCIN000001UK01Message payload) {
         // confirm filename in payload on future examples
-        if (!inboundMessage.getAttachments().get(0).getDescription().isEmpty()
-            && inboundMessage.getAttachments().get(0).getDescription().contains("Filename")) {
-            return XmlParseUtilService.parseFragmentFilename(inboundMessage.getAttachments().get(0).getDescription());
+        if (!inboundMessage.getAttachments().getFirst().getDescription().isEmpty()
+            && inboundMessage.getAttachments().getFirst().getDescription().contains("Filename")) {
+            return XmlParseUtilService.parseFragmentFilename(inboundMessage.getAttachments().getFirst().getDescription());
         } else {
             return retrieveFileNameFromPayload(payload);
         }
@@ -366,7 +366,7 @@ public class COPCMessageHandler {
             .getSubject()
             .getPayloadInformation()
             .getPertinentInformation()
-            .get(0)
+            .getFirst()
             .getPertinentPayloadBody()
             .getValue()
             .getReference()
@@ -398,16 +398,16 @@ public class COPCMessageHandler {
             if (payloadReference.getHref().contains("cid:")) {
                 // EMIS does not use unique IDs for cid references, so we have to generate our own
                 messageId = "ADAPTOR_GENERATED_" + idGeneratorService.generateUuid().toUpperCase();
-                descriptionString = message.getAttachments().get(0).getDescription();
+                descriptionString = message.getAttachments().getFirst().getDescription();
                 filename = createFilenameForFragment(XmlParseUtilService.parseFragmentFilename(descriptionString));
-                isBase64 = Boolean.parseBoolean(message.getAttachments().get(0).getIsBase64());
+                isBase64 = Boolean.parseBoolean(message.getAttachments().getFirst().getIsBase64());
 
                 // upload the file
                 attachmentHandlerService.storeAttachmentWithoutProcessing(
                     filename,
-                    message.getAttachments().get(0).getPayload(),
+                    message.getAttachments().getFirst().getPayload(),
                     conversationId,
-                    message.getAttachments().get(0).getContentType()
+                    message.getAttachments().getFirst().getContentType()
                 );
                 fileUpload = true;
             } else {

--- a/gp2gp-translator/src/main/java/uk/nhs/adaptors/pss/translator/util/BloodPressureValidatorUtil.java
+++ b/gp2gp-translator/src/main/java/uk/nhs/adaptors/pss/translator/util/BloodPressureValidatorUtil.java
@@ -63,7 +63,7 @@ public class BloodPressureValidatorUtil {
 
     private static boolean validateTriple(String header, String observationStatement1, String observationStatement2) {
         for (List<List<String>> list : VALID_BLOOD_PRESSURE_TRIPLES) {
-            if (isValidBloodTriple(list.get(0), list.get(1), list.get(2), header, observationStatement1, observationStatement2)) {
+            if (isValidBloodTriple(list.getFirst(), list.get(1), list.get(2), header, observationStatement1, observationStatement2)) {
                 return true;
             }
         }
@@ -87,7 +87,7 @@ public class BloodPressureValidatorUtil {
 
         if (observationStatements.size() == 2) {
             Optional<String> compoundStatementCode = extractSnomedCode(compoundStatement.getCode());
-            Optional<String> obsStatementCode1 = extractSnomedCode(observationStatements.get(0).getCode());
+            Optional<String> obsStatementCode1 = extractSnomedCode(observationStatements.getFirst().getCode());
             Optional<String> obsStatementCode2 = extractSnomedCode(observationStatements.get(1).getCode());
 
             if (compoundStatementCode.isEmpty() || obsStatementCode1.isEmpty() || obsStatementCode2.isEmpty()) {
@@ -103,7 +103,7 @@ public class BloodPressureValidatorUtil {
 
     public static boolean isBloodPressureWithBatteryAndBloodPressureTriple(
         RCMRMT030101UKCompoundStatement compoundStatement) {
-        return BATTERY_VALUE.equals(compoundStatement.getClassCode().get(0))
+        return BATTERY_VALUE.equals(compoundStatement.getClassCode().getFirst())
             && containsValidBloodPressureTriple(compoundStatement);
     }
 }

--- a/gp2gp-translator/src/main/java/uk/nhs/adaptors/pss/translator/util/OutboundMessageUtil.java
+++ b/gp2gp-translator/src/main/java/uk/nhs/adaptors/pss/translator/util/OutboundMessageUtil.java
@@ -7,10 +7,10 @@ import org.springframework.stereotype.Component;
 public class OutboundMessageUtil {
     public String parseFromAsid(RCMRIN030000UKMessage payload) {
         return payload.getCommunicationFunctionRcv()
-            .get(0)
+            .getFirst()
             .getDevice()
             .getId()
-            .get(0)
+            .getFirst()
             .getExtension();
     }
 
@@ -18,7 +18,7 @@ public class OutboundMessageUtil {
         return payload.getCommunicationFunctionSnd()
             .getDevice()
             .getId()
-            .get(0)
+            .getFirst()
             .getExtension();
     }
 

--- a/gp2gp-translator/src/main/java/uk/nhs/adaptors/pss/translator/util/ParticipantReferenceUtil.java
+++ b/gp2gp-translator/src/main/java/uk/nhs/adaptors/pss/translator/util/ParticipantReferenceUtil.java
@@ -73,7 +73,7 @@ public class ParticipantReferenceUtil {
 
         var participant2Reference = ehrComposition.getParticipant2().stream()
             .filter(participant2 -> participant2.getNullFlavor() == null)
-            .filter(participant2 -> typeCode.equals(participant2.getTypeCode().get(0)))
+            .filter(participant2 -> typeCode.equals(participant2.getTypeCode().getFirst()))
             .map(RCMRMT030101UKParticipant2::getAgentRef)
             .map(RCMRMT030101UKAgentRef::getId)
             .filter(II::hasRoot)
@@ -102,7 +102,7 @@ public class ParticipantReferenceUtil {
     }
 
     private static boolean hasTypeCode(RCMRMT030101UKParticipant participant, String typeCode) {
-        return !participant.getTypeCode().isEmpty() && participant.getTypeCode().get(0).equals(typeCode);
+        return !participant.getTypeCode().isEmpty() && participant.getTypeCode().getFirst().equals(typeCode);
     }
 
     private static boolean isNotNullFlavour(RCMRMT030101UKParticipant participant) {

--- a/gp2gp-translator/src/main/java/uk/nhs/adaptors/pss/translator/util/ResourceFilterUtil.java
+++ b/gp2gp-translator/src/main/java/uk/nhs/adaptors/pss/translator/util/ResourceFilterUtil.java
@@ -38,7 +38,7 @@ public class ResourceFilterUtil {
             && ALLERGY_CODES.contains(compoundStatement.getCode().getCode())
             && CODE_SYSTEM_READ_CODE_V2.equals(compoundStatement.getCode().getCodeSystem())
             && compoundStatement.getComponent().size() == 1
-            && compoundStatement.getComponent().get(0).hasObservationStatement();
+            && compoundStatement.getComponent().getFirst().hasObservationStatement();
     }
 
     public static boolean isDiagnosticReport(RCMRMT030101UKCompoundStatement compoundStatement) {
@@ -54,7 +54,7 @@ public class ResourceFilterUtil {
     public static boolean hasDiagnosticReportParent(RCMRMT030101UKEhrExtract ehrExtract,
                                                     RCMRMT030101UKCompoundStatement compoundStatement) {
 
-        return ehrExtract.getComponent().get(0).getEhrFolder().getComponent().stream()
+        return ehrExtract.getComponent().getFirst().getEhrFolder().getComponent().stream()
             .flatMap(component3 -> component3.getEhrComposition().getComponent().stream())
             .flatMap(CompoundStatementResourceExtractors::extractAllCompoundStatements)
             .filter(ResourceFilterUtil::isDiagnosticReport)
@@ -79,7 +79,7 @@ public class ResourceFilterUtil {
             && !isBloodPressure(compoundStatement)
             && !isDiagnosticReport(compoundStatement)
             && !isSpecimen(compoundStatement)
-            && List.of(BATTERY_VALUE, CLUSTER_VALUE).contains(compoundStatement.getClassCode().get(0));
+            && List.of(BATTERY_VALUE, CLUSTER_VALUE).contains(compoundStatement.getClassCode().getFirst());
     }
 
     private static boolean hasCode(RCMRMT030101UKCompoundStatement compoundStatement) {

--- a/gp2gp-translator/src/main/java/uk/nhs/adaptors/pss/translator/util/ResourceReferenceUtil.java
+++ b/gp2gp-translator/src/main/java/uk/nhs/adaptors/pss/translator/util/ResourceReferenceUtil.java
@@ -96,8 +96,8 @@ public class ResourceReferenceUtil {
 
         return compoundStatement == null
             || references.contains(QUESTIONNAIRE_ID.formatted(QUESTIONNAIRE_REFERENCE.formatted(
-            compoundStatement.getId().get(0).getRoot())))
-            || !references.contains(OBSERVATION_REFERENCE.formatted(compoundStatement.getId().get(0).getRoot()));
+            compoundStatement.getId().getFirst().getRoot())))
+            || !references.contains(OBSERVATION_REFERENCE.formatted(compoundStatement.getId().getFirst().getRoot()));
     }
 
     private void addObservationStatementEntry(RCMRMT030101UKObservationStatement observationStatement,
@@ -118,7 +118,7 @@ public class ResourceReferenceUtil {
     private static void addAllergyIntoleranceEntry(RCMRMT030101UKCompoundStatement compoundStatement,
                                                    List<Reference> entryReferences) {
 
-        var observationStatementPart = compoundStatement.getComponent().get(0).getObservationStatement();
+        var observationStatementPart = compoundStatement.getComponent().getFirst().getObservationStatement();
 
         entryReferences.add(createResourceReference(ResourceType.AllergyIntolerance.name(),
                 observationStatementPart.getId().getRoot()));
@@ -127,7 +127,7 @@ public class ResourceReferenceUtil {
     private static void addDiagnosticReportEntry(RCMRMT030101UKCompoundStatement compoundStatement,
                                                  List<Reference> entryReferences) {
         entryReferences.add(createResourceReference(ResourceType.DiagnosticReport.name(),
-                compoundStatement.getId().get(0).getRoot()));
+                compoundStatement.getId().getFirst().getRoot()));
     }
 
     private static void addMedicationEntry(RCMRMT030101UKMedicationStatement medicationStatement,
@@ -149,7 +149,7 @@ public class ResourceReferenceUtil {
                                               List<Reference> entryReferences) {
 
         entryReferences.add(createResourceReference(ResourceType.Observation.name(),
-                compoundStatement.getId().get(0).getRoot()));
+                compoundStatement.getId().getFirst().getRoot()));
     }
 
     private static void addImmunizationEntry(RCMRMT030101UKObservationStatement observationStatement,
@@ -180,17 +180,17 @@ public class ResourceReferenceUtil {
             if (requestStatement.getCode().getQualifier() == null
                     || requestStatement.getCode().getQualifier().isEmpty()) {
                 entryReferences.add(createResourceReference(
-                        ResourceType.ReferralRequest.name(), requestStatement.getId().get(0).getRoot()));
+                        ResourceType.ReferralRequest.name(), requestStatement.getId().getFirst().getRoot()));
             }
 
             //If qualifier present then add Observation or ReferralRequest depending on Value.
             for (CR qualifier : requestStatement.getCode().getQualifier()) {
                 if (qualifier.getValue().getCode().equals(SELF_REFERRAL)) {
                     entryReferences.add(createResourceReference(
-                            ResourceType.Observation.name(), requestStatement.getId().get(0).getRoot()));
+                            ResourceType.Observation.name(), requestStatement.getId().getFirst().getRoot()));
                 } else {
                     entryReferences.add(createResourceReference(
-                            ResourceType.ReferralRequest.name(), requestStatement.getId().get(0).getRoot()));
+                            ResourceType.ReferralRequest.name(), requestStatement.getId().getFirst().getRoot()));
                 }
             }
         }
@@ -202,7 +202,7 @@ public class ResourceReferenceUtil {
             if (isDocumentReference(narrativeStatement)) {
                 // document references actually use the narrative statement id rather than the referenceDocument root id in EMIS data
                 // if EMIS is incorrect, replace the id below with the following...
-                // narrativeStatement.getReference().get(0).getReferredToExternalDocument().getId().getRoot()
+                // narrativeStatement.getReference().getFirst().getReferredToExternalDocument().getId().getRoot()
                 entryReferences.add(createResourceReference(ResourceType.DocumentReference.name(),
                     narrativeStatement.getId().getRoot()));
             } else {

--- a/gp2gp-translator/src/main/java/uk/nhs/adaptors/pss/translator/util/XmlParseUtilService.java
+++ b/gp2gp-translator/src/main/java/uk/nhs/adaptors/pss/translator/util/XmlParseUtilService.java
@@ -140,10 +140,10 @@ public class XmlParseUtilService {
 
     public static String parseFromAsid(COPCIN000001UK01Message payload) {
         return payload.getCommunicationFunctionRcv()
-                .get(0)
+                .getFirst()
                 .getDevice()
                 .getId()
-                .get(0)
+                .getFirst()
                 .getExtension();
     }
 
@@ -151,7 +151,7 @@ public class XmlParseUtilService {
         return payload.getCommunicationFunctionSnd()
                 .getDevice()
                 .getId()
-                .get(0)
+                .getFirst()
                 .getExtension();
     }
 
@@ -166,7 +166,7 @@ public class XmlParseUtilService {
                 .getPayloadInformation()
                 .getValue()
                 .getAny()
-                .get(0);
+                .getFirst();
 
         return getFromPractiseValue(gp2gpElement);
     }
@@ -184,10 +184,10 @@ public class XmlParseUtilService {
 
     public static String parseFromAsid(RCMRIN030000UKMessage payload) {
         return payload.getCommunicationFunctionRcv()
-            .get(0)
+            .getFirst()
             .getDevice()
             .getId()
-            .get(0)
+            .getFirst()
             .getExtension();
     }
 
@@ -195,7 +195,7 @@ public class XmlParseUtilService {
         return payload.getCommunicationFunctionSnd()
                 .getDevice()
                 .getId()
-                .get(0)
+                .getFirst()
                 .getExtension();
     }
 

--- a/gp2gp-translator/src/main/resources/application.yml
+++ b/gp2gp-translator/src/main/resources/application.yml
@@ -9,7 +9,7 @@ spring:
   datasource:
     url: ${PS_DB_URL:jdbc:postgresql://localhost:5436}/patient_switching
     username: gp2gp_user
-    password: 123456
+    password: ${GP2GP_TRANSLATOR_USER_DB_PASSWORD}
 
 management:
   endpoints:

--- a/gp2gp-translator/src/main/resources/application.yml
+++ b/gp2gp-translator/src/main/resources/application.yml
@@ -9,7 +9,7 @@ spring:
   datasource:
     url: ${PS_DB_URL:jdbc:postgresql://localhost:5436}/patient_switching
     username: gp2gp_user
-    password: ${GP2GP_TRANSLATOR_USER_DB_PASSWORD}
+    password: 123456
 
 management:
   endpoints:

--- a/gp2gp-translator/src/test/java/uk/nhs/adaptors/pss/translator/generator/BundleGeneratorTest.java
+++ b/gp2gp-translator/src/test/java/uk/nhs/adaptors/pss/translator/generator/BundleGeneratorTest.java
@@ -38,6 +38,6 @@ public class BundleGeneratorTest {
         assertThat(bundle.getResourceType().toString()).isEqualTo(ResourceType.Bundle.name());
         assertThat(bundle.getId()).isEqualTo(BUNDLE_ID);
         assertThat(bundle.getType()).isEqualTo(Bundle.BundleType.COLLECTION);
-        assertThat(bundle.getMeta().getProfile().get(0).getValue()).isEqualTo(META_PROFILE);
+        assertThat(bundle.getMeta().getProfile().getFirst().getValue()).isEqualTo(META_PROFILE);
     }
 }

--- a/gp2gp-translator/src/test/java/uk/nhs/adaptors/pss/translator/mapper/AgentDirectoryMapperTest.java
+++ b/gp2gp-translator/src/test/java/uk/nhs/adaptors/pss/translator/mapper/AgentDirectoryMapperTest.java
@@ -56,21 +56,21 @@ public class AgentDirectoryMapperTest {
 
         assertEquals(THREE_RESOURCES_MAPPED, mappedAgents.size());
 
-        var practitioner = (Practitioner) mappedAgents.get(0);
+        var practitioner = (Practitioner) mappedAgents.getFirst();
         assertEquals("94F00D99-0601-4A8E-AD1D-1B564307B0A6", practitioner.getId());
-        assertEquals(PRACT_META_PROFILE, practitioner.getMeta().getProfile().get(0).getValue());
+        assertEquals(PRACT_META_PROFILE, practitioner.getMeta().getProfile().getFirst().getValue());
         assertEquals(NameUse.OFFICIAL, practitioner.getNameFirstRep().getUse());
         assertEquals("Test", practitioner.getNameFirstRep().getFamily());
 
         var organization = (Organization) mappedAgents.get(1);
         assertEquals("94F00D99-0601-4A8E-AD1D-1B564307B0A6-ORG", organization.getId());
-        assertEquals(ORG_META_PROFILE, organization.getMeta().getProfile().get(0).getValue());
+        assertEquals(ORG_META_PROFILE, organization.getMeta().getProfile().getFirst().getValue());
         assertEquals("TEMPLE SOWERBY MEDICAL PRACTICE", organization.getName());
         assertThat(organization.getType()).isEmpty();
 
         var practitionerRole = (PractitionerRole) mappedAgents.get(2);
         assertEquals("94F00D99-0601-4A8E-AD1D-1B564307B0A6-PR", practitionerRole.getId());
-        assertEquals(PRACT_ROLE_META_PROFILE, practitionerRole.getMeta().getProfile().get(0).getValue());
+        assertEquals(PRACT_ROLE_META_PROFILE, practitionerRole.getMeta().getProfile().getFirst().getValue());
         assertEquals("Practitioner/94F00D99-0601-4A8E-AD1D-1B564307B0A6", practitionerRole.getPractitioner().getReference());
         assertEquals("Organization/94F00D99-0601-4A8E-AD1D-1B564307B0A6-ORG", practitionerRole.getOrganization().getReference());
         assertThat(practitionerRole.getCode()).isEmpty();
@@ -81,12 +81,12 @@ public class AgentDirectoryMapperTest {
         var agentDirectory = unmarshallAgentDirectoryElement("agent_org_with_general_practitioner_number.xml");
 
         var mappedAgents = agentDirectoryMapper.mapAgentDirectory(agentDirectory);
-        var practitioner = (Practitioner) mappedAgents.get(0);
+        var practitioner = (Practitioner) mappedAgents.getFirst();
 
         assertEquals("E7E7B550-09EF-BE85-C20F-34598014166C", practitioner.getId());
         assertThat(practitioner.getIdentifier()).isNotEmpty();
-        assertEquals("https://fhir.hl7.org.uk/Id/gmp-number", practitioner.getIdentifier().get(0).getSystem());
-        assertEquals("12345", practitioner.getIdentifier().get(0).getValue());
+        assertEquals("https://fhir.hl7.org.uk/Id/gmp-number", practitioner.getIdentifier().getFirst().getSystem());
+        assertEquals("12345", practitioner.getIdentifier().getFirst().getValue());
     }
 
     @Test
@@ -97,21 +97,21 @@ public class AgentDirectoryMapperTest {
 
         assertEquals(THREE_RESOURCES_MAPPED, mappedAgents.size());
 
-        var practitioner = (Practitioner) mappedAgents.get(0);
+        var practitioner = (Practitioner) mappedAgents.getFirst();
         assertEquals("94F00D99-0601-4A8E-AD1D-1B564307B0A6", practitioner.getId());
-        assertEquals(PRACT_META_PROFILE, practitioner.getMeta().getProfile().get(0).getValue());
+        assertEquals(PRACT_META_PROFILE, practitioner.getMeta().getProfile().getFirst().getValue());
         assertEquals(NameUse.OFFICIAL, practitioner.getNameFirstRep().getUse());
         assertEquals("Test", practitioner.getNameFirstRep().getFamily());
 
         var organization = (Organization) mappedAgents.get(1);
         assertEquals("94F00D99-0601-4A8E-AD1D-1B564307B0A6-ORG", organization.getId());
-        assertEquals(ORG_META_PROFILE, organization.getMeta().getProfile().get(0).getValue());
+        assertEquals(ORG_META_PROFILE, organization.getMeta().getProfile().getFirst().getValue());
         assertEquals("TEMPLE SOWERBY MEDICAL PRACTICE", organization.getName());
         assertThat(organization.getType()).isEmpty();
 
         var practitionerRole = (PractitionerRole) mappedAgents.get(2);
         assertEquals("94F00D99-0601-4A8E-AD1D-1B564307B0A6-PR", practitionerRole.getId());
-        assertEquals(PRACT_ROLE_META_PROFILE, practitionerRole.getMeta().getProfile().get(0).getValue());
+        assertEquals(PRACT_ROLE_META_PROFILE, practitionerRole.getMeta().getProfile().getFirst().getValue());
         assertEquals("Practitioner/94F00D99-0601-4A8E-AD1D-1B564307B0A6", practitionerRole.getPractitioner().getReference());
         assertEquals("Organization/94F00D99-0601-4A8E-AD1D-1B564307B0A6-ORG", practitionerRole.getOrganization().getReference());
         assertEquals("Clerical Worker", practitionerRole.getCodeFirstRep().getText());
@@ -125,24 +125,24 @@ public class AgentDirectoryMapperTest {
 
         assertEquals(THREE_RESOURCES_MAPPED, mappedAgents.size());
 
-        var practitioner = (Practitioner) mappedAgents.get(0);
+        var practitioner = (Practitioner) mappedAgents.getFirst();
         assertEquals("94F00D99-0601-4A8E-AD1D-1B564307B0A6", practitioner.getId());
-        assertEquals(PRACT_META_PROFILE, practitioner.getMeta().getProfile().get(0).getValue());
+        assertEquals(PRACT_META_PROFILE, practitioner.getMeta().getProfile().getFirst().getValue());
         assertEquals(NameUse.OFFICIAL, practitioner.getNameFirstRep().getUse());
         assertEquals("Test", practitioner.getNameFirstRep().getFamily());
 
         var organization = (Organization) mappedAgents.get(1);
         assertEquals("94F00D99-0601-4A8E-AD1D-1B564307B0A6-ORG", organization.getId());
-        assertEquals(ORG_META_PROFILE, organization.getMeta().getProfile().get(0).getValue());
+        assertEquals(ORG_META_PROFILE, organization.getMeta().getProfile().getFirst().getValue());
         assertEquals("TEMPLE SOWERBY MEDICAL PRACTICE", organization.getName());
         assertThat(organization.getType()).isEmpty();
 
         var practitionerRole = (PractitionerRole) mappedAgents.get(2);
         assertEquals("94F00D99-0601-4A8E-AD1D-1B564307B0A6-PR", practitionerRole.getId());
-        assertEquals(PRACT_ROLE_META_PROFILE, practitionerRole.getMeta().getProfile().get(0).getValue());
+        assertEquals(PRACT_ROLE_META_PROFILE, practitionerRole.getMeta().getProfile().getFirst().getValue());
         assertEquals("Practitioner/94F00D99-0601-4A8E-AD1D-1B564307B0A6", practitionerRole.getPractitioner().getReference());
         assertEquals("Organization/94F00D99-0601-4A8E-AD1D-1B564307B0A6-ORG", practitionerRole.getOrganization().getReference());
-        assertEquals("General practice", practitionerRole.getCode().get(0).getCoding().get(0).getDisplay());
+        assertEquals("General practice", practitionerRole.getCode().getFirst().getCoding().getFirst().getDisplay());
     }
 
     @Test
@@ -153,9 +153,9 @@ public class AgentDirectoryMapperTest {
 
         assertThat(mappedAgents).hasSize(1);
 
-        var practitioner = (Practitioner) mappedAgents.get(0);
+        var practitioner = (Practitioner) mappedAgents.getFirst();
         assertEquals("95D00D99-0601-4A8E-AD1D-1B564307B0A6", practitioner.getId());
-        assertEquals(PRACT_META_PROFILE, practitioner.getMeta().getProfile().get(0).getValue());
+        assertEquals(PRACT_META_PROFILE, practitioner.getMeta().getProfile().getFirst().getValue());
         assertEquals(NameUse.OFFICIAL, practitioner.getNameFirstRep().getUse());
         assertEquals("Test", practitioner.getNameFirstRep().getFamily());
         assertThat(practitioner.getNameFirstRep().getGiven()).isEmpty();
@@ -170,10 +170,10 @@ public class AgentDirectoryMapperTest {
 
         assertThat(mappedAgents).hasSize(1);
 
-        var practitioner = (Practitioner) mappedAgents.get(0);
+        var practitioner = (Practitioner) mappedAgents.getFirst();
 
         assertThat(practitioner.getId()).isEqualTo("95D00D99-0601-4A8E-AD1D-1B564307B0A6");
-        assertThat(practitioner.getMeta().getProfile().get(0).getValue()).isEqualTo(PRACT_META_PROFILE);
+        assertThat(practitioner.getMeta().getProfile().getFirst().getValue()).isEqualTo(PRACT_META_PROFILE);
         assertThat(practitioner.getNameFirstRep().getUse()).isEqualTo(NameUse.OFFICIAL);
         assertThat(practitioner.getNameFirstRep().getFamily()).isEqualTo("Unknown");
         assertThat(practitioner.getNameFirstRep().getGiven()).isEmpty();
@@ -188,13 +188,13 @@ public class AgentDirectoryMapperTest {
 
         assertThat(mappedAgents).hasSize(1);
 
-        var practitioner = (Practitioner) mappedAgents.get(0);
+        var practitioner = (Practitioner) mappedAgents.getFirst();
         assertThat(practitioner.getId()).isEqualTo("95D00D99-0601-4A8E-AD1D-1B564307B0A6");
-        assertThat(practitioner.getMeta().getProfile().get(0).getValue()).isEqualTo(PRACT_META_PROFILE);
+        assertThat(practitioner.getMeta().getProfile().getFirst().getValue()).isEqualTo(PRACT_META_PROFILE);
         assertThat(practitioner.getNameFirstRep().getUse()).isEqualTo(NameUse.OFFICIAL);
         assertThat(practitioner.getNameFirstRep().getFamily()).isEqualTo("Test");
-        assertThat(practitioner.getNameFirstRep().getGiven().get(0).getValue()).isEqualTo("NHS");
-        assertThat(practitioner.getNameFirstRep().getPrefix().get(0).getValue()).isEqualTo("Mr");
+        assertThat(practitioner.getNameFirstRep().getGiven().getFirst().getValue()).isEqualTo("NHS");
+        assertThat(practitioner.getNameFirstRep().getPrefix().getFirst().getValue()).isEqualTo("Mr");
     }
 
     @Test
@@ -205,9 +205,9 @@ public class AgentDirectoryMapperTest {
 
         assertThat(mappedAgents).hasSize(1);
 
-        var organization = (Organization) mappedAgents.get(0);
+        var organization = (Organization) mappedAgents.getFirst();
         assertThat(organization.getId()).isEqualTo("1D9BDC28-50AB-440D-B421-0E5E049526FA");
-        assertThat(organization.getMeta().getProfile().get(0).getValue()).isEqualTo(ORG_META_PROFILE);
+        assertThat(organization.getMeta().getProfile().getFirst().getValue()).isEqualTo(ORG_META_PROFILE);
         assertThat(organization.getName()).isEqualTo("The Health Centre");
         assertThat(organization.getIdentifier()).isEmpty();
         assertThat(organization.getTelecom()).isEmpty();
@@ -222,9 +222,9 @@ public class AgentDirectoryMapperTest {
 
         assertThat(mappedAgents).hasSize(1);
 
-        var organization = (Organization) mappedAgents.get(0);
+        var organization = (Organization) mappedAgents.getFirst();
         assertThat(organization.getId()).isEqualTo("1D9BDC28-50AB-440D-B421-0E5E049526FA");
-        assertThat(organization.getMeta().getProfile().get(0).getValue()).isEqualTo(ORG_META_PROFILE);
+        assertThat(organization.getMeta().getProfile().getFirst().getValue()).isEqualTo(ORG_META_PROFILE);
         assertThat(organization.getName()).isEqualTo("Unknown");
         assertThat(organization.getIdentifier()).isEmpty();
         assertThat(organization.getTelecom()).isEmpty();
@@ -239,9 +239,9 @@ public class AgentDirectoryMapperTest {
 
         assertEquals(1, mappedAgents.size());
 
-        var organization = (Organization) mappedAgents.get(0);
+        var organization = (Organization) mappedAgents.getFirst();
         assertEquals("1D9BDC28-50AB-440D-B421-0E5E049526FA", organization.getId());
-        assertEquals(ORG_META_PROFILE, organization.getMeta().getProfile().get(0).getValue());
+        assertEquals(ORG_META_PROFILE, organization.getMeta().getProfile().getFirst().getValue());
         assertEquals("The Health Centre", organization.getName());
         assertEquals(ORG_IDENTIFIER_SYSTEM, organization.getIdentifierFirstRep().getSystem());
         assertEquals("A81001", organization.getIdentifierFirstRep().getValue());
@@ -257,9 +257,9 @@ public class AgentDirectoryMapperTest {
 
         assertEquals(1, mappedAgents.size());
 
-        var organization = (Organization) mappedAgents.get(0);
+        var organization = (Organization) mappedAgents.getFirst();
         assertEquals("1D9BDC28-50AB-440D-B421-0E5E049526FA", organization.getId());
-        assertEquals(ORG_META_PROFILE, organization.getMeta().getProfile().get(0).getValue());
+        assertEquals(ORG_META_PROFILE, organization.getMeta().getProfile().getFirst().getValue());
         assertEquals("The Health Centre", organization.getName());
         assertThat(organization.getIdentifier()).isEmpty();
         assertThat(organization.getTelecom()).isEmpty();
@@ -274,9 +274,9 @@ public class AgentDirectoryMapperTest {
 
         assertEquals(1, mappedAgents.size());
 
-        var organization = (Organization) mappedAgents.get(0);
+        var organization = (Organization) mappedAgents.getFirst();
         assertEquals("1D9BDC28-50AB-440D-B421-0E5E049526FA", organization.getId());
-        assertEquals(ORG_META_PROFILE, organization.getMeta().getProfile().get(0).getValue());
+        assertEquals(ORG_META_PROFILE, organization.getMeta().getProfile().getFirst().getValue());
         assertEquals("The Health Centre", organization.getName());
         assertThat(organization.getIdentifier()).isEmpty();
         assertTelecom(organization.getTelecomFirstRep(), "01234567890");
@@ -291,9 +291,9 @@ public class AgentDirectoryMapperTest {
 
         assertEquals(1, mappedAgents.size());
 
-        var organization = (Organization) mappedAgents.get(0);
+        var organization = (Organization) mappedAgents.getFirst();
         assertEquals("1D9BDC28-50AB-440D-B421-0E5E049526FA", organization.getId());
-        assertEquals(ORG_META_PROFILE, organization.getMeta().getProfile().get(0).getValue());
+        assertEquals(ORG_META_PROFILE, organization.getMeta().getProfile().getFirst().getValue());
         assertEquals("The Health Centre", organization.getName());
         assertThat(organization.getIdentifier()).isEmpty();
         assertTelecom(organization.getTelecomFirstRep(), "01234567890");
@@ -308,9 +308,9 @@ public class AgentDirectoryMapperTest {
 
         assertEquals(1, mappedAgents.size());
 
-        var organization = (Organization) mappedAgents.get(0);
+        var organization = (Organization) mappedAgents.getFirst();
         assertEquals("1D9BDC28-50AB-440D-B421-0E5E049526FA", organization.getId());
-        assertEquals(ORG_META_PROFILE, organization.getMeta().getProfile().get(0).getValue());
+        assertEquals(ORG_META_PROFILE, organization.getMeta().getProfile().getFirst().getValue());
         assertEquals("The Health Centre", organization.getName());
         assertThat(organization.getIdentifier()).isEmpty();
         assertThat(organization.getTelecom()).isEmpty();
@@ -344,12 +344,12 @@ public class AgentDirectoryMapperTest {
         var mappedAgents = agentDirectoryMapper.mapAgentDirectory(agentDirectory);
 
         var practitionerRole = (PractitionerRole) mappedAgents.get(2);
-        var coding = practitionerRole.getCode().get(0).getCoding().get(0);
+        var coding = practitionerRole.getCode().getFirst().getCoding().getFirst();
 
         assertAll(
-                () -> assertEquals("1234", coding.getCode()),
-                () -> assertEquals("http://snomed.info/sct", coding.getSystem()),
-                () -> assertEquals("General practice", coding.getDisplay())
+            () -> assertEquals("1234", coding.getCode()),
+            () -> assertEquals("http://snomed.info/sct", coding.getSystem()),
+            () -> assertEquals("General practice", coding.getDisplay())
         );
     }
 
@@ -383,12 +383,12 @@ public class AgentDirectoryMapperTest {
 
         var agents = agentDirectoryMapper.mapAgentDirectory(agentDirectory);
         var practitionerRole = (PractitionerRole) agents.get(2);
-        var coding = practitionerRole.getCode().get(0).getCoding().get(0);
+        var coding = practitionerRole.getCode().getFirst().getCoding().getFirst();
 
         assertAll(
-                () -> assertEquals("1234", coding.getCode()),
-                () -> assertEquals("http://read.info/readv2", coding.getSystem()),
-                () -> assertEquals("General practice", coding.getDisplay())
+            () -> assertEquals("1234", coding.getCode()),
+            () -> assertEquals("http://read.info/readv2", coding.getSystem()),
+            () -> assertEquals("General practice", coding.getDisplay())
         );
     }
 
@@ -419,19 +419,19 @@ public class AgentDirectoryMapperTest {
         var mappedAgents = agentDirectoryMapper.mapAgentDirectory(agentDirectory);
 
         var practitionerRole = (PractitionerRole) mappedAgents.get(2);
-        var coding = practitionerRole.getCode().get(0).getCoding().get(0);
+        var coding = practitionerRole.getCode().getFirst().getCoding().getFirst();
 
         assertAll(
-                () -> assertEquals("1234", coding.getCode()),
-                () -> assertEquals("urn:oid:1.2.3.4.5.6", coding.getSystem()),
-                () -> assertEquals("Other person", coding.getDisplay())
+            () -> assertEquals("1234", coding.getCode()),
+            () -> assertEquals("urn:oid:1.2.3.4.5.6", coding.getSystem()),
+            () -> assertEquals("Other person", coding.getDisplay())
         );
     }
 
     private void assertAddress(Address address) {
         assertEquals(AddressUse.WORK, address.getUse());
         assertEquals(AddressType.PHYSICAL, address.getType());
-        assertEquals("234 ASHTREE ROAD", address.getLine().get(0).getValue());
+        assertEquals("234 ASHTREE ROAD", address.getLine().getFirst().getValue());
         assertEquals("LEEDS", address.getLine().get(1).getValue());
         assertEquals("YORKSHIRE", address.getLine().get(2).getValue());
         assertEquals("LS12 3RT", address.getPostalCode());

--- a/gp2gp-translator/src/test/java/uk/nhs/adaptors/pss/translator/mapper/AllergyIntoleranceMapperTest.java
+++ b/gp2gp-translator/src/test/java/uk/nhs/adaptors/pss/translator/mapper/AllergyIntoleranceMapperTest.java
@@ -92,13 +92,13 @@ class AllergyIntoleranceMapperTest {
 
     public static final Function<RCMRMT030101UKEhrExtract, RCMRMT030101UKObservationStatement> GET_OBSERVATION_STATEMENT =
         extract -> extract
-            .getComponent().get(0)
+            .getComponent().getFirst()
             .getEhrFolder()
-            .getComponent().get(0)
+            .getComponent().getFirst()
             .getEhrComposition()
-            .getComponent().get(0)
+            .getComponent().getFirst()
             .getCompoundStatement()
-            .getComponent().get(0)
+            .getComponent().getFirst()
             .getObservationStatement();
 
     @Mock
@@ -133,18 +133,18 @@ class AllergyIntoleranceMapperTest {
             getEncounterList(), PRACTISE_CODE);
 
         assertThat(allergyIntolerances).hasSize(1);
-        final AllergyIntolerance allergyIntolerance = allergyIntolerances.get(0);
+        final AllergyIntolerance allergyIntolerance = allergyIntolerances.getFirst();
 
         assertFixedValues(allergyIntolerance);
         assertExtension(allergyIntolerance);
 
-        assertThat(allergyIntolerance.getCategory().get(0).getValue()).isEqualTo(MEDICATION);
+        assertThat(allergyIntolerance.getCategory().getFirst().getValue()).isEqualTo(MEDICATION);
         assertThat(allergyIntolerance.getAssertedDateElement().asStringValue()).isEqualTo("1978-12-31");
         assertThat(allergyIntolerance.getRecorder().getReference()).isEqualTo("Practitioner/2D70F602-6BB1-47E0-B2EC-39912A59787D");
         assertThat(allergyIntolerance.getOnsetDateTimeType().asStringValue())
             .isEqualTo(DateFormatUtil.parseToDateTimeType("19781231").asStringValue());
         assertThat(allergyIntolerance.getAsserter().getReference()).isEqualTo("Practitioner/2D70F602-6BB1-47E0-B2EC-39912A59787D");
-        assertThat(allergyIntolerance.getNote().get(0).getText()).isEqualTo(EPISODICITY_WITH_ORIGINAL_TEXT_NOTE_TEXT);
+        assertThat(allergyIntolerance.getNote().getFirst().getText()).isEqualTo(EPISODICITY_WITH_ORIGINAL_TEXT_NOTE_TEXT);
         assertThat(allergyIntolerance.getNote().get(1).getText()).isEqualTo(PERTINENT_NOTE_TEXT);
         assertThat(allergyIntolerance.getNote().get(2).getText()).isEqualTo(ALLERGY_NOTE_TEXT);
         assertThat(allergyIntolerance.getCode().getCodingFirstRep()).isEqualTo(DegradedCodeableConcepts.DEGRADED_DRUG_ALLERGY);
@@ -164,7 +164,7 @@ class AllergyIntoleranceMapperTest {
             getEncounterList(), PRACTISE_CODE);
 
         assertEquals(1, allergyIntolerances.size());
-        final AllergyIntolerance allergyIntolerance = allergyIntolerances.get(0);
+        final AllergyIntolerance allergyIntolerance = allergyIntolerances.getFirst();
 
         assertAll(
             () -> assertExtension(allergyIntolerance),
@@ -190,7 +190,7 @@ class AllergyIntoleranceMapperTest {
             getEncounterList(), PRACTISE_CODE);
 
         assertEquals(1, allergyIntolerances.size());
-        final AllergyIntolerance allergyIntolerance = allergyIntolerances.get(0);
+        final AllergyIntolerance allergyIntolerance = allergyIntolerances.getFirst();
 
         assertAll(
             () -> assertExtension(allergyIntolerance),
@@ -216,7 +216,7 @@ class AllergyIntoleranceMapperTest {
             getEncounterList(), PRACTISE_CODE);
 
         assertEquals(1, allergyIntolerances.size());
-        final AllergyIntolerance allergyIntolerance = allergyIntolerances.get(0);
+        final AllergyIntolerance allergyIntolerance = allergyIntolerances.getFirst();
 
         assertAll(
             () -> assertExtension(allergyIntolerance),
@@ -238,18 +238,18 @@ class AllergyIntoleranceMapperTest {
             = allergyIntoleranceMapper.mapResources(ehrExtract, getPatient(), getEncounterList(), PRACTISE_CODE);
 
         assertEquals(1, allergyIntolerances.size());
-        final AllergyIntolerance allergyIntolerance = allergyIntolerances.get(0);
+        final AllergyIntolerance allergyIntolerance = allergyIntolerances.getFirst();
 
         assertFixedValues(allergyIntolerance);
 
         assertExtension(allergyIntolerance);
-        assertEquals(ENVIRONMENT, allergyIntolerance.getCategory().get(0).getValue());
+        assertEquals(ENVIRONMENT, allergyIntolerance.getCategory().getFirst().getValue());
         assertEquals("1978-12-31", allergyIntolerance.getAssertedDateElement().asStringValue());
         assertEquals("Practitioner/2D70F602-6BB1-47E0-B2EC-39912A59787D", allergyIntolerance.getRecorder().getReference());
         assertEquals(DateFormatUtil.parseToDateTimeType("19781231").asStringValue(),
                                                     allergyIntolerance.getOnsetDateTimeType().asStringValue());
         assertEquals("Practitioner/2D70F602-6BB1-47E0-B2EC-39912A59787D", allergyIntolerance.getAsserter().getReference());
-        assertEquals(PERTINENT_NOTE_TEXT, allergyIntolerance.getNote().get(0).getText());
+        assertEquals(PERTINENT_NOTE_TEXT, allergyIntolerance.getNote().getFirst().getText());
         assertEquals(DegradedCodeableConcepts.DEGRADED_NON_DRUG_ALLERGY, allergyIntolerance.getCode().getCodingFirstRep());
         assertEquals(CODING_DISPLAY_1, allergyIntolerance.getCode().getCoding().get(1).getDisplay());
         verifyConfidentialityServiceCalled(1, Optional.empty(), Optional.empty());
@@ -266,7 +266,7 @@ class AllergyIntoleranceMapperTest {
             getEncounterList(), PRACTISE_CODE);
 
         assertThat(allergyIntolerances).hasSize(1);
-        final AllergyIntolerance allergyIntolerance = allergyIntolerances.get(0);
+        final AllergyIntolerance allergyIntolerance = allergyIntolerances.getFirst();
 
         assertThat(allergyIntolerance.getCode().getCodingFirstRep())
             .isEqualTo(DegradedCodeableConcepts.DEGRADED_NON_DRUG_ALLERGY);
@@ -283,7 +283,7 @@ class AllergyIntoleranceMapperTest {
                 getEncounterList(), PRACTISE_CODE);
 
         assertThat(allergyIntolerances).hasSize(1);
-        final AllergyIntolerance allergyIntolerance = allergyIntolerances.get(0);
+        final AllergyIntolerance allergyIntolerance = allergyIntolerances.getFirst();
 
         assertThat(allergyIntolerance.getCode().getCodingFirstRep())
             .isEqualTo(DegradedCodeableConcepts.DEGRADED_DRUG_ALLERGY);
@@ -303,7 +303,7 @@ class AllergyIntoleranceMapperTest {
             getEncounterList(), PRACTISE_CODE);
 
         assertThat(allergyIntolerances).hasSize(1);
-        final AllergyIntolerance allergyIntolerance = allergyIntolerances.get(0);
+        final AllergyIntolerance allergyIntolerance = allergyIntolerances.getFirst();
 
         assertFixedValues(allergyIntolerance);
 
@@ -322,7 +322,7 @@ class AllergyIntoleranceMapperTest {
             getEncounterList(), PRACTISE_CODE);
 
         assertThat(allergyIntolerances).hasSize(1);
-        final AllergyIntolerance allergyIntolerance = allergyIntolerances.get(0);
+        final AllergyIntolerance allergyIntolerance = allergyIntolerances.getFirst();
         assertFixedValues(allergyIntolerance);
         assertThat(allergyIntolerance.getCode().getCodingFirstRep()).isEqualTo(DegradedCodeableConcepts.DEGRADED_DRUG_ALLERGY);
         assertThat(allergyIntolerance.getCode().getCoding().get(1).getDisplay()).isEqualTo(CODING_DISPLAY_1);
@@ -345,7 +345,7 @@ class AllergyIntoleranceMapperTest {
             getEncounterList(), PRACTISE_CODE);
 
         assertThat(allergyIntolerances).hasSize(1);
-        final AllergyIntolerance allergyIntolerance = allergyIntolerances.get(0);
+        final AllergyIntolerance allergyIntolerance = allergyIntolerances.getFirst();
 
         assertFixedValues(allergyIntolerance);
 
@@ -384,7 +384,7 @@ class AllergyIntoleranceMapperTest {
         final List<AllergyIntolerance> allergyIntolerance = allergyIntoleranceMapper
             .mapResources(ehrExtract, getPatient(), getEncounterList(), PRACTISE_CODE);
 
-        final Meta meta = allergyIntolerance.get(0).getMeta();
+        final Meta meta = allergyIntolerance.getFirst().getMeta();
 
         assertMetaSecurityPresent(meta);
         verifyConfidentialityServiceCalled(1, ehrComposition.getConfidentialityCode(), Optional.empty());
@@ -406,7 +406,7 @@ class AllergyIntoleranceMapperTest {
         final List<AllergyIntolerance> allergyIntolerance = allergyIntoleranceMapper
             .mapResources(ehrExtract, getPatient(), getEncounterList(), PRACTISE_CODE);
 
-        final Meta meta = allergyIntolerance.get(0).getMeta();
+        final Meta meta = allergyIntolerance.getFirst().getMeta();
 
         assertMetaSecurityPresent(meta);
         verifyConfidentialityServiceCalled(1, Optional.empty(), observationStatement.getConfidentialityCode());
@@ -421,7 +421,7 @@ class AllergyIntoleranceMapperTest {
         final List<AllergyIntolerance> allergyIntolerance = allergyIntoleranceMapper
             .mapResources(ehrExtract, getPatient(), getEncounterList(), PRACTISE_CODE);
 
-        assertThat(allergyIntolerance.get(0).getMeta().getSecurity()).isEmpty();
+        assertThat(allergyIntolerance.getFirst().getMeta().getSecurity()).isEmpty();
         verifyConfidentialityServiceCalled(1, Optional.empty(), observationStatement.getConfidentialityCode());
     }
 
@@ -435,7 +435,7 @@ class AllergyIntoleranceMapperTest {
         final List<AllergyIntolerance> allergyIntolerances = allergyIntoleranceMapper.mapResources(ehrExtract, getPatient(),
             getEncounterList(), PRACTISE_CODE);
 
-        final AllergyIntolerance allergyIntolerance = allergyIntolerances.get(0);
+        final AllergyIntolerance allergyIntolerance = allergyIntolerances.getFirst();
         assertThat(allergyIntolerance.getExtension()).isEmpty();
         verifyConfidentialityServiceCalled(1, Optional.empty(), Optional.empty());
     }
@@ -451,18 +451,18 @@ class AllergyIntoleranceMapperTest {
             getEncounterList(), PRACTISE_CODE);
 
         assertThat(allergyIntolerances).hasSize(1);
-        final AllergyIntolerance allergyIntolerance = allergyIntolerances.get(0);
+        final AllergyIntolerance allergyIntolerance = allergyIntolerances.getFirst();
 
         assertFixedValues(allergyIntolerance);
 
         assertExtension(allergyIntolerance);
-        assertThat(allergyIntolerance.getCategory().get(0).getValue()).isEqualTo(MEDICATION);
+        assertThat(allergyIntolerance.getCategory().getFirst().getValue()).isEqualTo(MEDICATION);
         assertThat(allergyIntolerance.getAssertedDateElement().asStringValue()).isEqualTo("1978-12-31");
         assertThat(allergyIntolerance.getRecorder().getReference()).isEqualTo("Practitioner/2D70F602-6BB1-47E0-B2EC-39912A59787D");
         assertThat(allergyIntolerance.getOnsetDateTimeType().asStringValue())
             .isEqualTo(DateFormatUtil.parseToDateTimeType("19781231").asStringValue());
         assertThat(allergyIntolerance.getAsserter().getReference()).isEqualTo("Practitioner/2D70F602-6BB1-47E0-B2EC-39912A59787D");
-        assertThat(allergyIntolerance.getNote().get(0).getText()).isEqualTo(PERTINENT_NOTE_TEXT);
+        assertThat(allergyIntolerance.getNote().getFirst().getText()).isEqualTo(PERTINENT_NOTE_TEXT);
         assertThat(allergyIntolerance.getCode().getCodingFirstRep()).isEqualTo(DegradedCodeableConcepts.DEGRADED_DRUG_ALLERGY);
         assertThat(allergyIntolerance.getCode().getCoding().get(1).getDisplay()).isEqualTo(CODING_DISPLAY_1);
         assertThat(allergyIntolerance.getNote().size()).isOne();
@@ -481,18 +481,18 @@ class AllergyIntoleranceMapperTest {
             getEncounterList(), PRACTISE_CODE);
 
         assertThat(allergyIntolerances).hasSize(1);
-        final AllergyIntolerance allergyIntolerance = allergyIntolerances.get(0);
+        final AllergyIntolerance allergyIntolerance = allergyIntolerances.getFirst();
 
         assertFixedValues(allergyIntolerance);
 
         assertExtension(allergyIntolerance);
-        assertThat(allergyIntolerance.getCategory().get(0).getValue()).isEqualTo(MEDICATION);
+        assertThat(allergyIntolerance.getCategory().getFirst().getValue()).isEqualTo(MEDICATION);
         assertThat(allergyIntolerance.getAssertedDateElement().asStringValue()).isEqualTo("1978-12-31");
         assertThat(allergyIntolerance.getRecorder().getReference()).isEqualTo("Practitioner/2D70F602-6BB1-47E0-B2EC-39912A59787D");
         assertThat(allergyIntolerance.getOnsetDateTimeType().asStringValue())
             .isEqualTo(DateFormatUtil.parseToDateTimeType("19781231").asStringValue());
         assertThat(allergyIntolerance.getAsserter().getReference()).isEqualTo("Practitioner/2D70F602-6BB1-47E0-B2EC-39912A59787D");
-        assertThat(allergyIntolerance.getNote().get(0).getText()).isEqualTo(PERTINENT_NOTE_TEXT);
+        assertThat(allergyIntolerance.getNote().getFirst().getText()).isEqualTo(PERTINENT_NOTE_TEXT);
         assertThat(allergyIntolerance.getCode().getCodingFirstRep()).isEqualTo(DegradedCodeableConcepts.DEGRADED_DRUG_ALLERGY);
         assertThat(allergyIntolerance.getCode().getCoding().get(1).getDisplay()).isEqualTo(CODING_DISPLAY_3);
         assertThat(allergyIntolerance.getNote().size()).isOne();
@@ -511,7 +511,7 @@ class AllergyIntoleranceMapperTest {
             getEncounterList(), PRACTISE_CODE);
 
         assertThat(allergyIntolerances).hasSize(1);
-        final AllergyIntolerance allergyIntolerance = allergyIntolerances.get(0);
+        final AllergyIntolerance allergyIntolerance = allergyIntolerances.getFirst();
 
         assertFixedValues(allergyIntolerance);
 
@@ -531,9 +531,9 @@ class AllergyIntoleranceMapperTest {
         final List<AllergyIntolerance> allergyIntolerances = allergyIntoleranceMapper.mapResources(ehrExtract, getPatient(),
             getEncounterList(), PRACTISE_CODE);
 
-        final AllergyIntolerance allergyIntolerance = allergyIntolerances.get(0);
+        final AllergyIntolerance allergyIntolerance = allergyIntolerances.getFirst();
 
-        assertThat(allergyIntolerance.getNote().get(0).getText()).isEqualTo(EPISODICITY_WITH_ORIGINAL_TEXT_NOTE_TEXT);
+        assertThat(allergyIntolerance.getNote().getFirst().getText()).isEqualTo(EPISODICITY_WITH_ORIGINAL_TEXT_NOTE_TEXT);
         verifyConfidentialityServiceCalled(1, Optional.empty(), Optional.empty());
     }
 
@@ -547,9 +547,9 @@ class AllergyIntoleranceMapperTest {
         final List<AllergyIntolerance> allergyIntolerances = allergyIntoleranceMapper.mapResources(ehrExtract, getPatient(),
             getEncounterList(), PRACTISE_CODE);
 
-        final AllergyIntolerance allergyIntolerance = allergyIntolerances.get(0);
+        final AllergyIntolerance allergyIntolerance = allergyIntolerances.getFirst();
 
-        assertThat(allergyIntolerance.getNote().get(0).getText()).isEqualTo(EPISODICITY_WITHOUT_ORIGINAL_TEXT_NOTE_TEXT);
+        assertThat(allergyIntolerance.getNote().getFirst().getText()).isEqualTo(EPISODICITY_WITHOUT_ORIGINAL_TEXT_NOTE_TEXT);
         verifyConfidentialityServiceCalled(1, Optional.empty(), Optional.empty());
     }
 
@@ -572,7 +572,7 @@ class AllergyIntoleranceMapperTest {
         assertThat(cd.getDisplayName()).isEqualTo(CODING_DISPLAY_4);
         assertThat(cd.getTranslation().size()).isOne();
 
-        final CD translation = cd.getTranslation().get(0);
+        final CD translation = cd.getTranslation().getFirst();
 
         assertThat(translation.getCodeSystem()).isEqualTo(SNOMED_CODE_SYSTEM);
         assertThat(translation.getCode()).isEqualTo(SNOMED_COCONUT_OIL);
@@ -589,7 +589,7 @@ class AllergyIntoleranceMapperTest {
 
     private void assertFixedValues(AllergyIntolerance allergyIntolerance) {
         assertThat(allergyIntolerance.getId()).isEqualTo(COMPOUND_STATEMENT_ROOT_ID);
-        assertThat(allergyIntolerance.getMeta().getProfile().get(0).getValue()).isEqualTo(META_PROFILE);
+        assertThat(allergyIntolerance.getMeta().getProfile().getFirst().getValue()).isEqualTo(META_PROFILE);
         assertIdentifier(allergyIntolerance.getIdentifierFirstRep(), allergyIntolerance.getId());
         assertThat(allergyIntolerance.getClinicalStatus()).isEqualTo(ACTIVE);
         assertThat(allergyIntolerance.getVerificationStatus()).isEqualTo(UNCONFIRMED);
@@ -611,11 +611,11 @@ class AllergyIntoleranceMapperTest {
     private void assertMetaSecurityPresent(Meta meta) {
         assertAll(
             () -> assertThat(meta.getSecurity()).hasSize(1),
-            () -> assertThat(meta.getSecurity().get(0).getCode())
+            () -> assertThat(meta.getSecurity().getFirst().getCode())
                 .isEqualTo("NOPAT"),
-            () -> assertThat(meta.getSecurity().get(0).getSystem())
+            () -> assertThat(meta.getSecurity().getFirst().getSystem())
                 .isEqualTo("http://hl7.org/fhir/v3/ActCode"),
-            () -> assertThat(meta.getSecurity().get(0).getDisplay())
+            () -> assertThat(meta.getSecurity().getFirst().getDisplay())
                 .isEqualTo("no disclosure to patient, family or caregivers without attending provider's authorization")
         );
     }

--- a/gp2gp-translator/src/test/java/uk/nhs/adaptors/pss/translator/mapper/BloodPressureMapperTest.java
+++ b/gp2gp-translator/src/test/java/uk/nhs/adaptors/pss/translator/mapper/BloodPressureMapperTest.java
@@ -120,27 +120,28 @@ public class BloodPressureMapperTest {
     public void mapBloodPressureObservationWithValidData() {
         var ehrExtract = unmarshallEhrExtractElement("full_valid_data_bp_example.xml");
 
-        var bloodPressure = bloodPressureMapper.mapResources(ehrExtract, patient, ENCOUNTER_LIST, PRACTISE_CODE).get(0);
+        var bloodPressure = bloodPressureMapper.mapResources(ehrExtract, patient, ENCOUNTER_LIST, PRACTISE_CODE).getFirst();
 
         assertFixedValues(bloodPressure);
         assertThat(bloodPressure.getId()).isEqualTo(EXAMPLE_ID);
-        assertThat(bloodPressure.getComponent().get(0).getCode().getCodingFirstRep())
+        assertThat(bloodPressure.getComponent().getFirst().getCode().getCodingFirstRep())
             .isEqualTo(DegradedCodeableConcepts.DEGRADED_OTHER);
-        assertThat(bloodPressure.getComponent().get(0).getCode().getCoding().get(1).getDisplay())
+        assertThat(bloodPressure.getComponent().getFirst().getCode().getCoding().get(1).getDisplay())
             .isEqualTo(CODING_DISPLAY_MOCK);
         assertThat(bloodPressure.hasSubject()).isTrue();
         assertThat(bloodPressure.getIssuedElement().asStringValue()).isEqualTo(ISSUED_EXAMPLE);
         assertThat(bloodPressure.getEffective().toString()).isEqualTo(DateFormatUtil.parseToDateTimeType(EFFECTIVE_EXAMPLE).toString());
-        assertThat(bloodPressure.getPerformer().get(0).getReference()).isEqualTo(PPRF_PARTICIPANT_ID);
+        assertThat(bloodPressure.getPerformer().getFirst().getReference()).isEqualTo(PPRF_PARTICIPANT_ID);
         assertThat(bloodPressure.getComment()).isEqualTo(COMMENT_EXAMPLE_1);
 
-        assertThat(bloodPressure.getComponent().get(0).getCode().getCodingFirstRep())
+        assertThat(bloodPressure.getComponent().getFirst().getCode().getCodingFirstRep())
             .isEqualTo(DegradedCodeableConcepts.DEGRADED_OTHER);
-        assertThat(bloodPressure.getComponent().get(0).getCode().getCoding().get(1).getDisplay())
+        assertThat(bloodPressure.getComponent().getFirst().getCode().getCoding().get(1).getDisplay())
             .isEqualTo(CODING_DISPLAY_MOCK);
-        assertThat(bloodPressure.getComponent().get(0).getValueQuantity().getValue()).isEqualTo(COMPONENT_1_VALUE_QUANTITY_VALUE);
-        assertThat(bloodPressure.getComponent().get(0).getInterpretation().getText()).isEqualTo(COMPONENT_1_INTERPRETATION_TEXT);
-        assertThat(bloodPressure.getComponent().get(0).getReferenceRange().get(0).getText()).isEqualTo(COMPONENT_1_REFERENCE_RANGE_TEXT);
+        assertThat(bloodPressure.getComponent().getFirst().getValueQuantity().getValue()).isEqualTo(COMPONENT_1_VALUE_QUANTITY_VALUE);
+        assertThat(bloodPressure.getComponent().getFirst().getInterpretation().getText()).isEqualTo(COMPONENT_1_INTERPRETATION_TEXT);
+        assertThat(bloodPressure.getComponent().getFirst().getReferenceRange().getFirst().getText())
+            .isEqualTo(COMPONENT_1_REFERENCE_RANGE_TEXT);
 
         assertThat(bloodPressure.getComponent().get(1).getCode().getCodingFirstRep())
             .isEqualTo(DegradedCodeableConcepts.DEGRADED_OTHER);
@@ -148,14 +149,15 @@ public class BloodPressureMapperTest {
             .isEqualTo(CODING_DISPLAY_MOCK);
         assertThat(bloodPressure.getComponent().get(1).getValueQuantity().getValue()).isEqualTo(COMPONENT_2_VALUE_QUANTITY_VALUE);
         assertThat(bloodPressure.getComponent().get(1).getInterpretation().getText()).isEqualTo(COMPONENT_2_INTERPRETATION_TEXT);
-        assertThat(bloodPressure.getComponent().get(1).getReferenceRange().get(0).getText()).isEqualTo(COMPONENT_2_REFERENCE_RANGE_TEXT);
+        assertThat(bloodPressure.getComponent().get(1).getReferenceRange().getFirst().getText())
+            .isEqualTo(COMPONENT_2_REFERENCE_RANGE_TEXT);
     }
 
     @Test
     public void mapBloodPressureWithNoOptionalData() {
         var ehrExtract = unmarshallEhrExtractElement("no_optional_data_bp_example.xml");
 
-        var bloodPressure = bloodPressureMapper.mapResources(ehrExtract, patient, ENCOUNTER_LIST, PRACTISE_CODE).get(0);
+        var bloodPressure = bloodPressureMapper.mapResources(ehrExtract, patient, ENCOUNTER_LIST, PRACTISE_CODE).getFirst();
 
         assertFixedValues(bloodPressure);
         assertThat(bloodPressure.getId()).isEqualTo(EXAMPLE_ID);
@@ -163,18 +165,18 @@ public class BloodPressureMapperTest {
         assertThat(bloodPressure.getCode().getCoding().get(1).getDisplay()).isEqualTo(CODING_DISPLAY_MOCK);
         assertThat(bloodPressure.hasSubject()).isTrue();
         assertThat(bloodPressure.getIssuedElement().asStringValue()).isEqualTo(ISSUED_EXAMPLE);
-        assertThat(bloodPressure.getPerformer().get(0).getReference()).isEqualTo(PPRF_PARTICIPANT_ID);
+        assertThat(bloodPressure.getPerformer().getFirst().getReference()).isEqualTo(PPRF_PARTICIPANT_ID);
 
         assertThat(bloodPressure.getEffective()).isNull();
         assertThat(StringUtils.isEmpty(bloodPressure.getComment())).isTrue();
 
-        assertThat(bloodPressure.getComponent().get(0).getCode().getCodingFirstRep())
+        assertThat(bloodPressure.getComponent().getFirst().getCode().getCodingFirstRep())
             .isEqualTo(DegradedCodeableConcepts.DEGRADED_OTHER);
-        assertThat(bloodPressure.getComponent().get(0).getCode().getCoding().get(1).getDisplay())
+        assertThat(bloodPressure.getComponent().getFirst().getCode().getCoding().get(1).getDisplay())
             .isEqualTo(CODING_DISPLAY_MOCK);
-        assertThat(bloodPressure.getComponent().get(0).getValueQuantity()).isNull();
-        assertThat(bloodPressure.getComponent().get(0).getInterpretation().getCoding()).isEmpty();
-        assertThat(bloodPressure.getComponent().get(0).getReferenceRange()).isEmpty();
+        assertThat(bloodPressure.getComponent().getFirst().getValueQuantity()).isNull();
+        assertThat(bloodPressure.getComponent().getFirst().getInterpretation().getCoding()).isEmpty();
+        assertThat(bloodPressure.getComponent().getFirst().getReferenceRange()).isEmpty();
 
         assertThat(bloodPressure.getComponent().get(1).getCode().getCodingFirstRep())
             .isEqualTo(DegradedCodeableConcepts.DEGRADED_OTHER);
@@ -209,7 +211,7 @@ public class BloodPressureMapperTest {
 
         final var bloodPressure = bloodPressureMapper
             .mapResources(ehrExtract, patient, ENCOUNTER_LIST, PRACTISE_CODE)
-            .get(0);
+            .getFirst();
 
         assertAll(
             () -> assertThat(confidentialityCodesCaptor.getAllValues())
@@ -244,7 +246,7 @@ public class BloodPressureMapperTest {
     public void mapBloodPressureObservationWithCompositionIdMatchingEncounter() {
         var ehrExtract = unmarshallEhrExtractElement("ehr_composition_id_matching_encounter_bp_example.xml");
 
-        var bloodPressure = bloodPressureMapper.mapResources(ehrExtract, patient, ENCOUNTER_LIST, PRACTISE_CODE).get(0);
+        var bloodPressure = bloodPressureMapper.mapResources(ehrExtract, patient, ENCOUNTER_LIST, PRACTISE_CODE).getFirst();
 
         assertThat(bloodPressure.hasContext()).isTrue();
     }
@@ -253,7 +255,7 @@ public class BloodPressureMapperTest {
     public void mapBloodPressureObservationWithSystolicOnlyComment() {
         var ehrExtract = unmarshallEhrExtractElement("systolic_comment_only_bp_example.xml");
 
-        var bloodPressure = bloodPressureMapper.mapResources(ehrExtract, patient, ENCOUNTER_LIST, PRACTISE_CODE).get(0);
+        var bloodPressure = bloodPressureMapper.mapResources(ehrExtract, patient, ENCOUNTER_LIST, PRACTISE_CODE).getFirst();
 
         assertThat(bloodPressure.getComment()).isEqualTo(COMMENT_EXAMPLE_2);
     }
@@ -262,7 +264,7 @@ public class BloodPressureMapperTest {
     public void mapBloodPressureObservationWithDiastolicOnlyComment() {
         var ehrExtract = unmarshallEhrExtractElement("diastolic_comment_only_blood_pressure_example.xml");
 
-        var bloodPressure = bloodPressureMapper.mapResources(ehrExtract, patient, ENCOUNTER_LIST, PRACTISE_CODE).get(0);
+        var bloodPressure = bloodPressureMapper.mapResources(ehrExtract, patient, ENCOUNTER_LIST, PRACTISE_CODE).getFirst();
 
         assertThat(bloodPressure.getComment()).isEqualTo(COMMENT_EXAMPLE_3);
     }
@@ -271,7 +273,7 @@ public class BloodPressureMapperTest {
     public void mapBloodPressureObservationWithNarrativeStatementOnlyComment() {
         var ehrExtract = unmarshallEhrExtractElement("narrative_statement_comment_only_bp_example.xml");
 
-        var bloodPressure = bloodPressureMapper.mapResources(ehrExtract, patient, ENCOUNTER_LIST, PRACTISE_CODE).get(0);
+        var bloodPressure = bloodPressureMapper.mapResources(ehrExtract, patient, ENCOUNTER_LIST, PRACTISE_CODE).getFirst();
 
         assertThat(bloodPressure.getComment()).isEqualTo(COMMENT_EXAMPLE_4);
     }
@@ -281,7 +283,7 @@ public class BloodPressureMapperTest {
         var ehrExtract = unmarshallEhrExtractElement(
             "effective_date_time_using_effective_time_center_bp_example.xml");
 
-        var bloodPressure = bloodPressureMapper.mapResources(ehrExtract, patient, ENCOUNTER_LIST, PRACTISE_CODE).get(0);
+        var bloodPressure = bloodPressureMapper.mapResources(ehrExtract, patient, ENCOUNTER_LIST, PRACTISE_CODE).getFirst();
 
         assertThat(bloodPressure.getEffective()).isInstanceOf(DateTimeType.class);
         assertThat(bloodPressure.getEffectiveDateTimeType().getValueAsString()).isEqualTo("2006-04-25");
@@ -292,7 +294,7 @@ public class BloodPressureMapperTest {
         var ehrExtract = unmarshallEhrExtractElement(
             "effective_period_start_end_using_effective_time_bp_example.xml");
 
-        var bloodPressure = bloodPressureMapper.mapResources(ehrExtract, patient, ENCOUNTER_LIST, PRACTISE_CODE).get(0);
+        var bloodPressure = bloodPressureMapper.mapResources(ehrExtract, patient, ENCOUNTER_LIST, PRACTISE_CODE).getFirst();
 
         assertThat(bloodPressure.getEffective()).isInstanceOf(Period.class);
         assertThat(bloodPressure.getEffectivePeriod().getStartElement().getValueAsString()).isEqualTo("2006-04-25");
@@ -312,15 +314,15 @@ public class BloodPressureMapperTest {
     public void mapBloodPressureWithNoSnomedCodeInCoding() {
         var ehrExtract = unmarshallEhrExtractElement("full_valid_data_bp_example.xml");
 
-        var bloodPressure = bloodPressureMapper.mapResources(ehrExtract, patient, ENCOUNTER_LIST, PRACTISE_CODE).get(0);
+        var bloodPressure = bloodPressureMapper.mapResources(ehrExtract, patient, ENCOUNTER_LIST, PRACTISE_CODE).getFirst();
 
         assertThat(bloodPressure.getCode().getCodingFirstRep())
             .isEqualTo(DegradedCodeableConcepts.DEGRADED_OTHER);
         assertThat(bloodPressure.getCode().getCoding().get(1).getDisplay())
             .isEqualTo(CODING_DISPLAY_MOCK);
-        assertThat(bloodPressure.getComponent().get(0).getCode().getCodingFirstRep())
+        assertThat(bloodPressure.getComponent().getFirst().getCode().getCodingFirstRep())
             .isEqualTo(DegradedCodeableConcepts.DEGRADED_OTHER);
-        assertThat(bloodPressure.getComponent().get(0).getCode().getCoding().get(1).getDisplay())
+        assertThat(bloodPressure.getComponent().getFirst().getCode().getCoding().get(1).getDisplay())
             .isEqualTo(CODING_DISPLAY_MOCK);
         assertThat(bloodPressure.getComponent().get(1).getCode().getCodingFirstRep())
             .isEqualTo(DegradedCodeableConcepts.DEGRADED_OTHER);
@@ -335,19 +337,19 @@ public class BloodPressureMapperTest {
 
         var ehrExtract = unmarshallEhrExtractElement("full_valid_data_bp_example.xml");
 
-        var bloodPressure = bloodPressureMapper.mapResources(ehrExtract, patient, ENCOUNTER_LIST, PRACTISE_CODE).get(0);
+        var bloodPressure = bloodPressureMapper.mapResources(ehrExtract, patient, ENCOUNTER_LIST, PRACTISE_CODE).getFirst();
 
         assertAll(
             () -> assertEquals(codeableConcept, bloodPressure.getCode()),
-            () -> assertEquals(codeableConcept, bloodPressure.getComponent().get(0).getCode()),
+            () -> assertEquals(codeableConcept, bloodPressure.getComponent().getFirst().getCode()),
             () -> assertEquals(codeableConcept, bloodPressure.getComponent().get(1).getCode())
         );
     }
 
     private void assertFixedValues(Observation bloodPressure) {
-        assertThat(bloodPressure.getMeta().getProfile().get(0).getValue()).isEqualTo(META_PROFILE);
-        assertThat(bloodPressure.getIdentifier().get(0).getSystem()).isEqualTo(IDENTIFIER_SYSTEM);
-        assertThat(bloodPressure.getIdentifier().get(0).getValue()).isEqualTo(EXAMPLE_ID);
+        assertThat(bloodPressure.getMeta().getProfile().getFirst().getValue()).isEqualTo(META_PROFILE);
+        assertThat(bloodPressure.getIdentifier().getFirst().getSystem()).isEqualTo(IDENTIFIER_SYSTEM);
+        assertThat(bloodPressure.getIdentifier().getFirst().getValue()).isEqualTo(EXAMPLE_ID);
         assertThat(bloodPressure.getStatus()).isEqualTo(Observation.ObservationStatus.FINAL);
     }
 

--- a/gp2gp-translator/src/test/java/uk/nhs/adaptors/pss/translator/mapper/CodeableConceptMapperTest.java
+++ b/gp2gp-translator/src/test/java/uk/nhs/adaptors/pss/translator/mapper/CodeableConceptMapperTest.java
@@ -65,13 +65,13 @@ public class CodeableConceptMapperTest {
         var codedData = unmarshallCodeElementFromXMLString(XML_HEADER + inputXML);
         CodeableConcept codeableConcept = codeableConceptMapper.mapToCodeableConcept(codedData);
 
-        assertThat(codeableConcept.getCoding().get(0).getCode())
+        assertThat(codeableConcept.getCoding().getFirst().getCode())
             .isEqualTo(CONCEPT_ID);
-        assertThat(codeableConcept.getCoding().get(0).getDisplay())
+        assertThat(codeableConcept.getCoding().getFirst().getDisplay())
             .isEqualTo(SNOMED_PREFERRED.getTerm());
-        assertThat(codeableConcept.getCoding().get(0).getExtension().get(0).getExtension().get(0).getUrl())
+        assertThat(codeableConcept.getCoding().getFirst().getExtension().getFirst().getExtension().getFirst().getUrl())
             .isEqualTo(DESCRIPTION_ID);
-        assertThat(codeableConcept.getCoding().get(0).getExtension().get(0).getExtension().get(0).getValue())
+        assertThat(codeableConcept.getCoding().getFirst().getExtension().getFirst().getExtension().getFirst().getValue())
             .isEqualTo(new IdType(SNOMED_PREFERRED.getId()));
         assertThat(codeableConcept.getText())
             .isEqualTo(ORIGINAL_TEXT);
@@ -91,19 +91,19 @@ public class CodeableConceptMapperTest {
         var codedData = unmarshallCodeElementFromXMLString(XML_HEADER + inputXML);
         CodeableConcept codeableConcept = codeableConceptMapper.mapToCodeableConcept(codedData);
 
-        assertThat(codeableConcept.getCoding().get(0).getCode())
+        assertThat(codeableConcept.getCoding().getFirst().getCode())
             .isEqualTo("22298006");
-        assertThat(codeableConcept.getCoding().get(0).getDisplay())
+        assertThat(codeableConcept.getCoding().getFirst().getDisplay())
             .isEqualTo(SNOMED_PREFERRED.getTerm());
-        assertThat(codeableConcept.getCoding().get(0).getExtension().get(0).getExtension().size() == 2)
+        assertThat(codeableConcept.getCoding().getFirst().getExtension().getFirst().getExtension().size() == 2)
             .isTrue();
-        assertThat(codeableConcept.getCoding().get(0).getExtension().get(0).getExtension().get(0).getUrl())
+        assertThat(codeableConcept.getCoding().getFirst().getExtension().getFirst().getExtension().getFirst().getUrl())
             .isEqualTo(DESCRIPTION_ID);
-        assertThat(codeableConcept.getCoding().get(0).getExtension().get(0).getExtension().get(0).getValue())
+        assertThat(codeableConcept.getCoding().getFirst().getExtension().getFirst().getExtension().getFirst().getValue())
             .isEqualTo(new IdType(SNOMED_DESCRIPTION.getId()));
-        assertThat(codeableConcept.getCoding().get(0).getExtension().get(0).getExtension().get(1).getUrl())
+        assertThat(codeableConcept.getCoding().getFirst().getExtension().getFirst().getExtension().get(1).getUrl())
             .isEqualTo(DESCRIPTION_DISPLAY);
-        assertThat(codeableConcept.getCoding().get(0).getExtension().get(0).getExtension().get(1).getValue()
+        assertThat(codeableConcept.getCoding().getFirst().getExtension().getFirst().getExtension().get(1).getValue()
             .toString()).isEqualTo(SNOMED_DESCRIPTION.getTerm());
         assertThat(codeableConcept.getText())
             .isEqualTo(ORIGINAL_TEXT);
@@ -123,15 +123,15 @@ public class CodeableConceptMapperTest {
         var codedData = unmarshallCodeElementFromXMLString(XML_HEADER + inputXML);
         CodeableConcept codeableConcept = codeableConceptMapper.mapToCodeableConcept(codedData);
 
-        assertThat(codeableConcept.getCoding().get(0).getCode())
+        assertThat(codeableConcept.getCoding().getFirst().getCode())
             .isEqualTo(CONCEPT_ID);
-        assertThat(codeableConcept.getCoding().get(0).getDisplay())
+        assertThat(codeableConcept.getCoding().getFirst().getDisplay())
             .isEqualTo(DISPLAY_NAME_1);
-        assertThat(codeableConcept.getCoding().get(0).getExtension().get(0).getExtension().size() == 1)
+        assertThat(codeableConcept.getCoding().getFirst().getExtension().getFirst().getExtension().size() == 1)
             .isTrue();
-        assertThat(codeableConcept.getCoding().get(0).getExtension().get(0).getExtension().get(0).getUrl())
+        assertThat(codeableConcept.getCoding().getFirst().getExtension().getFirst().getExtension().getFirst().getUrl())
             .isEqualTo(DESCRIPTION_DISPLAY);
-        assertThat(codeableConcept.getCoding().get(0).getExtension().get(0).getExtension().get(0).getValue().toString())
+        assertThat(codeableConcept.getCoding().getFirst().getExtension().getFirst().getExtension().getFirst().getValue().toString())
             .isEqualTo((SNOMED_PREFERRED.getTerm()));
         assertThat(codeableConcept.getText())
             .isEqualTo(ORIGINAL_TEXT);
@@ -149,15 +149,15 @@ public class CodeableConceptMapperTest {
         var codedData = unmarshallCodeElementFromXMLString(XML_HEADER + inputXML);
         CodeableConcept codeableConcept = codeableConceptMapper.mapToCodeableConcept(codedData);
 
-        assertThat(codeableConcept.getCoding().get(0).getCode())
+        assertThat(codeableConcept.getCoding().getFirst().getCode())
             .isEqualTo(CONCEPT_ID);
-        assertThat(codeableConcept.getCoding().get(0).getDisplay())
+        assertThat(codeableConcept.getCoding().getFirst().getDisplay())
             .isEqualTo(DISPLAY_NAME_1);
-        assertThat(codeableConcept.getCoding().get(0).getExtension().get(0).getExtension().size() == 1)
+        assertThat(codeableConcept.getCoding().getFirst().getExtension().getFirst().getExtension().size() == 1)
             .isTrue();
-        assertThat(codeableConcept.getCoding().get(0).getExtension().get(0).getExtension().get(0).getUrl())
+        assertThat(codeableConcept.getCoding().getFirst().getExtension().getFirst().getExtension().getFirst().getUrl())
             .isEqualTo(DESCRIPTION_DISPLAY);
-        assertThat(codeableConcept.getCoding().get(0).getExtension().get(0).getExtension().get(0).getValue().toString())
+        assertThat(codeableConcept.getCoding().getFirst().getExtension().getFirst().getExtension().getFirst().getValue().toString())
             .isEqualTo((SNOMED_PREFERRED.getTerm()));
         assertThat(codeableConcept.getText())
             .isEqualTo(DISPLAY_NAME_1);
@@ -176,15 +176,15 @@ public class CodeableConceptMapperTest {
         var codedData = unmarshallCodeElementFromXMLString(XML_HEADER + inputXML);
         CodeableConcept codeableConcept = codeableConceptMapper.mapToCodeableConcept(codedData);
 
-        assertThat(codeableConcept.getCoding().get(0).getCode())
+        assertThat(codeableConcept.getCoding().getFirst().getCode())
             .isEqualTo(CONCEPT_ID);
-        assertThat(codeableConcept.getCoding().get(0).getDisplay())
+        assertThat(codeableConcept.getCoding().getFirst().getDisplay())
             .isEqualTo(DISPLAY_NAME_1);
-        assertThat(codeableConcept.getCoding().get(0).getExtension().get(0).getExtension().size() == 1)
+        assertThat(codeableConcept.getCoding().getFirst().getExtension().getFirst().getExtension().size() == 1)
             .isTrue();
-        assertThat(codeableConcept.getCoding().get(0).getExtension().get(0).getExtension().get(0).getUrl())
+        assertThat(codeableConcept.getCoding().getFirst().getExtension().getFirst().getExtension().getFirst().getUrl())
             .isEqualTo(DESCRIPTION_ID);
-        assertThat(codeableConcept.getCoding().get(0).getExtension().get(0).getExtension().get(0).getValue())
+        assertThat(codeableConcept.getCoding().getFirst().getExtension().getFirst().getExtension().getFirst().getValue())
             .isEqualTo(new IdType(SNOMED_DESCRIPTION.getId()));
     }
 
@@ -206,11 +206,11 @@ public class CodeableConceptMapperTest {
             .isEqualTo(CONCEPT_ID);
         assertThat(codeableConcept.getCoding().get(1).getDisplay())
             .isEqualTo(DISPLAY_NAME_1);
-        assertThat(codeableConcept.getCoding().get(1).getExtension().get(0).getExtension().size() == 1)
+        assertThat(codeableConcept.getCoding().get(1).getExtension().getFirst().getExtension().size() == 1)
             .isTrue();
-        assertThat(codeableConcept.getCoding().get(1).getExtension().get(0).getExtension().get(0).getUrl())
+        assertThat(codeableConcept.getCoding().get(1).getExtension().getFirst().getExtension().getFirst().getUrl())
             .isEqualTo(DESCRIPTION_DISPLAY);
-        assertThat(codeableConcept.getCoding().get(1).getExtension().get(0).getExtension().get(0).getValue().toString())
+        assertThat(codeableConcept.getCoding().get(1).getExtension().getFirst().getExtension().getFirst().getValue().toString())
             .isEqualTo((SNOMED_DESCRIPTION.getTerm()));
         assertThat(codeableConcept.getText())
             .isEqualTo(ORIGINAL_TEXT);
@@ -233,11 +233,11 @@ public class CodeableConceptMapperTest {
             .isEqualTo(CONCEPT_ID);
         assertThat(codeableConcept.getCoding().get(1).getDisplay())
             .isEqualTo(DISPLAY_NAME_1);
-        assertThat(codeableConcept.getCoding().get(1).getExtension().get(0).getExtension().size() == 1)
+        assertThat(codeableConcept.getCoding().get(1).getExtension().getFirst().getExtension().size() == 1)
             .isTrue();
-        assertThat(codeableConcept.getCoding().get(1).getExtension().get(0).getExtension().get(0).getUrl())
+        assertThat(codeableConcept.getCoding().get(1).getExtension().getFirst().getExtension().getFirst().getUrl())
             .isEqualTo(DESCRIPTION_DISPLAY);
-        assertThat(codeableConcept.getCoding().get(1).getExtension().get(0).getExtension().get(0).getValue().toString())
+        assertThat(codeableConcept.getCoding().get(1).getExtension().getFirst().getExtension().getFirst().getValue().toString())
             .isEqualTo((SNOMED_DESCRIPTION.getTerm()));
         assertThat(codeableConcept.getText())
             .isEqualTo(DISPLAY_NAME_2);
@@ -257,11 +257,11 @@ public class CodeableConceptMapperTest {
         var codedData = unmarshallCodeElementFromXMLString(XML_HEADER + inputXML);
         CodeableConcept codeableConcept = codeableConceptMapper.mapToCodeableConcept(codedData);
 
-        assertThat(codeableConcept.getCoding().get(0).getCode())
+        assertThat(codeableConcept.getCoding().getFirst().getCode())
             .isEqualTo(CONCEPT_ID);
-        assertThat(codeableConcept.getCoding().get(0).getDisplay())
+        assertThat(codeableConcept.getCoding().getFirst().getDisplay())
             .isEqualTo(DISPLAY_NAME_1);
-        assertThat(codeableConcept.getCoding().get(0).getExtension())
+        assertThat(codeableConcept.getCoding().getFirst().getExtension())
             .isNullOrEmpty();
         assertThat(codeableConcept.getText())
             .isEqualTo(ORIGINAL_TEXT);
@@ -279,11 +279,11 @@ public class CodeableConceptMapperTest {
         var codedData = unmarshallCodeElementFromXMLString(XML_HEADER + inputXML);
         CodeableConcept codeableConcept = codeableConceptMapper.mapToCodeableConcept(codedData);
 
-        assertThat(codeableConcept.getCoding().get(0).getCode())
+        assertThat(codeableConcept.getCoding().getFirst().getCode())
             .isEqualTo(CONCEPT_ID);
-        assertThat(codeableConcept.getCoding().get(0).getDisplay())
+        assertThat(codeableConcept.getCoding().getFirst().getDisplay())
             .isEqualTo(DISPLAY_NAME_1);
-        assertThat(codeableConcept.getCoding().get(0).getExtension())
+        assertThat(codeableConcept.getCoding().getFirst().getExtension())
             .isNullOrEmpty();
         assertThat(codeableConcept.getText())
             .isNull();
@@ -324,15 +324,15 @@ public class CodeableConceptMapperTest {
         var codedData = unmarshallCodeElementFromXMLString(XML_HEADER + inputXML);
         CodeableConcept codeableConcept = codeableConceptMapper.mapToCodeableConcept(codedData);
 
-        assertThat(codeableConcept.getCoding().get(0).getCode())
+        assertThat(codeableConcept.getCoding().getFirst().getCode())
             .isEqualTo(SNOMED_PREFERRED.getConceptid());
-        assertThat(codeableConcept.getCoding().get(0).getDisplay())
+        assertThat(codeableConcept.getCoding().getFirst().getDisplay())
             .isEqualTo(SNOMED_PREFERRED.getTerm());
-        assertThat(codeableConcept.getCoding().get(0).getExtension().get(0).getExtension().size() == 1)
+        assertThat(codeableConcept.getCoding().getFirst().getExtension().getFirst().getExtension().size() == 1)
             .isTrue();
-        assertThat(codeableConcept.getCoding().get(0).getExtension().get(0).getExtension().get(0).getUrl())
+        assertThat(codeableConcept.getCoding().getFirst().getExtension().getFirst().getExtension().getFirst().getUrl())
             .isEqualTo(DESCRIPTION_ID);
-        assertThat(codeableConcept.getCoding().get(0).getExtension().get(0).getExtension().get(0).getValue())
+        assertThat(codeableConcept.getCoding().getFirst().getExtension().getFirst().getExtension().getFirst().getValue())
             .isEqualTo(new IdType(SNOMED_PREFERRED.getId()));
         assertThat(codeableConcept.getText())
             .isEqualTo(ORIGINAL_TEXT);
@@ -350,15 +350,15 @@ public class CodeableConceptMapperTest {
         var codedData = unmarshallCodeElementFromXMLString(XML_HEADER + inputXML);
         CodeableConcept codeableConcept = codeableConceptMapper.mapToCodeableConcept(codedData);
 
-        assertThat(codeableConcept.getCoding().get(0).getCode())
+        assertThat(codeableConcept.getCoding().getFirst().getCode())
             .isEqualTo(SNOMED_PREFERRED.getConceptid());
-        assertThat(codeableConcept.getCoding().get(0).getDisplay())
+        assertThat(codeableConcept.getCoding().getFirst().getDisplay())
             .isEqualTo(SNOMED_PREFERRED.getTerm());
-        assertThat(codeableConcept.getCoding().get(0).getExtension().get(0).getExtension().size() == 1)
+        assertThat(codeableConcept.getCoding().getFirst().getExtension().getFirst().getExtension().size() == 1)
             .isTrue();
-        assertThat(codeableConcept.getCoding().get(0).getExtension().get(0).getExtension().get(0).getUrl())
+        assertThat(codeableConcept.getCoding().getFirst().getExtension().getFirst().getExtension().getFirst().getUrl())
             .isEqualTo(DESCRIPTION_ID);
-        assertThat(codeableConcept.getCoding().get(0).getExtension().get(0).getExtension().get(0).getValue())
+        assertThat(codeableConcept.getCoding().getFirst().getExtension().getFirst().getExtension().getFirst().getValue())
             .isEqualTo(new IdType(SNOMED_PREFERRED.getId()));
         assertThat(codeableConcept.getText()).isNull();
     }
@@ -376,13 +376,13 @@ public class CodeableConceptMapperTest {
         var codedData = unmarshallCodeElementFromXMLString(XML_HEADER + inputXML);
         CodeableConcept codeableConcept = codeableConceptMapper.mapToCodeableConcept(codedData);
 
-        assertEquals(SNOMED_PREFERRED.getConceptid(), codeableConcept.getCoding().get(0).getCode());
-        assertEquals(SNOMED_PREFERRED.getTerm(), codeableConcept.getCoding().get(0).getDisplay());
-        assertThat(codeableConcept.getCoding().get(0).getExtension().get(0).getExtension().size() == 1)
+        assertEquals(SNOMED_PREFERRED.getConceptid(), codeableConcept.getCoding().getFirst().getCode());
+        assertEquals(SNOMED_PREFERRED.getTerm(), codeableConcept.getCoding().getFirst().getDisplay());
+        assertThat(codeableConcept.getCoding().getFirst().getExtension().getFirst().getExtension().size() == 1)
             .isTrue();
-        assertThat(codeableConcept.getCoding().get(0).getExtension().get(0).getExtension().get(0).getUrl())
+        assertThat(codeableConcept.getCoding().getFirst().getExtension().getFirst().getExtension().getFirst().getUrl())
             .isEqualTo(DESCRIPTION_ID);
-        assertThat(codeableConcept.getCoding().get(0).getExtension().get(0).getExtension().get(0).getValue())
+        assertThat(codeableConcept.getCoding().getFirst().getExtension().getFirst().getExtension().getFirst().getValue())
             .isEqualTo(new IdType(SNOMED_PREFERRED.getId()));
         assertThat(codeableConcept.getText())
             .isEqualTo(DISPLAY_NAME_3);
@@ -402,19 +402,19 @@ public class CodeableConceptMapperTest {
         var codedData = unmarshallCodeElementFromXMLString(XML_HEADER + inputXML);
         CodeableConcept codeableConcept = codeableConceptMapper.mapToCodeableConcept(codedData);
 
-        assertThat(codeableConcept.getCoding().get(0).getCode())
+        assertThat(codeableConcept.getCoding().getFirst().getCode())
             .isEqualTo(SNOMED_DESCRIPTION.getConceptid());
-        assertThat(codeableConcept.getCoding().get(0).getDisplay())
+        assertThat(codeableConcept.getCoding().getFirst().getDisplay())
             .isEqualTo(SNOMED_PREFERRED.getTerm());
-        assertThat(codeableConcept.getCoding().get(0).getExtension().get(0).getExtension().size() == 2)
+        assertThat(codeableConcept.getCoding().getFirst().getExtension().getFirst().getExtension().size() == 2)
             .isTrue();
-        assertThat(codeableConcept.getCoding().get(0).getExtension().get(0).getExtension().get(0).getUrl())
+        assertThat(codeableConcept.getCoding().getFirst().getExtension().getFirst().getExtension().getFirst().getUrl())
             .isEqualTo(DESCRIPTION_ID);
-        assertThat(codeableConcept.getCoding().get(0).getExtension().get(0).getExtension().get(0).getValue())
+        assertThat(codeableConcept.getCoding().getFirst().getExtension().getFirst().getExtension().getFirst().getValue())
             .isEqualTo(new IdType(SNOMED_DESCRIPTION.getId()));
-        assertThat(codeableConcept.getCoding().get(0).getExtension().get(0).getExtension().get(1).getUrl())
+        assertThat(codeableConcept.getCoding().getFirst().getExtension().getFirst().getExtension().get(1).getUrl())
             .isEqualTo(DESCRIPTION_DISPLAY);
-        assertThat(codeableConcept.getCoding().get(0).getExtension().get(0).getExtension().get(1).getValue().toString())
+        assertThat(codeableConcept.getCoding().getFirst().getExtension().getFirst().getExtension().get(1).getValue().toString())
             .isEqualTo(SNOMED_DESCRIPTION.getTerm());
         assertThat(codeableConcept.getText())
             .isEqualTo(ORIGINAL_TEXT);
@@ -432,19 +432,19 @@ public class CodeableConceptMapperTest {
         var codedData = unmarshallCodeElementFromXMLString(XML_HEADER + inputXML);
         CodeableConcept codeableConcept = codeableConceptMapper.mapToCodeableConcept(codedData);
 
-        assertThat(codeableConcept.getCoding().get(0).getCode())
+        assertThat(codeableConcept.getCoding().getFirst().getCode())
             .isEqualTo(SNOMED_DESCRIPTION.getConceptid());
-        assertThat(codeableConcept.getCoding().get(0).getDisplay())
+        assertThat(codeableConcept.getCoding().getFirst().getDisplay())
             .isEqualTo(SNOMED_PREFERRED.getTerm());
-        assertThat(codeableConcept.getCoding().get(0).getExtension().get(0).getExtension().size() == 2)
+        assertThat(codeableConcept.getCoding().getFirst().getExtension().getFirst().getExtension().size() == 2)
             .isTrue();
-        assertThat(codeableConcept.getCoding().get(0).getExtension().get(0).getExtension().get(0).getUrl())
+        assertThat(codeableConcept.getCoding().getFirst().getExtension().getFirst().getExtension().getFirst().getUrl())
             .isEqualTo(DESCRIPTION_ID);
-        assertThat(codeableConcept.getCoding().get(0).getExtension().get(0).getExtension().get(0).getValue())
+        assertThat(codeableConcept.getCoding().getFirst().getExtension().getFirst().getExtension().getFirst().getValue())
             .isEqualTo(new IdType(SNOMED_DESCRIPTION.getId()));
-        assertThat(codeableConcept.getCoding().get(0).getExtension().get(0).getExtension().get(1).getUrl())
+        assertThat(codeableConcept.getCoding().getFirst().getExtension().getFirst().getExtension().get(1).getUrl())
             .isEqualTo(DESCRIPTION_DISPLAY);
-        assertThat(codeableConcept.getCoding().get(0).getExtension().get(0).getExtension().get(1).getValue().toString())
+        assertThat(codeableConcept.getCoding().getFirst().getExtension().getFirst().getExtension().get(1).getValue().toString())
             .isEqualTo(SNOMED_DESCRIPTION.getTerm());
         assertThat(codeableConcept.getText()).isNull();
     }
@@ -461,19 +461,19 @@ public class CodeableConceptMapperTest {
         var codedData = unmarshallCodeElementFromXMLString(XML_HEADER + inputXML);
         CodeableConcept codeableConcept = codeableConceptMapper.mapToCodeableConcept(codedData);
 
-        assertThat(codeableConcept.getCoding().get(0).getCode())
+        assertThat(codeableConcept.getCoding().getFirst().getCode())
             .isEqualTo(SNOMED_DESCRIPTION.getConceptid());
-        assertThat(codeableConcept.getCoding().get(0).getDisplay())
+        assertThat(codeableConcept.getCoding().getFirst().getDisplay())
             .isEqualTo(SNOMED_PREFERRED.getTerm());
-        assertThat(codeableConcept.getCoding().get(0).getExtension().get(0).getExtension().size() == 2)
+        assertThat(codeableConcept.getCoding().getFirst().getExtension().getFirst().getExtension().size() == 2)
             .isTrue();
-        assertThat(codeableConcept.getCoding().get(0).getExtension().get(0).getExtension().get(0).getUrl())
+        assertThat(codeableConcept.getCoding().getFirst().getExtension().getFirst().getExtension().getFirst().getUrl())
             .isEqualTo(DESCRIPTION_ID);
-        assertThat(codeableConcept.getCoding().get(0).getExtension().get(0).getExtension().get(0).getValue())
+        assertThat(codeableConcept.getCoding().getFirst().getExtension().getFirst().getExtension().getFirst().getValue())
             .isEqualTo(new IdType(SNOMED_DESCRIPTION.getId()));
-        assertThat(codeableConcept.getCoding().get(0).getExtension().get(0).getExtension().get(1).getUrl())
+        assertThat(codeableConcept.getCoding().getFirst().getExtension().getFirst().getExtension().get(1).getUrl())
             .isEqualTo(DESCRIPTION_DISPLAY);
-        assertThat(codeableConcept.getCoding().get(0).getExtension().get(0).getExtension().get(1).getValue().toString())
+        assertThat(codeableConcept.getCoding().getFirst().getExtension().getFirst().getExtension().get(1).getValue().toString())
             .isEqualTo(SNOMED_DESCRIPTION.getTerm());
         assertThat(codeableConcept.getText())
             .isEqualTo(DISPLAY_NAME_3);
@@ -548,11 +548,11 @@ public class CodeableConceptMapperTest {
         var codedData = unmarshallCodeElementFromXMLString(XML_HEADER + inputXML);
         CodeableConcept codeableConcept = codeableConceptMapper.mapToCodeableConceptForMedication(codedData);
 
-        assertThat(codeableConcept.getCoding().get(0).getCode())
+        assertThat(codeableConcept.getCoding().getFirst().getCode())
             .isEqualTo(CONCEPT_ID);
-        assertThat(codeableConcept.getCoding().get(0).getDisplay())
+        assertThat(codeableConcept.getCoding().getFirst().getDisplay())
             .isEqualTo(SNOMED_PREFERRED.getTerm());
-        assertThat(codeableConcept.getCoding().get(0).getExtension())
+        assertThat(codeableConcept.getCoding().getFirst().getExtension())
             .isNullOrEmpty();
         assertThat(codeableConcept.getText())
             .isEqualTo(ORIGINAL_TEXT);
@@ -573,11 +573,11 @@ public class CodeableConceptMapperTest {
 
         CodeableConcept codeableConcept = codeableConceptMapper.mapToCodeableConceptForMedication(codedData);
 
-        assertThat(codeableConcept.getCoding().get(0).getCode())
+        assertThat(codeableConcept.getCoding().getFirst().getCode())
             .isEqualTo("22298006");
-        assertThat(codeableConcept.getCoding().get(0).getDisplay())
+        assertThat(codeableConcept.getCoding().getFirst().getDisplay())
             .isEqualTo(SNOMED_PREFERRED.getTerm());
-        assertThat(codeableConcept.getCoding().get(0).getExtension())
+        assertThat(codeableConcept.getCoding().getFirst().getExtension())
             .isNullOrEmpty();
         assertThat(codeableConcept.getText())
             .isEqualTo(ORIGINAL_TEXT);
@@ -1014,7 +1014,7 @@ public class CodeableConceptMapperTest {
         var codeableConcept = codeableConceptMapper.mapToCodeableConcept(codedData);
 
         assertAll(
-                () -> assertThat(codeableConcept.getCoding().get(0).getCode()).isEqualTo("22K.."),
+                () -> assertThat(codeableConcept.getCoding().getFirst().getCode()).isEqualTo("22K.."),
                 () -> assertThat(codeableConcept.getCoding().get(1).getCode()).isEqualTo("60621009"),
                 () -> assertThat(codeableConcept.getCoding().get(2).getCode()).isEqualTo("22K..00")
         );

--- a/gp2gp-translator/src/test/java/uk/nhs/adaptors/pss/translator/mapper/ConditionMapperTest.java
+++ b/gp2gp-translator/src/test/java/uk/nhs/adaptors/pss/translator/mapper/ConditionMapperTest.java
@@ -3,6 +3,7 @@ package uk.nhs.adaptors.pss.translator.mapper;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertAll;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
@@ -115,7 +116,7 @@ class ConditionMapperTest {
 
         assertThat(conditions).isNotEmpty();
 
-        final Condition condition = conditions.get(0);
+        final Condition condition = conditions.getFirst();
 
         assertGeneratedComponentsAreCorrect(condition);
         assertThat(condition.getId()).isEqualTo(LINKSET_ID);
@@ -125,15 +126,15 @@ class ConditionMapperTest {
         assertThat(condition.getExtensionsByUrl(RELATED_CLINICAL_CONTENT_URL)).isEmpty();
 
         assertThat(condition.getClinicalStatus().getDisplay()).isEqualTo("Active");
-        assertThat(condition.getCode().getCodingFirstRep().hasDisplay()).isFalse();
+        assertFalse(condition.getCode().getCodingFirstRep().hasDisplay());
 
         assertThat(condition.getSubject().getResource().getIdElement().getIdPart()).isEqualTo(PATIENT_ID);
         assertThat(condition.getAsserter().getReference()).isEqualTo(ASSERTER_ID_REFERENCE);
-        assertThat(condition.getContext().hasReference()).isFalse();
+        assertFalse(condition.getContext().hasReference());
 
         assertThat(condition.getOnsetDateTimeType()).isEqualTo(EHR_EXTRACT_AVAILABILITY_DATETIME);
         assertThat(condition.getAbatementDateTimeType()).isEqualTo(EHR_EXTRACT_AVAILABILITY_DATETIME);
-        assertThat(condition.getAssertedDateElement().getValue()).isNull();
+        assertNull(condition.getAssertedDateElement().getValue());
 
         assertThat(condition.getNote()).isEmpty();
     }
@@ -148,8 +149,8 @@ class ConditionMapperTest {
         final List<Condition> conditions = conditionMapper.mapResources(ehrExtract, patient, List.of(), PRACTISE_CODE);
         conditionMapper.addReferences(buildBundleWithNamedStatementObservation(), conditions, ehrExtract);
 
-        assertThat(conditions.get(0).getCode().getCodingFirstRep()).isEqualTo(DegradedCodeableConcepts.DEGRADED_OTHER);
-        assertThat(conditions.get(0).getCode().getCoding().get(1).getDisplay()).isEqualTo(CODING_DISPLAY);
+        assertThat(conditions.getFirst().getCode().getCodingFirstRep()).isEqualTo(DegradedCodeableConcepts.DEGRADED_OTHER);
+        assertThat(conditions.getFirst().getCode().getCoding().get(1).getDisplay()).isEqualTo(CODING_DISPLAY);
     }
 
     @Test
@@ -162,8 +163,8 @@ class ConditionMapperTest {
         conditionMapper.addReferences(buildBundleWithNamedStatementObservation(), conditions, ehrExtract);
 
         assertThat(conditions).isNotEmpty();
-        assertThat(conditions.get(0).getExtensionsByUrl(ACTUAL_PROBLEM_URL)).isNotEmpty();
-        assertActualProblemExtension(conditions.get(0));
+        assertThat(conditions.getFirst().getExtensionsByUrl(ACTUAL_PROBLEM_URL)).isNotEmpty();
+        assertActualProblemExtension(conditions.getFirst());
     }
 
     @Test
@@ -176,8 +177,8 @@ class ConditionMapperTest {
         conditionMapper.addReferences(buildBundleWithStatementRefObservations(), conditions, ehrExtract);
 
         assertThat(conditions).isNotEmpty();
-        assertThat(conditions.get(0).getExtensionsByUrl(RELATED_CLINICAL_CONTENT_URL)).isNotEmpty();
-        assertRelatedClinicalContentExtension(conditions.get(0));
+        assertThat(conditions.getFirst().getExtensionsByUrl(RELATED_CLINICAL_CONTENT_URL)).isNotEmpty();
+        assertRelatedClinicalContentExtension(conditions.getFirst());
     }
 
     @Test
@@ -190,7 +191,7 @@ class ConditionMapperTest {
         final List<Condition> conditions = conditionMapper.mapResources(ehrExtract, patient, encounters, PRACTISE_CODE);
 
         assertThat(conditions).isNotEmpty();
-        assertThat(conditions.get(0).getContext().getResource().getIdElement().getValue()).isEqualTo(ENCOUNTER_ID);
+        assertThat(conditions.getFirst().getContext().getResource().getIdElement().getValue()).isEqualTo(ENCOUNTER_ID);
     }
 
     @Test
@@ -198,13 +199,13 @@ class ConditionMapperTest {
         final RCMRMT030101UKEhrExtract ehrExtract = unmarshallEhrExtract("linkset_no_dates.xml");
         final List<Condition> conditions = conditionMapper.mapResources(ehrExtract, patient, List.of(), PRACTISE_CODE);
 
-        assertGeneratedComponentsAreCorrect(conditions.get(0));
-        assertThat(conditions.get(0).getId()).isEqualTo(LINKSET_ID);
+        assertGeneratedComponentsAreCorrect(conditions.getFirst());
+        assertThat(conditions.getFirst().getId()).isEqualTo(LINKSET_ID);
 
-        assertThat(conditions.get(0).getClinicalStatus().getDisplay()).isEqualTo("Inactive");
+        assertThat(conditions.getFirst().getClinicalStatus().getDisplay()).isEqualTo("Inactive");
 
-        assertThat(conditions.get(0).getAbatementDateTimeType()).isNull();
-        assertThat(conditions.get(0).getAssertedDateElement().getValue()).isNull();
+        assertNull(conditions.getFirst().getAbatementDateTimeType());
+        assertNull(conditions.getFirst().getAssertedDateElement().getValue());
     }
 
     @Test
@@ -213,10 +214,10 @@ class ConditionMapperTest {
         final RCMRMT030101UKEhrExtract ehrExtract = unmarshallEhrExtract("linkset_with_null_flavor_unk.xml");
         final List<Condition> conditions = conditionMapper.mapResources(ehrExtract, patient, List.of(), PRACTISE_CODE);
 
-        assertGeneratedComponentsAreCorrect(conditions.get(0));
-        assertThat(conditions.get(0).getId()).isEqualTo(LINKSET_ID);
+        assertGeneratedComponentsAreCorrect(conditions.getFirst());
+        assertThat(conditions.getFirst().getId()).isEqualTo(LINKSET_ID);
 
-        assertNull(conditions.get(0).getOnsetDateTimeType());
+        assertNull(conditions.getFirst().getOnsetDateTimeType());
     }
 
     @Test
@@ -225,10 +226,10 @@ class ConditionMapperTest {
         final RCMRMT030101UKEhrExtract ehrExtract = unmarshallEhrExtract("linkset_with_center_null_flavor_unk.xml");
         final List<Condition> conditions = conditionMapper.mapResources(ehrExtract, patient, List.of(), PRACTISE_CODE);
 
-        assertGeneratedComponentsAreCorrect(conditions.get(0));
-        assertThat(conditions.get(0).getId()).isEqualTo(LINKSET_ID);
+        assertGeneratedComponentsAreCorrect(conditions.getFirst());
+        assertThat(conditions.getFirst().getId()).isEqualTo(LINKSET_ID);
 
-        assertNull(conditions.get(0).getOnsetDateTimeType());
+        assertNull(conditions.getFirst().getOnsetDateTimeType());
     }
 
     @Test
@@ -247,12 +248,12 @@ class ConditionMapperTest {
             assertThat(conditions.size()).isOne();
 
             var bundle = new Bundle();
-            bundle.addEntry(new BundleEntryComponent().setResource(conditions.get(0)));
+            bundle.addEntry(new BundleEntryComponent().setResource(conditions.getFirst()));
             addMedicationRequestsToBundle(bundle);
 
             conditionMapper.addReferences(bundle, conditions, ehrExtract);
 
-            var extensions = conditions.get(0).getExtension();
+            var extensions = conditions.getFirst().getExtension();
 
             assertThat(extensions).hasSize(EXPECTED_NUMBER_OF_EXTENSIONS);
             var relatedClinicalContentExtensions = extensions.stream()
@@ -286,9 +287,9 @@ class ConditionMapperTest {
         conditionMapper.addReferences(buildBundleWithNamedStatementObservation(), conditions, ehrExtract);
 
         assertThat(conditions).isNotEmpty();
-        assertThat(conditions.get(0).getCode().getCodingFirstRep())
+        assertThat(conditions.getFirst().getCode().getCodingFirstRep())
             .isEqualTo(DegradedCodeableConcepts.DEGRADED_OTHER);
-        assertThat(conditions.get(0).getCode().getCoding().get(1).getDisplay())
+        assertThat(conditions.getFirst().getCode().getCoding().get(1).getDisplay())
             .isEqualTo(CODING_DISPLAY);
     }
 
@@ -304,7 +305,7 @@ class ConditionMapperTest {
         conditionMapper.addReferences(buildBundleWithNamedStatementObservation(), conditions, ehrExtract);
 
         assertThat(conditions).isNotEmpty();
-        assertEquals(codeableConcept, conditions.get(0).getCode());
+        assertEquals(codeableConcept, conditions.getFirst().getCode());
     }
 
     @Test
@@ -324,7 +325,7 @@ class ConditionMapperTest {
 
         final CV linksetConfidentialityCode = confidentialityCodeCaptor
             .getAllValues()
-            .get(0) // linkSet.getConfidentialityCode()
+            .getFirst() // linkSet.getConfidentialityCode()
             .orElseThrow();
 
         assertAllConditionsHaveMeta(conditions, metaWithSecurity);
@@ -357,7 +358,7 @@ class ConditionMapperTest {
         assertAllConditionsHaveMeta(conditions, metaWithSecurity);
         assertAll(
             () -> assertThat(ehrCompositionConfidentialityCode.getCode()).isEqualTo(NOPAT),
-            () -> assertThat(confidentialityCodeCaptor.getAllValues().get(0)).isNotPresent()
+            () -> assertThat(confidentialityCodeCaptor.getAllValues().getFirst()).isNotPresent()
         );
     }
 
@@ -406,7 +407,7 @@ class ConditionMapperTest {
     }
 
     private void assertActualProblemExtension(Condition condition) {
-        var extension = condition.getExtensionsByUrl(ACTUAL_PROBLEM_URL).get(0);
+        var extension = condition.getExtensionsByUrl(ACTUAL_PROBLEM_URL).getFirst();
         assertThat(extension.getValue()).isInstanceOf(Reference.class);
         assertThat(((Reference) extension.getValue()).getResource()).isInstanceOf(Observation.class);
         assertThat(((Observation) ((Reference) extension.getValue()).getResource()).getId()).isEqualTo(NAMED_STATEMENT_REF_ID);
@@ -415,12 +416,12 @@ class ConditionMapperTest {
     private void assertRelatedClinicalContentExtension(Condition condition) {
         var extensions = condition.getExtensionsByUrl(RELATED_CLINICAL_CONTENT_URL);
         assertThat(extensions).hasSize(2);
-        assertThat(((Reference) extensions.get(0).getValue()).getResource().getIdElement().getValue()).isEqualTo(STATEMENT_REF_ID);
+        assertThat(((Reference) extensions.getFirst().getValue()).getResource().getIdElement().getValue()).isEqualTo(STATEMENT_REF_ID);
         assertThat(((Reference) extensions.get(1).getValue()).getResource().getIdElement().getValue()).isEqualTo(STATEMENT_REF_ID_1);
     }
 
     private void assertGeneratedComponentsAreCorrect(Condition condition) {
-        assertThat(condition.getMeta().getProfile().get(0)).isNotNull();
+        assertThat(condition.getMeta().getProfile().getFirst()).isNotNull();
         assertThat(condition.getIdentifierFirstRep().getValue()).isEqualTo(LINKSET_ID);
         assertThat(condition.getCategoryFirstRep().getCodingFirstRep().getDisplay()).isEqualTo("Problem List Item");
     }

--- a/gp2gp-translator/src/test/java/uk/nhs/adaptors/pss/translator/mapper/ConsultationListMapperTest.java
+++ b/gp2gp-translator/src/test/java/uk/nhs/adaptors/pss/translator/mapper/ConsultationListMapperTest.java
@@ -92,8 +92,8 @@ public class ConsultationListMapperTest {
         var ehrExtract = unmarshallEhrExtractElement(FULL_VALID_CONSULTATION_LIST_XML);
         setUpEncounter("20100113152000", "20150213152000", "test-display", "test-text");
 
-        var comp = ehrExtract.getComponent().get(0).getEhrFolder().
-                getComponent().get(0).getEhrComposition();
+        var comp = ehrExtract.getComponent().getFirst().getEhrFolder().
+                getComponent().getFirst().getEhrComposition();
         var consultation = listMapper.mapToConsultation(comp, encounter);
 
         assertConsultation(consultation, "20100113151332", "test-text");
@@ -105,8 +105,8 @@ public class ConsultationListMapperTest {
                 FULL_VALID_CONSULTATION_NOAUTHOR_NOAVAILABILITY_EFFECTCENTER_LIST_XML);
         setUpEncounter("20100113152000", "20150213152000", "test-display", "test-text");
 
-        var comp = ehrExtract.getComponent().get(0).getEhrFolder().
-                getComponent().get(0).getEhrComposition();
+        var comp = ehrExtract.getComponent().getFirst().getEhrFolder().
+                getComponent().getFirst().getEhrComposition();
         var consultation = listMapper.mapToConsultation(comp, encounter);
 
         assertConsultation(consultation, "20100113155000", "test-text");
@@ -118,8 +118,8 @@ public class ConsultationListMapperTest {
                 FULL_VALID_CONSULTATION_NOAUTHOR_NOAVAILABILITY_EFFECTCENTER_LIST_XML);
         setUpEncounter("20100113152000", "20150213152000", "test-display", "test-text");
 
-        var comp = ehrExtract.getComponent().get(0).getEhrFolder().
-                getComponent().get(0).getEhrComposition();
+        var comp = ehrExtract.getComponent().getFirst().getEhrFolder().
+                getComponent().getFirst().getEhrComposition();
         var consultation = listMapper.mapToConsultation(comp, encounter);
 
         assertConsultation(consultation, "20100113155000", "test-text");
@@ -131,8 +131,8 @@ public class ConsultationListMapperTest {
                 FULL_VALID_CONSULTATION_NOAUTHOR_NOAVAILABILITY_EFFECTLOW_LIST_XML);
         setUpEncounter("20100113152000", "20150213152000", "test-display", "test-text");
 
-        var comp = ehrExtract.getComponent().get(0).getEhrFolder().
-                getComponent().get(0).getEhrComposition();
+        var comp = ehrExtract.getComponent().getFirst().getEhrFolder().
+                getComponent().getFirst().getEhrComposition();
         var consultation = listMapper.mapToConsultation(comp, encounter);
 
         assertConsultation(consultation, "20100113152000", "test-text");
@@ -143,8 +143,8 @@ public class ConsultationListMapperTest {
                 FULL_VALID_CONSULTATION_NOAUTHOR_NOAVAILABILITY_LIST_XML);
         setUpEncounter("20100113152000", "20150213152000", "test-display", "test-text");
 
-        var comp = ehrExtract.getComponent().get(0).getEhrFolder().
-                getComponent().get(0).getEhrComposition();
+        var comp = ehrExtract.getComponent().getFirst().getEhrFolder().
+                getComponent().getFirst().getEhrComposition();
         var consultation = listMapper.mapToConsultation(comp, encounter);
 
         assertConsultation(consultation, "20100113153000", "test-text");
@@ -156,8 +156,8 @@ public class ConsultationListMapperTest {
                 FULL_VALID_CONSULTATION_NOAUTHORTIME_NOAVAILABILITY_EFFECTLOW_LIST_XML);
         setUpEncounter("20100113152000", "20150213152000", "test-display", "test-text");
 
-        var comp = ehrExtract.getComponent().get(0).getEhrFolder().
-                getComponent().get(0).getEhrComposition();
+        var comp = ehrExtract.getComponent().getFirst().getEhrFolder().
+                getComponent().getFirst().getEhrComposition();
         var consultation = listMapper.mapToConsultation(comp, encounter);
 
         assertConsultation(consultation, "20100113152000", "test-text");
@@ -167,8 +167,8 @@ public class ConsultationListMapperTest {
         var ehrExtract = unmarshallEhrExtractElement(FULL_VALID_CONSULTATION_LIST_NOAUTHOR_TIME_XML);
         setUpEncounter("20100113152000", "20150213152000", "test-display", "test-text");
 
-        var comp = ehrExtract.getComponent().get(0).getEhrFolder().
-                getComponent().get(0).getEhrComposition();
+        var comp = ehrExtract.getComponent().getFirst().getEhrFolder().
+                getComponent().getFirst().getEhrComposition();
         var consultation = listMapper.mapToConsultation(comp, encounter);
 
         assertConsultation(consultation, "20100113152000", "test-text");
@@ -179,8 +179,8 @@ public class ConsultationListMapperTest {
         var ehrExtract = unmarshallEhrExtractElement(FULL_VALID_CONSULTATION_NOAUTHOR_LIST_XML);
         setUpEncounter("20100113152000", "20150213152000", "test-display", "test-text");
 
-        var comp = ehrExtract.getComponent().get(0).getEhrFolder().
-                getComponent().get(0).getEhrComposition();
+        var comp = ehrExtract.getComponent().getFirst().getEhrFolder().
+                getComponent().getFirst().getEhrComposition();
         var consultation = listMapper.mapToConsultation(comp, encounter);
 
         assertConsultation(consultation, "20100113152000", "test-text");
@@ -191,8 +191,8 @@ public class ConsultationListMapperTest {
         var ehrExtract = unmarshallEhrExtractElement(FULL_VALID_CONSULTATION_LIST_XML);
         setUpEncounter(null, null, "test-display", null);
 
-        var comp = ehrExtract.getComponent().get(0).getEhrFolder().
-                getComponent().get(0).getEhrComposition();
+        var comp = ehrExtract.getComponent().getFirst().getEhrFolder().
+                getComponent().getFirst().getEhrComposition();
 
         var consultation = listMapper.mapToConsultation(comp, encounter);
 
@@ -209,7 +209,7 @@ public class ConsultationListMapperTest {
 
         var topic = listMapper.mapToTopic(consultation, compoundStatement);
 
-        assertTopic(topic, compoundStatement.getId().get(0).getRoot(), "20150213152000", "test-text");
+        assertTopic(topic, compoundStatement.getId().getFirst().getRoot(), "20150213152000", "test-text");
     }
 
     @Test
@@ -222,7 +222,7 @@ public class ConsultationListMapperTest {
 
         var topic = listMapper.mapToTopic(consultation, compoundStatement);
 
-        assertTopic(topic, compoundStatement.getId().get(0).getRoot(), "20130213152000", null);
+        assertTopic(topic, compoundStatement.getId().getFirst().getRoot(), "20130213152000", null);
     }
 
     @Test
@@ -264,7 +264,7 @@ public class ConsultationListMapperTest {
 
     private void assertCategory(ListResource category, String date, String title) {
         assertThat(category.getId()).isEqualTo(COMPOUND_STATEMENT_ID);
-        assertThat(category.getMeta().getProfile().get(0).getValue()).isEqualTo(LIST_META_PROFILE);
+        assertThat(category.getMeta().getProfile().getFirst().getValue()).isEqualTo(LIST_META_PROFILE);
         assertThat(category.getMode()).isEqualTo(ListMode.SNAPSHOT);
         assertThat(category.getStatus()).isEqualTo(ListStatus.CURRENT);
         assertThat(category.getSubject().getResource().getIdElement().getValue()).isEqualTo(PATIENT_ID);
@@ -279,7 +279,7 @@ public class ConsultationListMapperTest {
 
     private void assertTopic(ListResource topic, String id, String date, String title) {
         assertThat(topic.getId()).isEqualTo(id);
-        assertThat(topic.getMeta().getProfile().get(0).getValue()).isEqualTo(LIST_META_PROFILE);
+        assertThat(topic.getMeta().getProfile().getFirst().getValue()).isEqualTo(LIST_META_PROFILE);
         assertThat(topic.getMode()).isEqualTo(ListMode.SNAPSHOT);
         assertThat(topic.getStatus()).isEqualTo(ListStatus.CURRENT);
         assertThat(topic.getSubject().getResource().getIdElement().getValue()).isEqualTo(PATIENT_ID);
@@ -294,7 +294,7 @@ public class ConsultationListMapperTest {
 
     private void assertConsultation(ListResource consultation, String date, String title) {
         assertThat(consultation.getId()).isEqualTo(encounter.getId() + CONSULTATION_ID_SUFFIX);
-        assertThat(consultation.getMeta().getProfile().get(0).getValue()).isEqualTo(LIST_META_PROFILE);
+        assertThat(consultation.getMeta().getProfile().getFirst().getValue()).isEqualTo(LIST_META_PROFILE);
         assertThat(consultation.getMode()).isEqualTo(ListMode.SNAPSHOT);
         assertThat(consultation.getStatus()).isEqualTo(ListStatus.CURRENT);
         assertThat(consultation.getSubject().getResource().getIdElement().getValue()).isEqualTo(PATIENT_ID);

--- a/gp2gp-translator/src/test/java/uk/nhs/adaptors/pss/translator/mapper/DocumentReferenceMapperTest.java
+++ b/gp2gp-translator/src/test/java/uk/nhs/adaptors/pss/translator/mapper/DocumentReferenceMapperTest.java
@@ -4,6 +4,9 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.hl7.fhir.dstu3.model.Enumerations.DocumentReferenceStatus;
 import static org.junit.jupiter.api.Assertions.assertAll;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.when;
@@ -259,7 +262,7 @@ class DocumentReferenceMapperTest {
         assertThat(documentReference.getDescription()).isEqualTo("Some example text");
         assertThat(documentReference.getIndexedElement().getValue()).isEqualTo("2010-01-14");
         assertThat(documentReference.getCreatedElement().asStringValue()).isEqualTo("2019-07-08T13:35:00+00:00");
-        assertThat(documentReference.getSubject().getResource()).isNotNull();
+        assertNotNull(documentReference.getSubject().getResource());
         assertThat(documentReference.getSubject().getResource().getIdElement().getValue()).isEqualTo(PATIENT_ID);
         assertThat(documentReference.getContext().getEncounter().getResource().getIdElement().getValue()).isEqualTo(ENCOUNTER_ID);
         assertAttachmentData(documentReference);
@@ -275,7 +278,7 @@ class DocumentReferenceMapperTest {
         assertThat(documentReference.getDescription()).isEqualTo("Some example text");
         assertThat(documentReference.getIndexedElement().getValue()).isEqualTo("2010-01-14");
         assertThat(documentReference.getCreatedElement().asStringValue()).isEqualTo("2019-07-08T13:35:00+00:00");
-        assertThat(documentReference.getSubject().getResource()).isNotNull();
+        assertNotNull(documentReference.getSubject().getResource());
         assertThat(documentReference.getSubject().getResource().getIdElement().getValue()).isEqualTo(PATIENT_ID);
         assertThat(documentReference.getContext().getEncounter().getResource().getIdElement().getValue()).isEqualTo(ENCOUNTER_ID);
         assertAttachmentData(documentReference);
@@ -303,8 +306,8 @@ class DocumentReferenceMapperTest {
     private void assertDocumentReferenceWithAbsentAttachment(DocumentReference documentReference) {
         assertThat(documentReference.getId()).isEqualTo(NARRATIVE_STATEMENT_ROOT_ID);
         assertThat(documentReference.getContent().getFirst().getAttachment().getTitle()).isEqualTo(PLACEHOLDER);
-        assertThat(documentReference.getContent().getFirst().getAttachment().getUrl()).isNotNull();
-        assertThat(documentReference.getContent().getFirst().getAttachment().hasSize()).isFalse();
+        assertNotNull(documentReference.getContent().getFirst().getAttachment().getUrl());
+        assertFalse(documentReference.getContent().getFirst().getAttachment().hasSize());
         assertThat(documentReference.getContent().getFirst().getAttachment().getContentType()).isEqualTo(CONTENT_TYPE);
     }
 
@@ -314,7 +317,7 @@ class DocumentReferenceMapperTest {
         assertThat(documentReference.getStatus()).isEqualTo(DocumentReferenceStatus.CURRENT);
         assertThatIdentifierIsValid(documentReference.getIdentifierFirstRep(), documentReference.getId());
         assertThat(documentReference.getType().getText()).isEqualTo(NARRATIVE_STATEMENT_TYPE);
-        assertThat(documentReference.getContext().getEncounter().getResource()).isNull();
+        assertNull(documentReference.getContext().getEncounter().getResource());
     }
 
     private void assertThatIdentifierIsValid(Identifier identifier, String id) {

--- a/gp2gp-translator/src/test/java/uk/nhs/adaptors/pss/translator/mapper/DuplicateObservationStatementMapperTest.java
+++ b/gp2gp-translator/src/test/java/uk/nhs/adaptors/pss/translator/mapper/DuplicateObservationStatementMapperTest.java
@@ -65,7 +65,7 @@ class DuplicateObservationStatementMapperTest {
         mapper.mergeDuplicateObservationStatements(ehrExtract);
 
         assertThat(firstEhrComposition(ehrExtract)).hasSize(2);
-        assertThat(firstEhrComposition(ehrExtract).get(0).getObservationStatement().getId().getRoot()).isEqualTo("ID-1");
+        assertThat(firstEhrComposition(ehrExtract).getFirst().getObservationStatement().getId().getRoot()).isEqualTo("ID-1");
     }
 
     @Test
@@ -80,7 +80,7 @@ class DuplicateObservationStatementMapperTest {
         mapper.mergeDuplicateObservationStatements(ehrExtract);
 
         assertThat(firstEhrComposition(ehrExtract)).hasSize(3);
-        assertThat(firstEhrComposition(ehrExtract).get(0).getObservationStatement().getId().getRoot()).isEqualTo("ID-3");
+        assertThat(firstEhrComposition(ehrExtract).getFirst().getObservationStatement().getId().getRoot()).isEqualTo("ID-3");
     }
 
     @Test
@@ -270,7 +270,7 @@ class DuplicateObservationStatementMapperTest {
 
         mapper.mergeDuplicateObservationStatements(ehrExtract);
 
-        assertThat(firstPertinentInformationText(firstEhrComposition(ehrExtract).get(0).getObservationStatement())).isEqualTo(
+        assertThat(firstPertinentInformationText(firstEhrComposition(ehrExtract).getFirst().getObservationStatement())).isEqualTo(
                 "FIRST PREFIX SECOND PREFIX This is an observation which ends with ellipses removed."
         );
     }
@@ -328,7 +328,7 @@ class DuplicateObservationStatementMapperTest {
 
 
     private static String firstPertinentInformationText(RCMRMT030101UKObservationStatement observationStatement) {
-        return observationStatement.getPertinentInformation().get(0).getPertinentAnnotation().getText();
+        return observationStatement.getPertinentInformation().getFirst().getPertinentAnnotation().getText();
     }
 
     private static List<RCMRMT030101UKComponent4> firstEhrComposition(RCMRMT030101UKEhrExtract ehrExtract) {
@@ -336,7 +336,7 @@ class DuplicateObservationStatementMapperTest {
     }
 
     private static RCMRMT030101UKEhrComposition firstEhrComposition(RCMRMT030101UKEhrFolder rcmrmt030101UKEhrFolder) {
-        return rcmrmt030101UKEhrFolder.getComponent().get(0).getEhrComposition();
+        return rcmrmt030101UKEhrFolder.getComponent().getFirst().getEhrComposition();
     }
 
     private static RCMRMT030101UKEhrComposition secondEhrComposition(RCMRMT030101UKEhrFolder rcmrmt030101UKEhrFolder) {
@@ -344,7 +344,7 @@ class DuplicateObservationStatementMapperTest {
     }
 
     private static RCMRMT030101UKEhrFolder firstEhrFolder(RCMRMT030101UKEhrExtract ehrExtract) {
-        return ehrExtract.getComponent().get(0).getEhrFolder();
+        return ehrExtract.getComponent().getFirst().getEhrFolder();
     }
 
     private static RCMRMT030101UKEhrFolder secondEhrFolder(RCMRMT030101UKEhrExtract ehrExtract) {

--- a/gp2gp-translator/src/test/java/uk/nhs/adaptors/pss/translator/mapper/EncounterMapperTest.java
+++ b/gp2gp-translator/src/test/java/uk/nhs/adaptors/pss/translator/mapper/EncounterMapperTest.java
@@ -205,9 +205,9 @@ public class EncounterMapperTest {
         assertThat(mappedResources.get(TOPIC_KEY).size()).isOne();
         assertThat(mappedResources.get(CATEGORY_KEY).size()).isOne();
 
-        var encounter = (Encounter) mappedResources.get(ENCOUNTER_KEY).get(0);
+        var encounter = (Encounter) mappedResources.get(ENCOUNTER_KEY).getFirst();
 
-        assertThat(encounter.getType().get(0).getCodingFirstRep().getDisplay())
+        assertThat(encounter.getType().getFirst().getCodingFirstRep().getDisplay())
             .isEqualTo(CODING_DISPLAY);
         verifyCreateMetaAndAddSecurityCalled(1, Optional.empty());
     }
@@ -236,9 +236,9 @@ public class EncounterMapperTest {
         assertThat(mappedResources.get(TOPIC_KEY).size()).isOne();
         assertThat(mappedResources.get(CATEGORY_KEY).size()).isOne();
 
-        var encounter = (Encounter) mappedResources.get(ENCOUNTER_KEY).get(0);
+        var encounter = (Encounter) mappedResources.get(ENCOUNTER_KEY).getFirst();
 
-        assertThat(encounter.getType().get(0).getCodingFirstRep())
+        assertThat(encounter.getType().getFirst().getCodingFirstRep())
             .isEqualTo(DegradedCodeableConcepts.DEGRADED_OTHER);
         verifyCreateMetaAndAddSecurityCalled(1, Optional.empty());
     }
@@ -276,9 +276,9 @@ public class EncounterMapperTest {
             ehrExtract, patient, PRACTISE_CODE, entryLocations
         );
 
-        var encounter = (Encounter) mappedResources.get(ENCOUNTER_KEY).get(0);
+        var encounter = (Encounter) mappedResources.get(ENCOUNTER_KEY).getFirst();
 
-        assertThat(encounter.getType().get(0).getCodingFirstRep()).isEqualTo(DegradedCodeableConcepts.DEGRADED_OTHER);
+        assertThat(encounter.getType().getFirst().getCodingFirstRep()).isEqualTo(DegradedCodeableConcepts.DEGRADED_OTHER);
         assertMetaSecurityPresent(encounter.getMeta());
         verifyCreateMetaAndAddSecurityCalled(1,  ehrComposition.getConfidentialityCode());
     }
@@ -316,9 +316,9 @@ public class EncounterMapperTest {
             ehrExtract, patient, PRACTISE_CODE, entryLocations
         );
 
-        var encounter = (Encounter) mappedResources.get(ENCOUNTER_KEY).get(0);
+        var encounter = (Encounter) mappedResources.get(ENCOUNTER_KEY).getFirst();
 
-        assertThat(encounter.getType().get(0).getCodingFirstRep()).isEqualTo(DegradedCodeableConcepts.DEGRADED_OTHER);
+        assertThat(encounter.getType().getFirst().getCodingFirstRep()).isEqualTo(DegradedCodeableConcepts.DEGRADED_OTHER);
         assertThat(encounter.getMeta().getSecurity()).isEmpty();
         verifyCreateMetaAndAddSecurityCalled(1,  ehrComposition.getConfidentialityCode());
     }
@@ -343,20 +343,20 @@ public class EncounterMapperTest {
         assertThat(mappedResources.get(TOPIC_KEY).size()).isOne();
         assertThat(mappedResources.get(CATEGORY_KEY).size()).isOne();
 
-        var encounter = (Encounter) mappedResources.get(ENCOUNTER_KEY).get(0);
+        var encounter = (Encounter) mappedResources.get(ENCOUNTER_KEY).getFirst();
 
         assertEncounter(encounter, "2485BC20-90B4-11EC-B1E5-0800200C9A66", true,
             "2010-01-13T15:20:00+00:00", "2010-01-13T15:20:00+00:00");
 
-        var consultation = (ListResource) mappedResources.get(CONSULTATION_KEY).get(0);
+        var consultation = (ListResource) mappedResources.get(CONSULTATION_KEY).getFirst();
         assertThat(consultation.getEncounter().getReference()).isEqualTo(ENCOUNTER_ID);
 
-        var topic = (ListResource) mappedResources.get(TOPIC_KEY).get(0);
+        var topic = (ListResource) mappedResources.get(TOPIC_KEY).getFirst();
         assertThat(topic.getEncounter().getReference()).isEqualTo(ENCOUNTER_ID);
         assertThat(consultation.getEntryFirstRep().getItem().getReference())
             .isEqualTo(ENCOUNTER_ID);
 
-        var category = (ListResource) mappedResources.get(CATEGORY_KEY).get(0);
+        var category = (ListResource) mappedResources.get(CATEGORY_KEY).getFirst();
         assertThat(category.getEncounter().getReference()).isEqualTo(ENCOUNTER_ID);
         assertThat(topic.getEntryFirstRep().getItem().getReference())
             .isEqualTo(ENCOUNTER_ID);
@@ -383,7 +383,7 @@ public class EncounterMapperTest {
         assertThat(mappedResources.get(TOPIC_KEY).size()).isOne();
         assertThat(mappedResources.get(CATEGORY_KEY).size()).isOne();
 
-        var encounter = (Encounter) mappedResources.get(ENCOUNTER_KEY).get(0);
+        var encounter = (Encounter) mappedResources.get(ENCOUNTER_KEY).getFirst();
 
         assertEncounter(
                 encounter,
@@ -392,24 +392,24 @@ public class EncounterMapperTest {
                 "2010-01-13T15:20:00+00:00"
         );
 
-        var consultation = (ListResource) mappedResources.get(CONSULTATION_KEY).get(0);
+        var consultation = (ListResource) mappedResources.get(CONSULTATION_KEY).getFirst();
         assertThat(consultation.getEncounter().getReference()).isEqualTo(ENCOUNTER_ID);
 
-        var topic = (ListResource) mappedResources.get(TOPIC_KEY).get(0);
+        var topic = (ListResource) mappedResources.get(TOPIC_KEY).getFirst();
         assertThat(topic.getEncounter().getReference()).isEqualTo(ENCOUNTER_ID);
-        assertThat(consultation.getEntry().get(0).getItem().getReference())
+        assertThat(consultation.getEntry().getFirst().getItem().getReference())
             .isEqualTo(ENCOUNTER_ID);
 
         var relatedProblemExt = topic.getExtensionsByUrl(RELATED_PROBLEM_EXT_URL);
         assertThat(relatedProblemExt.size()).isOne();
 
-        var relatedProblemTarget = relatedProblemExt.get(0).getExtensionsByUrl(RELATED_PROBLEM_TARGET_URL);
+        var relatedProblemTarget = relatedProblemExt.getFirst().getExtensionsByUrl(RELATED_PROBLEM_TARGET_URL);
         assertThat(relatedProblemTarget.size()).isOne();
 
-        var relatedProblemReference = (Reference) relatedProblemTarget.get(0).getValue();
+        var relatedProblemReference = (Reference) relatedProblemTarget.getFirst().getValue();
         assertThat(relatedProblemReference.getReference()).isEqualTo(LINKSET_REFERENCE);
 
-        var category = (ListResource) mappedResources.get(CATEGORY_KEY).get(0);
+        var category = (ListResource) mappedResources.get(CATEGORY_KEY).getFirst();
         assertThat(category.getEncounter().getReference()).isEqualTo(ENCOUNTER_ID);
         assertThat(topic.getEntryFirstRep().getItem().getReference())
             .isEqualTo(ENCOUNTER_ID);
@@ -434,15 +434,15 @@ public class EncounterMapperTest {
         assertThat(mappedResources.get(TOPIC_KEY).size()).isOne();
         assertThat(mappedResources.get(CATEGORY_KEY)).isEmpty();
 
-        var encounter = (Encounter) mappedResources.get(ENCOUNTER_KEY).get(0);
+        var encounter = (Encounter) mappedResources.get(ENCOUNTER_KEY).getFirst();
 
         assertEncounter(encounter, "5EB5D070-8FE1-11EC-B1E5-0800200C9A66", true,
             "2010-01-13T15:20:00+00:00", "2010-01-13T15:20:00+00:00");
 
-        var consultation = (ListResource) mappedResources.get(CONSULTATION_KEY).get(0);
+        var consultation = (ListResource) mappedResources.get(CONSULTATION_KEY).getFirst();
         assertThat(consultation.getEncounter().getReference()).isEqualTo(ENCOUNTER_ID);
 
-        var topic = (ListResource) mappedResources.get(TOPIC_KEY).get(0);
+        var topic = (ListResource) mappedResources.get(TOPIC_KEY).getFirst();
         assertThat(topic.getEncounter().getReference()).isEqualTo(ENCOUNTER_ID);
         assertThat(consultation.getEntryFirstRep().getItem().getReference()).isEqualTo(ENCOUNTER_ID);
 
@@ -469,15 +469,15 @@ public class EncounterMapperTest {
         assertThat(mappedResources.get(TOPIC_KEY).size()).isOne();
         assertThat(mappedResources.get(CATEGORY_KEY)).isEmpty();
 
-        var encounter = (Encounter) mappedResources.get(ENCOUNTER_KEY).get(0);
+        var encounter = (Encounter) mappedResources.get(ENCOUNTER_KEY).getFirst();
 
         assertEncounter(encounter, "5EB5D070-8FE1-11EC-B1E5-0800200C9A66", true,
             "2010-01-13T15:20:00+00:00", "2010-01-13T15:20:00+00:00");
 
-        var consultation = (ListResource) mappedResources.get(CONSULTATION_KEY).get(0);
+        var consultation = (ListResource) mappedResources.get(CONSULTATION_KEY).getFirst();
         assertThat(consultation.getEncounter().getReference()).isEqualTo(ENCOUNTER_ID);
 
-        var topic = (ListResource) mappedResources.get(TOPIC_KEY).get(0);
+        var topic = (ListResource) mappedResources.get(TOPIC_KEY).getFirst();
         assertThat(topic.getEncounter().getReference()).isEqualTo(ENCOUNTER_ID);
         assertThat(consultation.getEntryFirstRep().getItem().getReference()).isEqualTo(ENCOUNTER_ID);
         verifyCreateMetaAndAddSecurityCalled(1, Optional.empty());
@@ -501,14 +501,14 @@ public class EncounterMapperTest {
         assertThat(mappedResources.get(TOPIC_KEY).size()).isOne();
         assertThat(mappedResources.get(CATEGORY_KEY)).isEmpty();
 
-        var encounter = (Encounter) mappedResources.get(ENCOUNTER_KEY).get(0);
+        var encounter = (Encounter) mappedResources.get(ENCOUNTER_KEY).getFirst();
 
         assertEncounter(encounter, "5EB5D070-8FE1-11EC-B1E5-0800200C9A66", false, null, null);
 
-        var consultation = (ListResource) mappedResources.get(CONSULTATION_KEY).get(0);
+        var consultation = (ListResource) mappedResources.get(CONSULTATION_KEY).getFirst();
         assertThat(consultation.getEncounter().getReference()).isEqualTo(ENCOUNTER_ID);
 
-        var topic = (ListResource) mappedResources.get(TOPIC_KEY).get(0);
+        var topic = (ListResource) mappedResources.get(TOPIC_KEY).getFirst();
         assertThat(topic.getEncounter().getReference()).isEqualTo(ENCOUNTER_ID);
         assertThat(consultation.getEntryFirstRep().getItem().getReference()).isEqualTo(ENCOUNTER_ID);
         verifyCreateMetaAndAddSecurityCalled(1, Optional.empty());
@@ -534,20 +534,20 @@ public class EncounterMapperTest {
         assertThat(mappedResources.get(TOPIC_KEY).size()).isOne();
         assertThat(mappedResources.get(CATEGORY_KEY).size()).isOne();
 
-        var encounter = (Encounter) mappedResources.get(ENCOUNTER_KEY).get(0);
+        var encounter = (Encounter) mappedResources.get(ENCOUNTER_KEY).getFirst();
 
         assertEncounter(encounter, "2485BC20-90B4-11EC-B1E5-0800200C9A66", true,
             "2010-01-13T15:20:00+00:00", "2010-01-13T15:20:00+00:00");
 
-        var consultation = (ListResource) mappedResources.get(CONSULTATION_KEY).get(0);
+        var consultation = (ListResource) mappedResources.get(CONSULTATION_KEY).getFirst();
         assertThat(consultation.getEncounter().getReference()).isEqualTo(ENCOUNTER_ID);
 
-        var topic = (ListResource) mappedResources.get(TOPIC_KEY).get(0);
+        var topic = (ListResource) mappedResources.get(TOPIC_KEY).getFirst();
         assertThat(topic.getEncounter().getReference()).isEqualTo(ENCOUNTER_ID);
         assertThat(consultation.getEntryFirstRep().getItem().getReference())
             .isEqualTo(ENCOUNTER_ID);
 
-        var category = (ListResource) mappedResources.get(CATEGORY_KEY).get(0);
+        var category = (ListResource) mappedResources.get(CATEGORY_KEY).getFirst();
         assertThat(category.getEncounter().getReference()).isEqualTo(ENCOUNTER_ID);
         assertThat(topic.getEntryFirstRep().getItem().getReference())
             .isEqualTo(ENCOUNTER_ID);
@@ -575,15 +575,15 @@ public class EncounterMapperTest {
         assertThat(mappedResources.get(TOPIC_KEY).size()).isOne();
         assertThat(mappedResources.get(CATEGORY_KEY)).isEmpty();
 
-        var encounter = (Encounter) mappedResources.get(ENCOUNTER_KEY).get(0);
+        var encounter = (Encounter) mappedResources.get(ENCOUNTER_KEY).getFirst();
 
         assertEncounter(encounter, "5EB5D070-8FE1-11EC-B1E5-0800200C9A66", true,
             "2010-01-13T15:20:00+00:00", "2010-01-13T15:20:00+00:00");
 
-        var consultation = (ListResource) mappedResources.get(CONSULTATION_KEY).get(0);
+        var consultation = (ListResource) mappedResources.get(CONSULTATION_KEY).getFirst();
         assertThat(consultation.getEncounter().getReference()).isEqualTo(ENCOUNTER_ID);
 
-        var topic = (ListResource) mappedResources.get(TOPIC_KEY).get(0);
+        var topic = (ListResource) mappedResources.get(TOPIC_KEY).getFirst();
         assertThat(topic.getEncounter().getReference()).isEqualTo(ENCOUNTER_ID);
         assertThat(consultation.getEntryFirstRep().getItem().getReference()).isEqualTo(ENCOUNTER_ID);
 
@@ -609,7 +609,7 @@ public class EncounterMapperTest {
         var encounterList = mappedResources.get(ENCOUNTER_KEY);
         assertThat(encounterList.size()).isOne();
 
-        var encounter = (Encounter) mappedResources.get(ENCOUNTER_KEY).get(0);
+        var encounter = (Encounter) mappedResources.get(ENCOUNTER_KEY).getFirst();
         assertEncounter(encounter, "5EB5D070-8FE1-11EC-B1E5-0800200C9A66", false, startDate, endDate);
         verifyCreateMetaAndAddSecurityCalled(1, Optional.empty());
     }
@@ -659,7 +659,7 @@ public class EncounterMapperTest {
             String endDate
     ) {
         assertThat(encounter.getId()).isEqualTo(id);
-        assertThat(encounter.getMeta().getProfile().get(0).getValue()).isEqualTo(META_PROFILE);
+        assertThat(encounter.getMeta().getProfile().getFirst().getValue()).isEqualTo(META_PROFILE);
         assertThat(encounter.getIdentifierFirstRep().getSystem()).isEqualTo(IDENTIFIER_SYSTEM);
         assertThat(encounter.getIdentifierFirstRep().getValue()).isEqualTo(id);
         assertThat(encounter.getStatus()).isEqualTo(EncounterStatus.FINISHED);
@@ -680,11 +680,11 @@ public class EncounterMapperTest {
     private void assertMetaSecurityPresent(Meta meta) {
         assertAll(
             () -> assertThat(meta.getSecurity()).hasSize(1),
-            () -> assertThat(meta.getSecurity().get(0).getCode())
+            () -> assertThat(meta.getSecurity().getFirst().getCode())
                 .isEqualTo("NOPAT"),
-            () -> assertThat(meta.getSecurity().get(0).getSystem())
+            () -> assertThat(meta.getSecurity().getFirst().getSystem())
                 .isEqualTo("http://hl7.org/fhir/v3/ActCode"),
-            () -> assertThat(meta.getSecurity().get(0).getDisplay())
+            () -> assertThat(meta.getSecurity().getFirst().getDisplay())
                 .isEqualTo("no disclosure to patient, family or caregivers without attending provider's authorization")
         );
     }

--- a/gp2gp-translator/src/test/java/uk/nhs/adaptors/pss/translator/mapper/ImmunizationMapperTest.java
+++ b/gp2gp-translator/src/test/java/uk/nhs/adaptors/pss/translator/mapper/ImmunizationMapperTest.java
@@ -86,7 +86,7 @@ public class ImmunizationMapperTest {
         var ehrExtract = unmarshallEhrExtract("full_valid_immunization.xml");
         List<Immunization> immunizationList = immunizationMapper.mapResources(ehrExtract, getPatient(), getEncounterList(), PRACTISE_CODE);
 
-        var immunization = (Immunization) immunizationList.get(0);
+        var immunization = (Immunization) immunizationList.getFirst();
         assertFullValidData(immunization, immunizationList);
     }
 
@@ -95,7 +95,7 @@ public class ImmunizationMapperTest {
         var ehrExtract = unmarshallEhrExtract("immunization_with_missing_optional_values.xml");
         List<Immunization> immunizationList = immunizationMapper.mapResources(ehrExtract, getPatient(), getEncounterList(), PRACTISE_CODE);
 
-        var immunization = (Immunization) immunizationList.get(0);
+        var immunization = (Immunization) immunizationList.getFirst();
         assertMissingData(immunization, immunizationList);
     }
 
@@ -104,7 +104,7 @@ public class ImmunizationMapperTest {
         var ehrExtract = unmarshallEhrExtract("immunization_with_ehr_composition_id_not_matching_encounter_id.xml");
         List<Immunization> immunizationList = immunizationMapper.mapResources(ehrExtract, getPatient(), getEncounterList(), PRACTISE_CODE);
 
-        var immunization = (Immunization) immunizationList.get(0);
+        var immunization = (Immunization) immunizationList.getFirst();
         assertNull(immunization.getEncounter().getReference());
     }
 
@@ -113,13 +113,13 @@ public class ImmunizationMapperTest {
         var ehrExtract = unmarshallEhrExtract("immunization_with_ehr_composition_with_author_and_participant.xml");
         List<Immunization> immunizationList = immunizationMapper.mapResources(ehrExtract, getPatient(), getEncounterList(), PRACTISE_CODE);
 
-        var immunization = (Immunization) immunizationList.get(0);
+        var immunization = (Immunization) immunizationList.getFirst();
         assertEquals("Practitioner/E7E7B550-09EF-BE85-C20F-34598014166C",
-            immunization.getPractitioner().get(0).getActor().getReference());
+            immunization.getPractitioner().getFirst().getActor().getReference());
         assertEquals("EP",
-            immunization.getPractitioner().get(0).getRole().getCoding().get(0).getCode());
+            immunization.getPractitioner().getFirst().getRole().getCoding().getFirst().getCode());
         assertEquals("http://hl7.org/fhir/stu3/valueset-immunization-role.html",
-            immunization.getPractitioner().get(0).getRole().getCoding().get(0).getSystem());
+            immunization.getPractitioner().getFirst().getRole().getCoding().getFirst().getSystem());
         assertEquals("Practitioner/9A5D5A78-1F63-434C-9637-1D7E7843341B",
             immunization.getPractitioner().get(1).getActor().getReference());
         assertNull(immunization.getPractitioner().get(1).getRole().getText());
@@ -130,11 +130,11 @@ public class ImmunizationMapperTest {
         var ehrExtract = unmarshallEhrExtract("immunization_with_ehr_composition_with_one_observation_participant.xml");
         List<Immunization> immunizationList = immunizationMapper.mapResources(ehrExtract, getPatient(), getEncounterList(), PRACTISE_CODE);
 
-        var immunization = (Immunization) immunizationList.get(0);
+        var immunization = (Immunization) immunizationList.getFirst();
         assertEquals(1, immunization.getPractitioner().size());
         assertEquals("Practitioner/9A5D5A78-1F63-434C-9637-1D7E7843341B",
-            immunization.getPractitioner().get(0).getActor().getReference());
-        assertNull(immunization.getPractitioner().get(0).getRole().getText());
+            immunization.getPractitioner().getFirst().getActor().getReference());
+        assertNull(immunization.getPractitioner().getFirst().getRole().getText());
     }
 
     @Test
@@ -142,10 +142,10 @@ public class ImmunizationMapperTest {
         var ehrExtract = unmarshallEhrExtract("full_valid_immunization_with_multiple_observation_statements.xml");
         List<Immunization> immunizationList = immunizationMapper.mapResources(ehrExtract, getPatient(), getEncounterList(), PRACTISE_CODE);
 
-        var immunization = (Immunization) immunizationList.get(0);
+        var immunization = (Immunization) immunizationList.getFirst();
         assertThat(immunizationList).hasSize(THREE);
         assertEquals(OBSERVATION_ROOT_ID, immunization.getId());
-        assertEquals(META_PROFILE, immunization.getMeta().getProfile().get(0).getValue());
+        assertEquals(META_PROFILE, immunization.getMeta().getProfile().getFirst().getValue());
         assertThatIdentifierIsValid(immunization.getIdentifierFirstRep(), immunization.getId());
     }
 
@@ -155,9 +155,10 @@ public class ImmunizationMapperTest {
         var ehrExtract = unmarshallEhrExtract("full_valid_immunization_with_multiple_observation_statements.xml");
         List<Immunization> immunizationList = immunizationMapper.mapResources(ehrExtract, getPatient(), getEncounterList(), PRACTISE_CODE);
 
-        var immunization = (Immunization) immunizationList.get(0);
-        assertEquals(VACCINE_PROCEDURE_URL, immunization.getExtension().get(0).getUrl());
-        assertEquals(CODING_DISPLAY, ((CodeableConcept) immunization.getExtension().get(0).getValue()).getCoding().get(0).getDisplay());
+        var immunization = (Immunization) immunizationList.getFirst();
+        assertEquals(VACCINE_PROCEDURE_URL, immunization.getExtension().getFirst().getUrl());
+        assertEquals(CODING_DISPLAY,
+                     ((CodeableConcept) immunization.getExtension().getFirst().getValue()).getCoding().getFirst().getDisplay());
     }
 
     @Test
@@ -165,7 +166,7 @@ public class ImmunizationMapperTest {
         var ehrExtract = unmarshallEhrExtract("immunization_with_only_center_effective_time.xml");
         List<Immunization> immunizationList = immunizationMapper.mapResources(ehrExtract, getPatient(), getEncounterList(), PRACTISE_CODE);
 
-        var immunization = (Immunization) immunizationList.get(0);
+        var immunization = (Immunization) immunizationList.getFirst();
         assertImmunizationWithHighEffectiveTimeCenter(immunization);
     }
 
@@ -174,7 +175,7 @@ public class ImmunizationMapperTest {
         var ehrExtract = unmarshallEhrExtract("immunization_with_only_low_effective_time.xml");
         List<Immunization> immunizationList = immunizationMapper.mapResources(ehrExtract, getPatient(), getEncounterList(), PRACTISE_CODE);
 
-        var immunization = (Immunization) immunizationList.get(0);
+        var immunization = (Immunization) immunizationList.getFirst();
         assertImmunizationWithEffectiveTimeLow(immunization);
     }
 
@@ -183,7 +184,7 @@ public class ImmunizationMapperTest {
         var ehrExtract = unmarshallEhrExtract("immunization_with_high_and_low_effective_time.xml");
         List<Immunization> immunizationList = immunizationMapper.mapResources(ehrExtract, getPatient(), getEncounterList(), PRACTISE_CODE);
 
-        var immunization = (Immunization) immunizationList.get(0);
+        var immunization = (Immunization) immunizationList.getFirst();
         assertImmunizationWithHighAndLowEffectiveTime(immunization);
     }
 
@@ -192,7 +193,7 @@ public class ImmunizationMapperTest {
         var ehrExtract = unmarshallEhrExtract("immunization_with_only_high_effective_time.xml");
         List<Immunization> immunizationList = immunizationMapper.mapResources(ehrExtract, getPatient(), getEncounterList(), PRACTISE_CODE);
 
-        var immunization = (Immunization) immunizationList.get(0);
+        var immunization = (Immunization) immunizationList.getFirst();
         assertImmunizationWithHighEffectiveTime(immunization);
     }
 
@@ -201,7 +202,7 @@ public class ImmunizationMapperTest {
         var ehrExtract = unmarshallEhrExtract("immunization_with_only_high_effective_time.xml");
         List<Immunization> immunizationList = immunizationMapper.mapResources(ehrExtract, getPatient(), getEncounterList(), PRACTISE_CODE);
 
-        var immunization = (Immunization) immunizationList.get(0);
+        var immunization = (Immunization) immunizationList.getFirst();
         assertImmunizationWithDefaultVaccineCode(immunization);
     }
 
@@ -222,11 +223,11 @@ public class ImmunizationMapperTest {
             getEncounterList(), PRACTISE_CODE
         );
         final var securityMeta = immunizations
-            .get(0)
+            .getFirst()
             .getMeta()
             .getSecurity(NOPAT_URL_CODESYSTEM, NOPAT_CODE);
 
-        final var ehrCompositionConfidentialityCode = confidentialityCodeCaptor.getAllValues().get(0);
+        final var ehrCompositionConfidentialityCode = confidentialityCodeCaptor.getAllValues().getFirst();
 
         assertAll(
             () -> {
@@ -238,9 +239,7 @@ public class ImmunizationMapperTest {
                         TestUtility.createCv(NOPAT_CODE, NOPAT_OID_CODESYSTEM, NOPAT_DISPLAY)
                     );
             },
-            () -> assertThat(securityMeta.getDisplay())
-                .isEqualTo(NOPAT_DISPLAY)
-        );
+            () -> assertThat(securityMeta.getDisplay()).isEqualTo(NOPAT_DISPLAY));
     }
 
     @Test
@@ -260,7 +259,7 @@ public class ImmunizationMapperTest {
             getEncounterList(), PRACTISE_CODE
         );
         final var securityMeta = immunizations
-            .get(0)
+            .getFirst()
             .getMeta()
             .getSecurity(NOPAT_URL_CODESYSTEM, NOPAT_CODE);
 
@@ -283,51 +282,52 @@ public class ImmunizationMapperTest {
     private void assertImmunizationWithHighAndLowEffectiveTime(Immunization immunization) {
 
         assertEquals(DateFormatUtil.parseToDateTimeType("20110118114100000").getValue(), immunization.getDateElement().getValue());
-        assertEquals(OBSERVATION_TEXT, immunization.getNote().get(0).getText());
+        assertEquals(OBSERVATION_TEXT, immunization.getNote().getFirst().getText());
         assertEquals("End Date: 2010-01-18T11:41:00+00:00", immunization.getNote().get(1).getText());
     }
 
     private void assertImmunizationWithEffectiveTimeLow(Immunization immunization) {
         assertEquals(DateFormatUtil.parseToDateTimeType("20100118114100000").getValue(), immunization.getDateElement().getValue());
-        assertEquals(OBSERVATION_TEXT, immunization.getNote().get(0).getText());
+        assertEquals(OBSERVATION_TEXT, immunization.getNote().getFirst().getText());
     }
 
     private void assertImmunizationWithHighEffectiveTime(Immunization immunization) {
         assertNull(immunization.getDate());
-        assertEquals(OBSERVATION_TEXT, immunization.getNote().get(0).getText());
+        assertEquals(OBSERVATION_TEXT, immunization.getNote().getFirst().getText());
         assertEquals("End Date: 2010-01-18T11:41:00+00:00", immunization.getNote().get(1).getText());
     }
 
     private void assertImmunizationWithDefaultVaccineCode(Immunization immunization) {
         assertNotNull(immunization.getVaccineCode());
-        assertEquals("UNK", immunization.getVaccineCode().getCoding().get(0).getCode());
-        assertEquals("http://hl7.org/fhir/v3/NullFlavor", immunization.getVaccineCode().getCoding().get(0).getSystem());
+        assertEquals("UNK", immunization.getVaccineCode().getCoding().getFirst().getCode());
+        assertEquals("http://hl7.org/fhir/v3/NullFlavor", immunization.getVaccineCode().getCoding().getFirst().getSystem());
     }
 
     private void assertImmunizationWithHighEffectiveTimeCenter(Immunization immunization) {
         assertEquals(DateFormatUtil.parseToDateTimeType("20100118114100000").getValue(), immunization.getDateElement().getValue());
-        assertEquals(OBSERVATION_TEXT, immunization.getNote().get(0).getText());
+        assertEquals(OBSERVATION_TEXT, immunization.getNote().getFirst().getText());
     }
 
     private void assertFullValidData(Immunization immunization, List<Immunization> immunizationList) {
         assertThat(immunizationList).hasSize(1);
         assertEquals(OBSERVATION_ROOT_ID, immunization.getId());
-        assertEquals(META_PROFILE, immunization.getMeta().getProfile().get(0).getValue());
+        assertEquals(META_PROFILE, immunization.getMeta().getProfile().getFirst().getValue());
         assertThatIdentifierIsValid(immunization.getIdentifierFirstRep(), immunization.getId());
         assertEquals(Immunization.ImmunizationStatus.COMPLETED, immunization.getStatus());
         assertTrue(immunization.getPrimarySource());
         assertEquals(DateFormatUtil.parseToDateTimeType("20100118114100000").getValue(), immunization.getDateElement().getValue());
-        assertEquals(OBSERVATION_TEXT, immunization.getNote().get(0).getText());
+        assertEquals(OBSERVATION_TEXT, immunization.getNote().getFirst().getText());
         assertEquals("End Date: 2010-01-18T11:41:00+00:00", immunization.getNote().get(1).getText());
         assertEquals(PATIENT_ID, immunization.getPatient().getResource().getIdElement().getValue());
         assertEquals(ENCOUNTER_ID, immunization.getEncounter().getResource().getIdElement().getValue());
-        assertEquals("Practitioner/9C1610C2-5E48-4ED5-882B-5A4A172AFA35", immunization.getPractitioner().get(0).getActor().getReference());
+        assertEquals("Practitioner/9C1610C2-5E48-4ED5-882B-5A4A172AFA35",
+                     immunization.getPractitioner().getFirst().getActor().getReference());
     }
 
     private void assertMissingData(Immunization immunization, List<Immunization> immunizationList) {
         assertEquals(1, immunizationList.size());
         assertEquals(OBSERVATION_ROOT_ID, immunization.getId());
-        assertEquals(META_PROFILE, immunization.getMeta().getProfile().get(0).getValue());
+        assertEquals(META_PROFILE, immunization.getMeta().getProfile().getFirst().getValue());
         assertThatIdentifierIsValid(immunization.getIdentifierFirstRep(), immunization.getId());
         assertEquals(Immunization.ImmunizationStatus.COMPLETED, immunization.getStatus());
         assertTrue(immunization.getPrimarySource());
@@ -346,8 +346,7 @@ public class ImmunizationMapperTest {
 
         when(codeableConceptMapper.mapToCodeableConcept(any()))
             .thenReturn(createCodeableConcept(null, null, CODING_DISPLAY));
-        when(immunizationChecker.isImmunization(any()))
-            .thenReturn(true);
+        when(immunizationChecker.isImmunization(any())).thenReturn(true);
         lenient()
             .when(confidentialityService.createMetaAndAddSecurityIfConfidentialityCodesPresent(
                 eq("Immunization-1"),

--- a/gp2gp-translator/src/test/java/uk/nhs/adaptors/pss/translator/mapper/LocationMapperTest.java
+++ b/gp2gp-translator/src/test/java/uk/nhs/adaptors/pss/translator/mapper/LocationMapperTest.java
@@ -37,10 +37,10 @@ public class LocationMapperTest {
 
         assertThatIdentifierIsValid(location.getIdentifierFirstRep(), location.getId());
         assertThat(location.getStatus()).isEqualTo(Location.LocationStatus.ACTIVE);
-        assertThat(location.getMeta().getProfile().get(0).getValue()).isEqualTo(META_PROFILE);
+        assertThat(location.getMeta().getProfile().getFirst().getValue()).isEqualTo(META_PROFILE);
         assertThat(location.getName()).isEqualTo(ehrComposition.getLocation().getLocatedEntity().getLocatedPlace().getName());
         assertTelecom(location.getTelecomFirstRep(), ehrComposition.getLocation().getLocatedEntity().getLocatedPlace()
-                .getTelecom().get(0).getValue().substring(TEL_PREFIX_INT));
+                .getTelecom().getFirst().getValue().substring(TEL_PREFIX_INT));
         assertThat(location.getAddress().getLine().toString()).hasToString(ehrComposition.getLocation().getLocatedEntity()
                 .getLocatedPlace().getAddr().getStreetAddressLine().toString());
         assertThat(location.getAddress().getPostalCode()).isEqualTo(ehrComposition.getLocation().getLocatedEntity()
@@ -55,7 +55,7 @@ public class LocationMapperTest {
 
         assertThatIdentifierIsValid(location.getIdentifierFirstRep(), location.getId());
         assertThat(location.getStatus()).isEqualTo(Location.LocationStatus.ACTIVE);
-        assertThat(location.getMeta().getProfile().get(0).getValue()).isEqualTo(META_PROFILE);
+        assertThat(location.getMeta().getProfile().getFirst().getValue()).isEqualTo(META_PROFILE);
     }
 
     @Test
@@ -66,7 +66,7 @@ public class LocationMapperTest {
 
         assertThatIdentifierIsValid(location.getIdentifierFirstRep(), location.getId());
         assertThat(location.getStatus()).isEqualTo(Location.LocationStatus.ACTIVE);
-        assertThat(location.getMeta().getProfile().get(0).getValue()).isEqualTo(META_PROFILE);
+        assertThat(location.getMeta().getProfile().getFirst().getValue()).isEqualTo(META_PROFILE);
     }
 
     @Test
@@ -77,7 +77,7 @@ public class LocationMapperTest {
 
         assertThatIdentifierIsValid(location.getIdentifierFirstRep(), location.getId());
         assertThat(location.getStatus()).isEqualTo(Location.LocationStatus.ACTIVE);
-        assertThat(location.getMeta().getProfile().get(0).getValue()).isEqualTo(META_PROFILE);
+        assertThat(location.getMeta().getProfile().getFirst().getValue()).isEqualTo(META_PROFILE);
         assertThat(location.getName()).isEqualTo(ehrComposition.getLocation().getLocatedEntity().getLocatedPlace().getName());
     }
 
@@ -89,7 +89,7 @@ public class LocationMapperTest {
 
         assertThatIdentifierIsValid(location.getIdentifierFirstRep(), location.getId());
         assertThat(location.getStatus()).isEqualTo(Location.LocationStatus.ACTIVE);
-        assertThat(location.getMeta().getProfile().get(0).getValue()).isEqualTo(META_PROFILE);
+        assertThat(location.getMeta().getProfile().getFirst().getValue()).isEqualTo(META_PROFILE);
         assertThat(location.getName()).isEqualTo(UNKNOWN_NAME);
     }
 
@@ -101,10 +101,10 @@ public class LocationMapperTest {
 
         assertThatIdentifierIsValid(location.getIdentifierFirstRep(), location.getId());
         assertThat(location.getStatus()).isEqualTo(Location.LocationStatus.ACTIVE);
-        assertThat(location.getMeta().getProfile().get(0).getValue()).isEqualTo(META_PROFILE);
+        assertThat(location.getMeta().getProfile().getFirst().getValue()).isEqualTo(META_PROFILE);
         assertThat(location.getName()).isEqualTo(ehrComposition.getLocation().getLocatedEntity().getLocatedPlace().getName());
         assertTelecom(location.getTelecomFirstRep(), ehrComposition.getLocation().getLocatedEntity().getLocatedPlace()
-                .getTelecom().get(0).getValue().substring(TEL_PREFIX_INT));
+                .getTelecom().getFirst().getValue().substring(TEL_PREFIX_INT));
     }
 
     @Test
@@ -115,10 +115,10 @@ public class LocationMapperTest {
 
         assertThatIdentifierIsValid(location.getIdentifierFirstRep(), location.getId());
         assertThat(location.getStatus()).isEqualTo(Location.LocationStatus.ACTIVE);
-        assertThat(location.getMeta().getProfile().get(0).getValue()).isEqualTo(META_PROFILE);
+        assertThat(location.getMeta().getProfile().getFirst().getValue()).isEqualTo(META_PROFILE);
         assertThat(location.getName()).isEqualTo(ehrComposition.getLocation().getLocatedEntity().getLocatedPlace().getName());
         assertTelecom(location.getTelecomFirstRep(), ehrComposition.getLocation().getLocatedEntity().getLocatedPlace()
-                .getTelecom().get(0).getValue());
+                .getTelecom().getFirst().getValue());
     }
 
     @Test
@@ -129,7 +129,7 @@ public class LocationMapperTest {
 
         assertThatIdentifierIsValid(location.getIdentifierFirstRep(), location.getId());
         assertThat(location.getStatus()).isEqualTo(Location.LocationStatus.ACTIVE);
-        assertThat(location.getMeta().getProfile().get(0).getValue()).isEqualTo(META_PROFILE);
+        assertThat(location.getMeta().getProfile().getFirst().getValue()).isEqualTo(META_PROFILE);
         assertThat(location.getName()).isEqualTo(ehrComposition.getLocation().getLocatedEntity().getLocatedPlace().getName());
         assertThat(location.getAddress().getLine().toString()).hasToString(ehrComposition.getLocation().getLocatedEntity()
                 .getLocatedPlace().getAddr().getStreetAddressLine().toString());
@@ -145,7 +145,7 @@ public class LocationMapperTest {
 
         assertThatIdentifierIsValid(location.getIdentifierFirstRep(), location.getId());
         assertThat(location.getStatus()).isEqualTo(Location.LocationStatus.ACTIVE);
-        assertThat(location.getMeta().getProfile().get(0).getValue()).isEqualTo(META_PROFILE);
+        assertThat(location.getMeta().getProfile().getFirst().getValue()).isEqualTo(META_PROFILE);
         assertThat(location.getName()).isEqualTo(ehrComposition.getLocation().getLocatedEntity().getLocatedPlace().getName());
         assertThat(location.getAddress().getLine().toString()).hasToString(ehrComposition.getLocation().getLocatedEntity()
                 .getLocatedPlace().getAddr().getStreetAddressLine().toString());
@@ -160,7 +160,7 @@ public class LocationMapperTest {
 
         assertThatIdentifierIsValid(location.getIdentifierFirstRep(), location.getId());
         assertThat(location.getStatus()).isEqualTo(Location.LocationStatus.ACTIVE);
-        assertThat(location.getMeta().getProfile().get(0).getValue()).isEqualTo(META_PROFILE);
+        assertThat(location.getMeta().getProfile().getFirst().getValue()).isEqualTo(META_PROFILE);
         assertThat(location.getName()).isEqualTo(ehrComposition.getLocation().getLocatedEntity().getLocatedPlace().getName());
         assertThat(location.getAddress().isEmpty()).isTrue();
     }

--- a/gp2gp-translator/src/test/java/uk/nhs/adaptors/pss/translator/mapper/ObservationCommentMapperTest.java
+++ b/gp2gp-translator/src/test/java/uk/nhs/adaptors/pss/translator/mapper/ObservationCommentMapperTest.java
@@ -51,27 +51,27 @@ public class ObservationCommentMapperTest {
         List<Observation> observations =
             observationCommentMapper.mapResources(ehrExtract, patient, Collections.singletonList(encounter), PRACTISE_CODE);
 
-        var observation = observations.get(0);
+        var observation = observations.getFirst();
 
         assertThat(observation.getId()).isEqualTo(narrativeStatementId);
-        assertThat(observation.getMeta().getProfile().get(0).getValue()).isEqualTo(META_URL);
+        assertThat(observation.getMeta().getProfile().getFirst().getValue()).isEqualTo(META_URL);
         assertThat(observation.getStatus()).isEqualTo(Observation.ObservationStatus.FINAL);
         assertThat(observation.getSubject().getResource()).isEqualTo(patient);
 
         var coding = observation.getCode().getCoding();
-        assertThat(coding.get(0).getCode()).isEqualTo(CODING_CODE);
-        assertThat(coding.get(0).getSystem()).isEqualTo(CODING_SYSTEM);
+        assertThat(coding.getFirst().getCode()).isEqualTo(CODING_CODE);
+        assertThat(coding.getFirst().getSystem()).isEqualTo(CODING_SYSTEM);
 
         assertThat(observation.getEffective().toString()).isEqualTo(
             DateFormatUtil.parseToDateTimeType(narrativeStatement.getAvailabilityTime().getValue()).toString());
 
         assertThat(observation.getIssuedElement().asStringValue()).isEqualTo("2020-10-12T13:33:44.000+00:00");
 
-        var identifier = observation.getIdentifier().get(0);
+        var identifier = observation.getIdentifier().getFirst();
         assertThat(identifier.getValue()).isEqualTo(narrativeStatementId);
         assertThat(identifier.getSystem()).isEqualTo(IDENTIFIER_SYSTEM);
 
-        assertThat(observation.getPerformer().get(0).getReference()).isEqualTo("Practitioner/2D70F602-6BB1-47E0-B2EC-39912A59787D");
+        assertThat(observation.getPerformer().getFirst().getReference()).isEqualTo("Practitioner/2D70F602-6BB1-47E0-B2EC-39912A59787D");
         assertThat(observation.getComment()).isEqualTo("Some example text");
         assertThat(observation.getContext().getResource()).isEqualTo(encounter);
     }
@@ -129,7 +129,7 @@ public class ObservationCommentMapperTest {
         List<Observation> observations =
             observationCommentMapper.mapResources(ehrExtract, patient, Collections.emptyList(), PRACTISE_CODE);
 
-        assertThat(observations.get(0).getIssuedElement().asStringValue()).isNull();
+        assertThat(observations.getFirst().getIssuedElement().asStringValue()).isNull();
     }
 
     @Test
@@ -140,7 +140,7 @@ public class ObservationCommentMapperTest {
             observationCommentMapper.mapResources(ehrExtract, patient, Collections.emptyList(), PRACTISE_CODE);
 
         // Calling `getContext` auto creates a Reference object so asserting the reference is null
-        assertThat(observations.get(0).getContext().getReference()).isNull();
+        assertThat(observations.getFirst().getContext().getReference()).isNull();
     }
 
     @Test
@@ -150,13 +150,13 @@ public class ObservationCommentMapperTest {
         List<Observation> observations =
             observationCommentMapper.mapResources(ehrExtract, patient, Collections.emptyList(), PRACTISE_CODE);
 
-        assertThat(observations.get(0).getComment()).isNull();
+        assertThat(observations.getFirst().getComment()).isNull();
     }
 
     private RCMRMT030101UKNarrativeStatement getNarrativeStatement(RCMRMT030101UKEhrExtract ehrExtract) {
-        return ehrExtract.getComponent().get(0)
-            .getEhrFolder().getComponent().get(0)
-            .getEhrComposition().getComponent().get(0)
+        return ehrExtract.getComponent().getFirst()
+            .getEhrFolder().getComponent().getFirst()
+            .getEhrComposition().getComponent().getFirst()
             .getNarrativeStatement();
     }
 

--- a/gp2gp-translator/src/test/java/uk/nhs/adaptors/pss/translator/mapper/ObservationMapperTest.java
+++ b/gp2gp-translator/src/test/java/uk/nhs/adaptors/pss/translator/mapper/ObservationMapperTest.java
@@ -122,7 +122,7 @@ public class ObservationMapperTest {
         when(confidentialityService.createMetaAndAddSecurityIfConfidentialityCodesPresent(
             META_PROFILE,
             ehrComposition.getConfidentialityCode(),
-            observationStatements.get(0).getConfidentialityCode(),
+            observationStatements.getFirst().getConfidentialityCode(),
             compoundStatement.getConfidentialityCode()
         )).thenReturn(META);
 
@@ -136,7 +136,7 @@ public class ObservationMapperTest {
         var observations = observationMapper.mapResources(ehrExtract, patient, ENCOUNTER_LIST, PRACTISE_CODE);
 
         assertThat(observations).hasSize(2);
-        assertMetaSecurityIsPresent(observations.get(0).getMeta());
+        assertMetaSecurityIsPresent(observations.getFirst().getMeta());
         assertMetaSecurityIsPresent(observations.get(1).getMeta());
     }
 
@@ -176,7 +176,7 @@ public class ObservationMapperTest {
             Optional.empty()
         )).thenReturn(META);
 
-        var observation = observationMapper.mapResources(ehrExtract, patient, ENCOUNTER_LIST, PRACTISE_CODE).get(0);
+        var observation = observationMapper.mapResources(ehrExtract, patient, ENCOUNTER_LIST, PRACTISE_CODE).getFirst();
 
         assertMetaSecurityIsPresent(observation.getMeta());
     }
@@ -194,21 +194,21 @@ public class ObservationMapperTest {
             Optional.empty()
         )).thenReturn(META);
 
-        var observation = observationMapper.mapResources(ehrExtract, patient, ENCOUNTER_LIST, PRACTISE_CODE).get(0);
+        var observation = observationMapper.mapResources(ehrExtract, patient, ENCOUNTER_LIST, PRACTISE_CODE).getFirst();
 
         assertFixedValues(observation);
         assertThat(observation.getId()).isEqualTo(EXAMPLE_ID);
         assertThat(observation.getEffective()).isInstanceOf(DateTimeType.class);
         assertThat(observation.getEffectiveDateTimeType().getValue()).isEqualTo("2019-07-08T13:35:00+00:00");
         assertThat(observation.getIssuedElement().asStringValue()).isEqualTo(ISSUED_EHR_COMPOSITION_EXAMPLE);
-        assertThat(observation.getPerformer().get(0).getReference()).isEqualTo(PPRF_PARTICIPANT_ID);
+        assertThat(observation.getPerformer().getFirst().getReference()).isEqualTo(PPRF_PARTICIPANT_ID);
         assertThat(observation.getValue()).isInstanceOf(Quantity.class);
         assertQuantity(observation.getValueQuantity(), QUANTITY_VALUE, "kilogram per square meter", "kg/m2");
         assertInterpretation(observation.getInterpretation(), "High", "H", "High");
         assertThat(observation.getComment()).isEqualTo("Subject: Uncle Test text 1");
-        assertThat(observation.getReferenceRange().get(0).getText()).isEqualTo("Age and sex based");
-        assertQuantity(observation.getReferenceRange().get(0).getLow(), REFERENCE_RANGE_LOW_VALUE, "liter", "L");
-        assertQuantity(observation.getReferenceRange().get(0).getHigh(), REFERENCE_RANGE_HIGH_VALUE, "liter", "L");
+        assertThat(observation.getReferenceRange().getFirst().getText()).isEqualTo("Age and sex based");
+        assertQuantity(observation.getReferenceRange().getFirst().getLow(), REFERENCE_RANGE_LOW_VALUE, "liter", "L");
+        assertQuantity(observation.getReferenceRange().getFirst().getHigh(), REFERENCE_RANGE_HIGH_VALUE, "liter", "L");
         assertTrue(observation.hasSubject());
     }
 
@@ -229,7 +229,7 @@ public class ObservationMapperTest {
             Optional.empty()
         )).thenReturn(META);
 
-        var observation = observationMapper.mapResources(ehrExtract, patient, ENCOUNTER_LIST, PRACTISE_CODE).get(0);
+        var observation = observationMapper.mapResources(ehrExtract, patient, ENCOUNTER_LIST, PRACTISE_CODE).getFirst();
 
         assertFixedValues(observation);
         assertThat(observation.getComment()).isEqualTo(EPISODICITY_WITH_ORIGINAL_TEXT_NOTE_TEXT);
@@ -251,7 +251,7 @@ public class ObservationMapperTest {
             Optional.empty()
         )).thenReturn(META);
 
-        var observation = observationMapper.mapResources(ehrExtract, patient, ENCOUNTER_LIST, PRACTISE_CODE).get(0);
+        var observation = observationMapper.mapResources(ehrExtract, patient, ENCOUNTER_LIST, PRACTISE_CODE).getFirst();
 
         assertFixedValues(observation);
         assertThat(observation.getComment()).isEqualTo(EPISODICITY_WITH_ORIGINAL_TEXT_NOTE_TEXT_WITH_ORIGINAL_TEXT);
@@ -269,7 +269,7 @@ public class ObservationMapperTest {
             Optional.empty()
         )).thenReturn(META);
 
-        var observation = observationMapper.mapResources(ehrExtract, patient, ENCOUNTER_LIST, PRACTISE_CODE).get(0);
+        var observation = observationMapper.mapResources(ehrExtract, patient, ENCOUNTER_LIST, PRACTISE_CODE).getFirst();
 
         assertFixedValues(observation);
         assertThat(observation.getComment()).contains(EPISODICITY_WITH_ORIGINAL_TEXT_NOTE_TEXT_WITH_ORIGINAL_TEXT);
@@ -306,12 +306,12 @@ public class ObservationMapperTest {
             Optional.empty()
         )).thenReturn(META);
 
-        var observation = observationMapper.mapResources(ehrExtract, patient, ENCOUNTER_LIST, PRACTISE_CODE).get(0);
+        var observation = observationMapper.mapResources(ehrExtract, patient, ENCOUNTER_LIST, PRACTISE_CODE).getFirst();
 
         assertFixedValues(observation);
         assertThat(observation.getId()).isEqualTo(EXAMPLE_ID);
         assertThat(observation.getIssuedElement().asStringValue()).isEqualTo(ISSUED_EHR_COMPOSITION_EXAMPLE);
-        assertThat(observation.getPerformer().get(0).getReference()).isEqualTo(PPRF_PARTICIPANT_ID);
+        assertThat(observation.getPerformer().getFirst().getReference()).isEqualTo(PPRF_PARTICIPANT_ID);
         assertNull(observation.getEffective());
         assertNull(observation.getValue());
         assertThat(observation.getInterpretation().getCoding()).isEmpty();
@@ -322,7 +322,7 @@ public class ObservationMapperTest {
     @Test
     public void mapObservationWithValueStringUsingValueTypeST() {
         var ehrExtract = unmarshallEhrExtractElement("value_st_observation_example.xml");
-        var observation = observationMapper.mapResources(ehrExtract, patient, ENCOUNTER_LIST, PRACTISE_CODE).get(0);
+        var observation = observationMapper.mapResources(ehrExtract, patient, ENCOUNTER_LIST, PRACTISE_CODE).getFirst();
 
         assertThat(observation.getValue()).isInstanceOf(StringType.class);
         assertThat(observation.getValueStringType().getValue()).isEqualToIgnoringWhitespace(NEGATIVE_VALUE);
@@ -331,7 +331,7 @@ public class ObservationMapperTest {
     @Test
     public void mapObservationWithValueStringUsingValueTypeCVOriginalText() {
         var ehrExtract = unmarshallEhrExtractElement("value_cv_display_name_observation_example.xml");
-        var observation = observationMapper.mapResources(ehrExtract, patient, ENCOUNTER_LIST, PRACTISE_CODE).get(0);
+        var observation = observationMapper.mapResources(ehrExtract, patient, ENCOUNTER_LIST, PRACTISE_CODE).getFirst();
 
         assertThat(observation.getValue()).isInstanceOf(StringType.class);
         assertThat(observation.getValueStringType().getValue()).isEqualTo(TEST_DISPLAY_VALUE);
@@ -340,7 +340,7 @@ public class ObservationMapperTest {
     @Test
     public void mapObservationWithMultiplePertinentInformation() {
         var ehrExtract = unmarshallEhrExtractElement("multiple_pertinent_information_observation_example.xml");
-        var observation = observationMapper.mapResources(ehrExtract, patient, ENCOUNTER_LIST, PRACTISE_CODE).get(0);
+        var observation = observationMapper.mapResources(ehrExtract, patient, ENCOUNTER_LIST, PRACTISE_CODE).getFirst();
 
         assertThat(observation.getComment()).isEqualTo("Test text 1 Test text 2");
     }
@@ -348,7 +348,7 @@ public class ObservationMapperTest {
     @Test
     public void mapObservationWithCompositionIdMatchingEncounter() {
         var ehrExtract = unmarshallEhrExtractElement("ehr_composition_id_matching_encounter_observation_example.xml");
-        var observation = observationMapper.mapResources(ehrExtract, patient, ENCOUNTER_LIST, PRACTISE_CODE).get(0);
+        var observation = observationMapper.mapResources(ehrExtract, patient, ENCOUNTER_LIST, PRACTISE_CODE).getFirst();
 
         assertTrue(observation.hasContext());
     }
@@ -357,7 +357,7 @@ public class ObservationMapperTest {
     public void mapObservationWithEffectiveDateTime() {
         var ehrExtract = unmarshallEhrExtractElement(
             "effective_date_time_type_using_effective_time_center.xml");
-        var observation = observationMapper.mapResources(ehrExtract, patient, ENCOUNTER_LIST, PRACTISE_CODE).get(0);
+        var observation = observationMapper.mapResources(ehrExtract, patient, ENCOUNTER_LIST, PRACTISE_CODE).getFirst();
 
         assertTrue(observation.getEffective() instanceof DateTimeType);
         assertThat(observation.getEffectiveDateTimeType().getValueAsString()).isEqualTo("2010-05-21");
@@ -367,7 +367,7 @@ public class ObservationMapperTest {
     public void mapObservationWithEffectivePeriod() {
         var ehrExtract = unmarshallEhrExtractElement(
             "effective_period_start_end_using_effective_time_observation_example.xml");
-        var observation = observationMapper.mapResources(ehrExtract, patient, ENCOUNTER_LIST, PRACTISE_CODE).get(0);
+        var observation = observationMapper.mapResources(ehrExtract, patient, ENCOUNTER_LIST, PRACTISE_CODE).getFirst();
 
         assertTrue(observation.getEffective() instanceof Period);
         assertThat(observation.getEffectivePeriod().getStartElement().getValueAsString()).isEqualTo("2010-05-21");
@@ -386,7 +386,7 @@ public class ObservationMapperTest {
     public void When_MapObservation_With_Plus1SequenceComment_Expect_CommentMapped() {
         var ehrExtract = unmarshallEhrExtractElement(
             "sequence_comment_plus1__originalText_observation.xml");
-        var observation = observationMapper.mapResources(ehrExtract, patient, ENCOUNTER_LIST, PRACTISE_CODE).get(0);
+        var observation = observationMapper.mapResources(ehrExtract, patient, ENCOUNTER_LIST, PRACTISE_CODE).getFirst();
 
         assertThat(observation.getComment()).isEqualTo(PLUS_ONE_ANNOTATION_TEXT);
     }
@@ -395,7 +395,7 @@ public class ObservationMapperTest {
     public void When_MapObservation_With_Minus1SequenceComment_Expect_CommentAndOriginalTextMapped() {
         var ehrExtract = unmarshallEhrExtractElement(
             "sequence_comment_minus1_originalText_observation.xml");
-        var observation = observationMapper.mapResources(ehrExtract, patient, ENCOUNTER_LIST, PRACTISE_CODE).get(0);
+        var observation = observationMapper.mapResources(ehrExtract, patient, ENCOUNTER_LIST, PRACTISE_CODE).getFirst();
 
         var expectedComment = MINUS_ONE_ANNOTATION_TEXT + StringUtils.SPACE + ORIGINAL_TEXT;
 
@@ -406,7 +406,7 @@ public class ObservationMapperTest {
     public void When_MapObservation_With_Minus1AndPlus1SequenceComment_Expect_CommentsAndOriginalTextMapped() {
         var ehrExtract = unmarshallEhrExtractElement(
             "sequence_comment_plus1_minus1_originalText_observation.xml");
-        var observation = observationMapper.mapResources(ehrExtract, patient, ENCOUNTER_LIST, PRACTISE_CODE).get(0);
+        var observation = observationMapper.mapResources(ehrExtract, patient, ENCOUNTER_LIST, PRACTISE_CODE).getFirst();
 
         var expectedComment = MINUS_ONE_ANNOTATION_TEXT + StringUtils.SPACE + ORIGINAL_TEXT + StringUtils.SPACE + PLUS_ONE_ANNOTATION_TEXT;
 
@@ -417,7 +417,7 @@ public class ObservationMapperTest {
     public void When_MapObservation_With_ZeroSequenceAndPlus1SequenceComment_Expect_CommentsMapped() {
         var ehrExtract = unmarshallEhrExtractElement(
             "sequence_comment_plus1_zero_originalText_observation.xml");
-        var observation = observationMapper.mapResources(ehrExtract, patient, ENCOUNTER_LIST, PRACTISE_CODE).get(0);
+        var observation = observationMapper.mapResources(ehrExtract, patient, ENCOUNTER_LIST, PRACTISE_CODE).getFirst();
 
         var expectedComment = ZERO_ANNOTATION_TEXT + StringUtils.SPACE + PLUS_ONE_ANNOTATION_TEXT;
 
@@ -428,7 +428,7 @@ public class ObservationMapperTest {
     public void When_MapObservation_With_ZeroSequenceComment_Expect_CommentMapped() {
         var ehrExtract = unmarshallEhrExtractElement(
             "sequence_comment_zero_originalText_observation.xml");
-        var observation = observationMapper.mapResources(ehrExtract, patient, ENCOUNTER_LIST, PRACTISE_CODE).get(0);
+        var observation = observationMapper.mapResources(ehrExtract, patient, ENCOUNTER_LIST, PRACTISE_CODE).getFirst();
 
         assertThat(observation.getComment()).isEqualTo(ZERO_ANNOTATION_TEXT);
     }
@@ -437,7 +437,7 @@ public class ObservationMapperTest {
     public void When_MapObservation_With_Minus1SequenceCommentAndNoOriginalText_Expect_CommentMapped() {
         var ehrExtract = unmarshallEhrExtractElement(
             "sequence_comment_minus1_observation.xml");
-        var observation = observationMapper.mapResources(ehrExtract, patient, ENCOUNTER_LIST, PRACTISE_CODE).get(0);
+        var observation = observationMapper.mapResources(ehrExtract, patient, ENCOUNTER_LIST, PRACTISE_CODE).getFirst();
 
         assertThat(observation.getComment()).isEqualTo(MINUS_ONE_ANNOTATION_TEXT);
     }
@@ -446,7 +446,7 @@ public class ObservationMapperTest {
     public void When_MapObservation_With_AllSequenceCommentsAndOriginalText_Expect_MappedInCorrectOrder() {
         var ehrExtract = unmarshallEhrExtractElement(
             "sequence_comment_all_observation.xml");
-        var observation = observationMapper.mapResources(ehrExtract, patient, ENCOUNTER_LIST, PRACTISE_CODE).get(0);
+        var observation = observationMapper.mapResources(ehrExtract, patient, ENCOUNTER_LIST, PRACTISE_CODE).getFirst();
 
         var expectedComment = MINUS_ONE_ANNOTATION_TEXT + StringUtils.SPACE + ORIGINAL_TEXT + StringUtils.SPACE + ZERO_ANNOTATION_TEXT
             + StringUtils.SPACE + PLUS_ONE_ANNOTATION_TEXT;
@@ -458,7 +458,7 @@ public class ObservationMapperTest {
     public void When_MapObservation_WithNullFlavorSequenceComments_Expect_CommentsPostFixed() {
         var ehrExtract = unmarshallEhrExtractElement(
             "sequence_comment_minus1_nullFlavor_originalText.xml");
-        var observation = observationMapper.mapResources(ehrExtract, patient, ENCOUNTER_LIST, PRACTISE_CODE).get(0);
+        var observation = observationMapper.mapResources(ehrExtract, patient, ENCOUNTER_LIST, PRACTISE_CODE).getFirst();
 
         var expectedComment = MINUS_ONE_ANNOTATION_TEXT + StringUtils.SPACE + ORIGINAL_TEXT + StringUtils.SPACE
             + NULL_FLAVOR_ANNOTATION_TEXT;
@@ -473,7 +473,7 @@ public class ObservationMapperTest {
         when(codeableConceptMapper.mapToCodeableConcept(any())).thenReturn(codeableConcept);
 
         var ehrExtract = unmarshallEhrExtractElement("full_valid_data_observation_example.xml");
-        var observation = observationMapper.mapResources(ehrExtract, patient, ENCOUNTER_LIST, PRACTISE_CODE).get(0);
+        var observation = observationMapper.mapResources(ehrExtract, patient, ENCOUNTER_LIST, PRACTISE_CODE).getFirst();
 
         assertThat(observation.getCode().getCodingFirstRep())
             .isEqualTo(DegradedCodeableConcepts.DEGRADED_OTHER);
@@ -486,7 +486,7 @@ public class ObservationMapperTest {
         lenient().when(codeableConceptMapper.mapToCodeableConcept(any())).thenReturn(codeableConcept);
 
         var ehrExtract = unmarshallEhrExtractElement("full_valid_data_observation_example.xml");
-        var observation = observationMapper.mapResources(ehrExtract, patient, ENCOUNTER_LIST, PRACTISE_CODE).get(0);
+        var observation = observationMapper.mapResources(ehrExtract, patient, ENCOUNTER_LIST, PRACTISE_CODE).getFirst();
 
         assertThat(observation.getCode().getCodingFirstRep().getDisplay())
             .isEqualTo(CODING_DISPLAY_MOCK);
@@ -495,17 +495,17 @@ public class ObservationMapperTest {
     }
 
     private void assertFixedValues(Observation observation) {
-        assertThat(observation.getMeta().getProfile().get(0).getValue()).isEqualTo(META_PROFILE);
-        assertThat(observation.getIdentifier().get(0).getSystem()).isEqualTo(IDENTIFIER_SYSTEM);
-        assertThat(observation.getIdentifier().get(0).getValue()).isEqualTo(EXAMPLE_ID);
+        assertThat(observation.getMeta().getProfile().getFirst().getValue()).isEqualTo(META_PROFILE);
+        assertThat(observation.getIdentifier().getFirst().getSystem()).isEqualTo(IDENTIFIER_SYSTEM);
+        assertThat(observation.getIdentifier().getFirst().getValue()).isEqualTo(EXAMPLE_ID);
         assertThat(observation.getStatus()).isEqualTo(ObservationStatus.FINAL);
     }
 
     private void assertInterpretation(CodeableConcept interpretation, String text, String code, String display) {
         assertThat(interpretation.getText()).isEqualTo(text);
-        assertThat(interpretation.getCoding().get(0).getCode()).isEqualTo(code);
-        assertThat(interpretation.getCoding().get(0).getDisplay()).isEqualTo(display);
-        assertThat(interpretation.getCoding().get(0).getSystem()).isEqualTo(INTERPRETATION_SYSTEM);
+        assertThat(interpretation.getCoding().getFirst().getCode()).isEqualTo(code);
+        assertThat(interpretation.getCoding().getFirst().getDisplay()).isEqualTo(display);
+        assertThat(interpretation.getCoding().getFirst().getSystem()).isEqualTo(INTERPRETATION_SYSTEM);
     }
 
     private void assertQuantity(Quantity quantity, BigDecimal value, String unit, String code) {
@@ -517,8 +517,8 @@ public class ObservationMapperTest {
     private void assertMetaSecurityIsPresent(final Meta meta) {
         final List<Coding> metaSecurity = meta.getSecurity();
         final int metaSecuritySize = metaSecurity.size();
-        final Coding metaSecurityCoding = metaSecurity.get(0);
-        final UriType metaProfile = meta.getProfile().get(0);
+        final Coding metaSecurityCoding = metaSecurity.getFirst();
+        final UriType metaProfile = meta.getProfile().getFirst();
 
         assertAll(
             () -> assertThat(metaSecuritySize).isEqualTo(1),
@@ -531,24 +531,24 @@ public class ObservationMapperTest {
 
     private RCMRMT030101UKEhrComposition getEhrComposition(RCMRMT030101UKEhrExtract ehrExtract) {
 
-        return ehrExtract.getComponent().get(0)
-            .getEhrFolder().getComponent().get(0)
+        return ehrExtract.getComponent().getFirst()
+            .getEhrFolder().getComponent().getFirst()
             .getEhrComposition();
     }
 
     private RCMRMT030101UKObservationStatement getObservationStatement(RCMRMT030101UKEhrExtract ehrExtract) {
-        return ehrExtract.getComponent().get(0)
-            .getEhrFolder().getComponent().get(0)
-            .getEhrComposition().getComponent().get(0)
+        return ehrExtract.getComponent().getFirst()
+            .getEhrFolder().getComponent().getFirst()
+            .getEhrComposition().getComponent().getFirst()
             .getObservationStatement();
     }
 
     private List<RCMRMT030101UKObservationStatement> getObservationStatementIncludedIntoCompoundStatement(
         RCMRMT030101UKEhrExtract ehrExtract) {
 
-        return ehrExtract.getComponent().get(0)
-            .getEhrFolder().getComponent().get(0)
-            .getEhrComposition().getComponent().get(0).getCompoundStatement().getComponent().stream()
+        return ehrExtract.getComponent().getFirst()
+            .getEhrFolder().getComponent().getFirst()
+            .getEhrComposition().getComponent().getFirst().getCompoundStatement().getComponent().stream()
             .filter(RCMRMT030101UKComponent02::hasObservationStatement)
             .map(RCMRMT030101UKComponent02::getObservationStatement)
             .toList();

--- a/gp2gp-translator/src/test/java/uk/nhs/adaptors/pss/translator/mapper/OrganizationMapperTest.java
+++ b/gp2gp-translator/src/test/java/uk/nhs/adaptors/pss/translator/mapper/OrganizationMapperTest.java
@@ -39,6 +39,6 @@ public class OrganizationMapperTest {
         assertThat(organization.getId()).isEqualTo(ID);
         assertThat(organization.getIdentifierFirstRep().getSystem()).isEqualTo(ODS_SYSTEM);
         assertThat(organization.getIdentifierFirstRep().getValue()).isEqualTo(ODS_CODE);
-        assertThat(organization.getMeta().getProfile().get(0).getValue()).isEqualTo(CARE_CONNECT_PROFILE_ORG);
+        assertThat(organization.getMeta().getProfile().getFirst().getValue()).isEqualTo(CARE_CONNECT_PROFILE_ORG);
     }
 }

--- a/gp2gp-translator/src/test/java/uk/nhs/adaptors/pss/translator/mapper/ProcedureRequestMapperTest.java
+++ b/gp2gp-translator/src/test/java/uk/nhs/adaptors/pss/translator/mapper/ProcedureRequestMapperTest.java
@@ -406,8 +406,8 @@ public class ProcedureRequestMapperTest {
     private void assertMetaSecurityIsPresent(final Meta meta) {
         final List<Coding> metaSecurity = meta.getSecurity();
         final int metaSecuritySize = metaSecurity.size();
-        final Coding metaSecurityCoding = metaSecurity.get(0);
-        final UriType metaProfile = meta.getProfile().get(0);
+        final Coding metaSecurityCoding = metaSecurity.getFirst();
+        final UriType metaProfile = meta.getProfile().getFirst();
 
         assertAll(
             () -> assertThat(metaSecuritySize).isEqualTo(1),
@@ -423,7 +423,7 @@ public class ProcedureRequestMapperTest {
 
         assertAll(
             () -> assertThat(meta.getSecurity()).isEmpty(),
-            () -> assertEquals(META_PROFILE, meta.getProfile().get(0).getValue())
+            () -> assertEquals(META_PROFILE, meta.getProfile().getFirst().getValue())
         );
     }
 
@@ -432,21 +432,21 @@ public class ProcedureRequestMapperTest {
         assertThat(procedureRequest.getIntent()).isEqualTo(ProcedureRequestIntent.PLAN);
         assertThat(procedureRequest.getIdentifierFirstRep().getSystem()).isEqualTo(IDENTIFIER_SYSTEM);
         assertThat(procedureRequest.getIdentifierFirstRep().getValue()).isEqualTo(planStatement.getId().getRoot());
-        assertThat(procedureRequest.getMeta().getProfile().get(0).getValue()).isEqualTo(META_PROFILE);
+        assertThat(procedureRequest.getMeta().getProfile().getFirst().getValue()).isEqualTo(META_PROFILE);
         assertThat(procedureRequest.getSubject().getResource().getIdElement().getValue()).isEqualTo(SUBJECT.getId());
     }
 
     private RCMRMT030101UKPlanStatement getPlanStatement(RCMRMT030101UKEhrExtract ehrExtract) {
-        return ehrExtract.getComponent().get(0)
-            .getEhrFolder().getComponent().get(0)
-            .getEhrComposition().getComponent().get(0)
+        return ehrExtract.getComponent().getFirst()
+            .getEhrFolder().getComponent().getFirst()
+            .getEhrComposition().getComponent().getFirst()
             .getPlanStatement();
     }
 
     private RCMRMT030101UKEhrComposition getEhrComposition(RCMRMT030101UKEhrExtract ehrExtract) {
 
-        return ehrExtract.getComponent().get(0)
-            .getEhrFolder().getComponent().get(0)
+        return ehrExtract.getComponent().getFirst()
+            .getEhrFolder().getComponent().getFirst()
             .getEhrComposition();
     }
 

--- a/gp2gp-translator/src/test/java/uk/nhs/adaptors/pss/translator/mapper/ReferralRequestMapperTest.java
+++ b/gp2gp-translator/src/test/java/uk/nhs/adaptors/pss/translator/mapper/ReferralRequestMapperTest.java
@@ -98,8 +98,14 @@ class ReferralRequestMapperTest {
         var ehrExtract = unmarshallEhrExtractElement("full_valid_data_with_referral_request.xml");
 
         var referralRequest = mapReferralRequest(ehrExtract,
-                                                 ehrExtract.getComponent().get(0).getEhrFolder().getComponent().get(0).getEhrComposition(),
-                                                 composition -> composition.getComponent().get(0).getRequestStatement());
+                                                 ehrExtract
+                                                     .getComponent()
+                                                     .getFirst()
+                                                     .getEhrFolder()
+                                                     .getComponent()
+                                                     .getFirst()
+                                                     .getEhrComposition(),
+                                                 composition -> composition.getComponent().getFirst().getRequestStatement());
 
         assertAll(
             () -> assertFixedValues(referralRequest),
@@ -107,8 +113,8 @@ class ReferralRequestMapperTest {
             () -> assertThat(referralRequest.getAuthoredOn()).isEqualTo("2020-11-17T13:30:32:00"),
             () -> assertEquals(PRACTITIONER_ID, referralRequest.getRequester().getAgent().getReference()),
             () -> assertEquals("Organization/9C3AB881-FCDE-48EC-8028-37B20E0AE893",
-                               referralRequest.getRecipient().get(0).getReference()),
-            () -> assertEquals("Reason Code 1", referralRequest.getReasonCodeFirstRep().getCoding().get(0).getDisplay())
+                               referralRequest.getRecipient().getFirst().getReference()),
+            () -> assertEquals("Reason Code 1", referralRequest.getReasonCodeFirstRep().getCoding().getFirst().getDisplay())
         );
     }
 
@@ -123,21 +129,27 @@ class ReferralRequestMapperTest {
         var ehrExtract = unmarshallEhrExtractElement("full_valid_data_example.xml");
 
         var referralRequest = mapReferralRequest(ehrExtract,
-                                                 ehrExtract.getComponent().get(0).getEhrFolder().getComponent().get(0).getEhrComposition(),
-                                                 composition -> composition.getComponent().get(0).getRequestStatement());
+                                                 ehrExtract
+                                                     .getComponent()
+                                                     .getFirst()
+                                                     .getEhrFolder()
+                                                     .getComponent()
+                                                     .getFirst()
+                                                     .getEhrComposition(),
+                                                 composition -> composition.getComponent().getFirst().getRequestStatement());
 
         assertAll(
-                () -> assertFixedValues(referralRequest),
-                () -> assertEquals(EXAMPLE_ID, referralRequest.getId()),
-                () -> assertEquals("Priority: Routine", referralRequest.getNote().get(0).getText()),
-                () -> assertEquals("Action Date: 2005-04-06", referralRequest.getNote().get(1).getText()),
-                () -> assertEquals("Test request statement text New line", referralRequest.getNote().get(2).getText()),
-                () -> assertThat(referralRequest.getAuthoredOn()).isEqualTo("2010-01-01T12:30:00+00:00"),
-                () -> assertEquals(PRACTITIONER_ID, referralRequest.getRequester().getAgent().getReference()),
-                () -> assertEquals("Practitioner/B8CA3710-4D1C-11E3-9E6B-010000001205",
-                                   referralRequest.getRecipient().get(0).getReference()),
-                () -> assertEquals("Reason Code 1", referralRequest.getReasonCodeFirstRep().getCoding().get(0).getDisplay()),
-                () -> assertEquals(ENCOUNTER_ID, referralRequest.getContext().getResource().getIdElement().getValue())
+            () -> assertFixedValues(referralRequest),
+            () -> assertEquals(EXAMPLE_ID, referralRequest.getId()),
+            () -> assertEquals("Priority: Routine", referralRequest.getNote().getFirst().getText()),
+            () -> assertEquals("Action Date: 2005-04-06", referralRequest.getNote().get(1).getText()),
+            () -> assertEquals("Test request statement text New line", referralRequest.getNote().get(2).getText()),
+            () -> assertThat(referralRequest.getAuthoredOn()).isEqualTo("2010-01-01T12:30:00+00:00"),
+            () -> assertEquals(PRACTITIONER_ID, referralRequest.getRequester().getAgent().getReference()),
+            () -> assertEquals("Practitioner/B8CA3710-4D1C-11E3-9E6B-010000001205",
+                               referralRequest.getRecipient().getFirst().getReference()),
+            () -> assertEquals("Reason Code 1", referralRequest.getReasonCodeFirstRep().getCoding().getFirst().getDisplay()),
+            () -> assertEquals(ENCOUNTER_ID, referralRequest.getContext().getResource().getIdElement().getValue())
         );
     }
 
@@ -158,15 +170,15 @@ class ReferralRequestMapperTest {
         var ehrComposition = unmarshallStringToEhrCompositionElement(inputXml);
 
         var referralRequest = mapReferralRequest(null, ehrComposition,
-            composition -> composition.getComponent().get(0).getRequestStatement());
+            composition -> composition.getComponent().getFirst().getRequestStatement());
 
         assertAll(
-                () -> assertEquals(EXAMPLE_ID, referralRequest.getId()),
-                () -> assertThat(referralRequest.getNote()).isEmpty(),
-                () -> assertNull(referralRequest.getAuthoredOn()),
-                () -> assertNull(referralRequest.getRequester().getAgent().getReference()),
-                () -> assertThat(referralRequest.getRecipient()).isEmpty(),
-                () -> assertThat(referralRequest.getReasonCode()).isEmpty()
+            () -> assertEquals(EXAMPLE_ID, referralRequest.getId()),
+            () -> assertThat(referralRequest.getNote()).isEmpty(),
+            () -> assertNull(referralRequest.getAuthoredOn()),
+            () -> assertNull(referralRequest.getRequester().getAgent().getReference()),
+            () -> assertThat(referralRequest.getRecipient()).isEmpty(),
+            () -> assertThat(referralRequest.getReasonCode()).isEmpty()
         );
     }
 
@@ -187,7 +199,7 @@ class ReferralRequestMapperTest {
         var ehrComposition = unmarshallStringToEhrCompositionElement(inputXml);
 
         ReferralRequest referralRequest = mapReferralRequest(null, ehrComposition,
-            composition -> composition.getComponent().get(0).getRequestStatement());
+            composition -> composition.getComponent().getFirst().getRequestStatement());
 
         assertNull(referralRequest.getContext().getResource());
     }
@@ -219,15 +231,15 @@ class ReferralRequestMapperTest {
         var ehrComposition = unmarshallStringToEhrCompositionElement(inputXml);
 
         ReferralRequest referralRequest = mapReferralRequest(null, ehrComposition,
-            composition -> composition.getComponent().get(0).getRequestStatement());
+            composition -> composition.getComponent().getFirst().getRequestStatement());
 
         assertAll(
-                () -> assertEquals(EXAMPLE_ID, referralRequest.getId()),
-                () -> assertThat(referralRequest.getNote()).isEmpty(),
-                () -> assertNull(referralRequest.getAuthoredOn()),
-                () -> assertEquals(PRACTITIONER_ID, referralRequest.getRequester().getAgent().getReference()),
-                () -> assertThat(referralRequest.getRecipient()).isEmpty(),
-                () -> assertThat(referralRequest.getReasonCode()).isEmpty()
+            () -> assertEquals(EXAMPLE_ID, referralRequest.getId()),
+            () -> assertThat(referralRequest.getNote()).isEmpty(),
+            () -> assertNull(referralRequest.getAuthoredOn()),
+            () -> assertEquals(PRACTITIONER_ID, referralRequest.getRequester().getAgent().getReference()),
+            () -> assertThat(referralRequest.getRecipient()).isEmpty(),
+            () -> assertThat(referralRequest.getReasonCode()).isEmpty()
         );
     }
 
@@ -258,15 +270,15 @@ class ReferralRequestMapperTest {
         var ehrComposition = unmarshallStringToEhrCompositionElement(inputXml);
 
         ReferralRequest referralRequest = mapReferralRequest(null, ehrComposition,
-            composition -> composition.getComponent().get(0).getRequestStatement());
+            composition -> composition.getComponent().getFirst().getRequestStatement());
 
         assertAll(
-                () -> assertEquals(EXAMPLE_ID, referralRequest.getId()),
-                () -> assertThat(referralRequest.getNote()).isEmpty(),
-                () -> assertNull(referralRequest.getAuthoredOn()),
-                () -> assertEquals(EHR_COMPOSITION_PRACTITIONER2_ID, referralRequest.getRequester().getAgent().getReference()),
-                () -> assertThat(referralRequest.getRecipient()).isEmpty(),
-                () -> assertThat(referralRequest.getReasonCode()).isEmpty()
+            () -> assertEquals(EXAMPLE_ID, referralRequest.getId()),
+            () -> assertThat(referralRequest.getNote()).isEmpty(),
+            () -> assertNull(referralRequest.getAuthoredOn()),
+            () -> assertEquals(EHR_COMPOSITION_PRACTITIONER2_ID, referralRequest.getRequester().getAgent().getReference()),
+            () -> assertThat(referralRequest.getRecipient()).isEmpty(),
+            () -> assertThat(referralRequest.getReasonCode()).isEmpty()
         );
     }
 
@@ -301,16 +313,22 @@ class ReferralRequestMapperTest {
         var ehrExtract = unmarshallStringToEhrExtractElement(inputXml);
 
         var referralRequest = mapReferralRequest(ehrExtract,
-                                                 ehrExtract.getComponent().get(0).getEhrFolder().getComponent().get(0).getEhrComposition(),
-                                                 composition -> composition.getComponent().get(0).getRequestStatement());
+                                                 ehrExtract
+                                                     .getComponent()
+                                                     .getFirst()
+                                                     .getEhrFolder()
+                                                     .getComponent()
+                                                     .getFirst()
+                                                     .getEhrComposition(),
+                                                 composition -> composition.getComponent().getFirst().getRequestStatement());
 
         assertAll(
-                () -> assertEquals(EXAMPLE_ID, referralRequest.getId()),
-                () -> assertThat(referralRequest.getNote()).isEmpty(),
-                () -> assertNull(referralRequest.getAuthoredOn()),
-                () -> assertNull(referralRequest.getRequester().getAgent().getReference()),
-                () -> assertThat(referralRequest.getRecipient()).isEmpty(),
-                () -> assertThat(referralRequest.getReasonCode()).isEmpty()
+            () -> assertEquals(EXAMPLE_ID, referralRequest.getId()),
+            () -> assertThat(referralRequest.getNote()).isEmpty(),
+            () -> assertNull(referralRequest.getAuthoredOn()),
+            () -> assertNull(referralRequest.getRequester().getAgent().getReference()),
+            () -> assertThat(referralRequest.getRecipient()).isEmpty(),
+            () -> assertThat(referralRequest.getReasonCode()).isEmpty()
         );
     }
 
@@ -334,15 +352,15 @@ class ReferralRequestMapperTest {
         var ehrComposition = unmarshallStringToEhrCompositionElement(inputXml);
 
         ReferralRequest referralRequest = mapReferralRequest(null, ehrComposition,
-            composition -> composition.getComponent().get(0).getRequestStatement());
+            composition -> composition.getComponent().getFirst().getRequestStatement());
 
         assertAll(
-                () -> assertEquals(EXAMPLE_ID, referralRequest.getId()),
-                () -> assertEquals("Priority: Normal", referralRequest.getNote().get(0).getText()),
-                () -> assertNull(referralRequest.getAuthoredOn()),
-                () -> assertNull(referralRequest.getRequester().getAgent().getReference()),
-                () -> assertThat(referralRequest.getRecipient()).isEmpty(),
-                () -> assertThat(referralRequest.getReasonCode()).isEmpty()
+            () -> assertEquals(EXAMPLE_ID, referralRequest.getId()),
+            () -> assertEquals("Priority: Normal", referralRequest.getNote().getFirst().getText()),
+            () -> assertNull(referralRequest.getAuthoredOn()),
+            () -> assertNull(referralRequest.getRequester().getAgent().getReference()),
+            () -> assertThat(referralRequest.getRecipient()).isEmpty(),
+            () -> assertThat(referralRequest.getReasonCode()).isEmpty()
         );
     }
 
@@ -367,9 +385,9 @@ class ReferralRequestMapperTest {
         var ehrComposition = unmarshallStringToEhrCompositionElement(inputXml);
 
         var referralRequest = mapReferralRequest(null, ehrComposition,
-            composition -> composition.getComponent().get(0).getRequestStatement());
+            composition -> composition.getComponent().getFirst().getRequestStatement());
 
-        assertEquals(DegradedCodeableConcepts.DEGRADED_REFERRAL, referralRequest.getReasonCode().get(0).getCoding().get(0));
+        assertEquals(DegradedCodeableConcepts.DEGRADED_REFERRAL, referralRequest.getReasonCode().getFirst().getCoding().getFirst());
     }
 
     @ParameterizedTest
@@ -396,7 +414,7 @@ class ReferralRequestMapperTest {
         var ehrComposition = unmarshallStringToEhrCompositionElement(inputXml);
 
         var referralRequest = mapReferralRequest(null, ehrComposition,
-            composition -> composition.getComponent().get(0).getRequestStatement());
+            composition -> composition.getComponent().getFirst().getRequestStatement());
 
         assertThat(referralRequest.getPriority().getDisplay()).isEqualTo(expectedDisplay);
     }
@@ -416,8 +434,14 @@ class ReferralRequestMapperTest {
         var ehrExtract = unmarshallEhrExtractElement("request_statement_missing_priority_code.xml");
 
         var referralRequest = mapReferralRequest(ehrExtract,
-                                                 ehrExtract.getComponent().get(0).getEhrFolder().getComponent().get(0).getEhrComposition(),
-                                                 composition -> composition.getComponent().get(0).getRequestStatement());
+                                                 ehrExtract
+                                                     .getComponent()
+                                                     .getFirst()
+                                                     .getEhrFolder()
+                                                     .getComponent()
+                                                     .getFirst()
+                                                     .getEhrComposition(),
+                                                 composition -> composition.getComponent().getFirst().getRequestStatement());
 
         assertNull(referralRequest.getPriority());
     }
@@ -437,8 +461,14 @@ class ReferralRequestMapperTest {
         var ehrExtract = unmarshallEhrExtractElement("request_statement_unexpected_priority_code.xml");
 
         var referralRequest = mapReferralRequest(ehrExtract,
-                                                 ehrExtract.getComponent().get(0).getEhrFolder().getComponent().get(0).getEhrComposition(),
-                                                 composition -> composition.getComponent().get(0).getRequestStatement());
+                                                 ehrExtract
+                                                     .getComponent()
+                                                     .getFirst()
+                                                     .getEhrFolder()
+                                                     .getComponent()
+                                                     .getFirst()
+                                                     .getEhrComposition(),
+                                                 composition -> composition.getComponent().getFirst().getRequestStatement());
 
         assertNull(referralRequest.getPriority());
     }
@@ -449,8 +479,14 @@ class ReferralRequestMapperTest {
         var ehrExtract = unmarshallEhrExtractElement("request_statement_unexpected_priority_code.xml");
 
         var referralRequest = mapReferralRequest(ehrExtract,
-                                                 ehrExtract.getComponent().get(0).getEhrFolder().getComponent().get(0).getEhrComposition(),
-                                                 composition -> composition.getComponent().get(0).getRequestStatement());
+                                                 ehrExtract
+                                                     .getComponent()
+                                                     .getFirst()
+                                                     .getEhrFolder()
+                                                     .getComponent()
+                                                     .getFirst()
+                                                     .getEhrComposition(),
+                                                 composition -> composition.getComponent().getFirst().getRequestStatement());
 
         var priorityNotes = referralRequest.getNote()
             .stream()
@@ -476,11 +512,11 @@ class ReferralRequestMapperTest {
         )).thenReturn(metaWithSecurity);
 
         final ReferralRequest result = mapReferralRequest(ehrExtract, ehrComposition,
-            composition -> composition.getComponent().get(0).getRequestStatement());
+            composition -> composition.getComponent().getFirst().getRequestStatement());
 
         final CV confidentialityCode = confidentialityCodeCaptor
             .getAllValues()
-            .get(0) // ehrComposition.getConfidentialityCode()
+            .getFirst() // ehrComposition.getConfidentialityCode()
             .orElseThrow();
 
         assertAll(
@@ -504,7 +540,7 @@ class ReferralRequestMapperTest {
         )).thenReturn(metaWithSecurity);
 
         final ReferralRequest result = mapReferralRequest(ehrExtract, ehrComposition,
-            composition -> composition.getComponent().get(0).getRequestStatement());
+            composition -> composition.getComponent().getFirst().getRequestStatement());
 
         final CV confidentialityCode = confidentialityCodeCaptor
             .getAllValues()
@@ -514,36 +550,31 @@ class ReferralRequestMapperTest {
         assertAll(
             () -> assertThat(result.getMeta()).usingRecursiveComparison().isEqualTo(metaWithSecurity),
             () -> assertThat(confidentialityCode.getCode()).isEqualTo(NOPAT),
-            () -> assertThat(confidentialityCodeCaptor.getAllValues().get(0)).isNotPresent()
+            () -> assertThat(confidentialityCodeCaptor.getAllValues().getFirst()).isNotPresent()
         );
     }
 
     private RCMRMT030101UKRequestStatement getNestedRequestStatement(RCMRMT030101UKEhrComposition ehrComposition) {
         return ehrComposition.getComponent()
-            .get(0)
+            .getFirst()
             .getCompoundStatement()
             .getComponent()
             .get(1)
             .getCompoundStatement()
             .getComponent()
-            .get(0)
+            .getFirst()
             .getRequestStatement();
     }
 
     private void assertFixedValues(ReferralRequest referralRequest) {
         assertAll(
-                () -> assertThat(referralRequest.getMeta().getProfile().get(0).getValue())
-                        .isEqualTo(META_PROFILE),
-                () -> assertThat(referralRequest.getIdentifier().get(0).getSystem())
-                        .isEqualTo(IDENTIFIER_SYSTEM),
-                () -> assertThat(referralRequest.getIdentifier().get(0).getValue())
-                        .isEqualTo(EXAMPLE_ID),
-                () -> assertThat(referralRequest.getIntent())
-                        .isEqualTo(ReferralRequest.ReferralCategory.ORDER),
-                () -> assertThat(referralRequest.getStatus())
-                        .isEqualTo(ReferralRequestStatus.UNKNOWN),
-                () -> assertThat(referralRequest.getSubject().getResource().getIdElement().getValue())
-                        .isEqualTo(PATIENT_ID)
+            () -> assertThat(referralRequest.getMeta().getProfile().getFirst().getValue()).isEqualTo(META_PROFILE),
+            () -> assertThat(referralRequest.getIdentifier().getFirst().getSystem()).isEqualTo(IDENTIFIER_SYSTEM),
+            () -> assertThat(referralRequest.getIdentifier().getFirst().getValue()).isEqualTo(EXAMPLE_ID),
+            () -> assertThat(referralRequest.getIntent()).isEqualTo(ReferralRequest.ReferralCategory.ORDER),
+            () -> assertThat(referralRequest.getStatus()).isEqualTo(ReferralRequestStatus.UNKNOWN),
+            () -> assertThat(referralRequest.getSubject().getResource().getIdElement().getValue())
+                .isEqualTo(PATIENT_ID)
         );
     }
 

--- a/gp2gp-translator/src/test/java/uk/nhs/adaptors/pss/translator/mapper/TemplateMapperTest.java
+++ b/gp2gp-translator/src/test/java/uk/nhs/adaptors/pss/translator/mapper/TemplateMapperTest.java
@@ -71,8 +71,8 @@ public class TemplateMapperTest {
         var mappedResources = templateMapper.mapResources(ehrExtract, getPatient(), ENCOUNTER_LIST, PRACTISE_CODE);
 
         assertThat(mappedResources.size()).isEqualTo(1);
-        // var questionnaireResponse = (QuestionnaireResponse) mappedResources.get(0);
-        var parentObservation = (Observation) mappedResources.get(0);
+        // var questionnaireResponse = (QuestionnaireResponse) mappedResources.getFirst();
+        var parentObservation = (Observation) mappedResources.getFirst();
 
         // assertQuestionnaireResponse(questionnaireResponse, ENCOUNTER_ID, "original-text", "20100113151332");
         assertParentObservation(parentObservation, ENCOUNTER_ID, "20100113151332", "3707E1F0-9011-11EC-B1E5-0800200C9A66");
@@ -90,8 +90,8 @@ public class TemplateMapperTest {
         var mappedResources = templateMapper.mapResources(ehrExtract, getPatient(), ENCOUNTER_LIST, PRACTISE_CODE);
 
         assertThat(mappedResources.size()).isEqualTo(1);
-//      var questionnaireResponse = (QuestionnaireResponse) mappedResources.get(0);
-        var parentObservation = (Observation) mappedResources.get(0);
+//      var questionnaireResponse = (QuestionnaireResponse) mappedResources.getFirst();
+        var parentObservation = (Observation) mappedResources.getFirst();
 
 //      assertQuestionnaireResponse(questionnaireResponse, null, "display-text", "20200101010101");
         assertParentObservation(parentObservation, null, null, "9007E1F0-9011-11EC-B1E5-0800200C9A66");
@@ -110,8 +110,8 @@ public class TemplateMapperTest {
         var mappedResources = templateMapper.mapResources(ehrExtract, getPatient(), ENCOUNTER_LIST, PRACTISE_CODE);
 
         assertThat(mappedResources.size()).isEqualTo(1);
-        //var questionnaireResponse = (QuestionnaireResponse) mappedResources.get(0);
-        var parentObservation = (Observation) mappedResources.get(0);
+        //var questionnaireResponse = (QuestionnaireResponse) mappedResources.getFirst();
+        var parentObservation = (Observation) mappedResources.getFirst();
 
         //assertQuestionnaireResponse(questionnaireResponse, null, "display-text", "20200101010101");
         assertParentObservation(parentObservation, null, null, "9007E1F0-9011-11EC-B1E5-0800200C9A66");
@@ -142,23 +142,23 @@ public class TemplateMapperTest {
 
         templateMapper.addReferences(templates, observations, ehrExtract);
 
-        var parentRelations = ((Observation) templates.get(0)).getRelated();
-        var fistChildRelations = observations.get(0).getRelated();
+        var parentRelations = ((Observation) templates.getFirst()).getRelated();
+        var fistChildRelations = observations.getFirst().getRelated();
         var secondChildRelations = observations.get(1).getRelated();
 
         assertThat(parentRelations.size()).isEqualTo(2);
-        assertThat(parentRelations.get(0).getTarget().getReferenceElement().getIdPart()).isEqualTo("CHILD_OBSERVATION_ID_1");
-        assertThat(parentRelations.get(0).getType()).isEqualTo(HASMEMBER);
+        assertThat(parentRelations.getFirst().getTarget().getReferenceElement().getIdPart()).isEqualTo("CHILD_OBSERVATION_ID_1");
+        assertThat(parentRelations.getFirst().getType()).isEqualTo(HASMEMBER);
         assertThat(parentRelations.get(1).getTarget().getReferenceElement().getIdPart()).isEqualTo("CHILD_OBSERVATION_ID_2");
         assertThat(parentRelations.get(1).getType()).isEqualTo(HASMEMBER);
 
         assertThat(fistChildRelations.size()).isOne();
-        assertThat(fistChildRelations.get(0).getTarget().getReferenceElement().getIdPart()).isEqualTo("PARENT_OBSERVATION_ID");
-        assertThat(fistChildRelations.get(0).getType()).isEqualTo(DERIVEDFROM);
+        assertThat(fistChildRelations.getFirst().getTarget().getReferenceElement().getIdPart()).isEqualTo("PARENT_OBSERVATION_ID");
+        assertThat(fistChildRelations.getFirst().getType()).isEqualTo(DERIVEDFROM);
 
         assertThat(secondChildRelations.size()).isOne();
-        assertThat(secondChildRelations.get(0).getTarget().getReferenceElement().getIdPart()).isEqualTo("PARENT_OBSERVATION_ID");
-        assertThat(secondChildRelations.get(0).getType()).isEqualTo(DERIVEDFROM);
+        assertThat(secondChildRelations.getFirst().getTarget().getReferenceElement().getIdPart()).isEqualTo("PARENT_OBSERVATION_ID");
+        assertThat(secondChildRelations.getFirst().getType()).isEqualTo(DERIVEDFROM);
     }
 
     @Test
@@ -167,7 +167,7 @@ public class TemplateMapperTest {
 
         var ehrExtract = unmarshallEhrExtractElement("full_valid_template.xml");
         var mappedResources = templateMapper.mapResources(ehrExtract, getPatient(), ENCOUNTER_LIST, PRACTISE_CODE);
-        var parentObservation = (Observation) mappedResources.get(0);
+        var parentObservation = (Observation) mappedResources.getFirst();
 
         assertThat(parentObservation.getCode()).isEqualTo(CODEABLE_CONCEPT);
     }
@@ -179,7 +179,7 @@ public class TemplateMapperTest {
 
         var ehrExtract = unmarshallEhrExtractElement("full_valid_template.xml");
         var mappedResources = templateMapper.mapResources(ehrExtract, getPatient(), ENCOUNTER_LIST, PRACTISE_CODE);
-        var parentObservation = (Observation) mappedResources.get(0);
+        var parentObservation = (Observation) mappedResources.getFirst();
 
         assertThat(parentObservation.getCode().getCodingFirstRep()).isEqualTo(DegradedCodeableConcepts.DEGRADED_OTHER);
     }
@@ -187,7 +187,7 @@ public class TemplateMapperTest {
     private void assertQuestionnaireResponse(QuestionnaireResponse questionnaireResponse, String encounter, String linkId,
         String authored) {
         assertThat(questionnaireResponse.getId()).isEqualTo(COMPOUND_ID + QUESTIONNAIRE_SUFFIX);
-        assertThat(questionnaireResponse.getMeta().getProfile().get(0).getValue()).isEqualTo(QUESTIONNAIRE_META);
+        assertThat(questionnaireResponse.getMeta().getProfile().getFirst().getValue()).isEqualTo(QUESTIONNAIRE_META);
         assertThat(questionnaireResponse.getIdentifier().getSystem()).isEqualTo(IDENTIFIER);
         assertThat(questionnaireResponse.getIdentifier().getValue()).isEqualTo(COMPOUND_ID);
         assertThat(questionnaireResponse.getParentFirstRep().getResource().getIdElement().getValue()).isEqualTo(COMPOUND_ID);
@@ -206,7 +206,7 @@ public class TemplateMapperTest {
 
     private void assertParentObservation(Observation parentObservation, String encounter, String issued, String performer) {
         assertThat(parentObservation.getId()).isEqualTo(COMPOUND_ID);
-        assertThat(parentObservation.getMeta().getProfile().get(0).getValue()).isEqualTo(OBSERVATION_META);
+        assertThat(parentObservation.getMeta().getProfile().getFirst().getValue()).isEqualTo(OBSERVATION_META);
         assertThat(parentObservation.getIdentifierFirstRep().getSystem()).isEqualTo(IDENTIFIER);
         assertThat(parentObservation.getIdentifierFirstRep().getValue()).isEqualTo(COMPOUND_ID);
         assertThat(parentObservation.getSubject().getResource().getIdElement().getValue()).isEqualTo(PATIENT_ID);

--- a/gp2gp-translator/src/test/java/uk/nhs/adaptors/pss/translator/mapper/diagnosticreport/SpecimenBatteryMapperTest.java
+++ b/gp2gp-translator/src/test/java/uk/nhs/adaptors/pss/translator/mapper/diagnosticreport/SpecimenBatteryMapperTest.java
@@ -117,7 +117,7 @@ public class SpecimenBatteryMapperTest {
         final var ehrExtract = unmarshallEhrExtractFromEhrCompositionXml(ehrCompositionXml);
         final var batteryCompoundStatements = getBatteryCompoundStatements(ehrExtract);
 
-        assertThat(batteryCompoundStatements).map(r -> r.getId().get(0).getRoot())
+        assertThat(batteryCompoundStatements).map(r -> r.getId().getFirst().getRoot())
                     .isEqualTo(List.of("SPECIMEN_CHILD_BATTERY_COMPOUND_STATEMENT_ID_1",
                                        "SPECIMEN_CHILD_BATTERY_COMPOUND_STATEMENT_ID_2",
                                        "SPECIMEN_CHILD_BATTERY_COMPOUND_STATEMENT_ID_3"));
@@ -297,7 +297,7 @@ public class SpecimenBatteryMapperTest {
                 .contains("TEST_SPECIMEN_ID_1"),
             () -> assertThat(observation.getStatus())
                 .isEqualTo(ObservationStatus.FINAL),
-            () -> assertThat(observation.getMeta().getProfile().get(0).getValue())
+            () -> assertThat(observation.getMeta().getProfile().getFirst().getValue())
                 .contains("Observation-1"),
             () -> assertThat(observation.getComment())
                 .isEqualTo("Looks like Covid"),
@@ -322,7 +322,7 @@ public class SpecimenBatteryMapperTest {
         final Observation observation = specimenBatteryMapper.mapBatteryObservation(batteryParameters);
 
         assertAll(
-            () -> assertThat(observations.get(0).getRelatedFirstRep().getType())
+            () -> assertThat(observations.getFirst().getRelatedFirstRep().getType())
                 .isEqualTo(ObservationRelationshipType.DERIVEDFROM),
             () -> assertThat(observation.getRelatedFirstRep().getTarget().getReference())
                 .contains("BATTERY_DIRECT_CHILD_OBSERVATION_STATEMENT"),
@@ -453,18 +453,18 @@ public class SpecimenBatteryMapperTest {
     }
 
     private RCMRMT030101UKEhrComposition getEhrComposition(RCMRMT030101UKEhrExtract ehrExtract) {
-        return ehrExtract.getComponent().get(0).getEhrFolder().getComponent().get(0).getEhrComposition();
+        return ehrExtract.getComponent().getFirst().getEhrFolder().getComponent().getFirst().getEhrComposition();
     }
 
     private RCMRMT030101UKCompoundStatement getSpecimenCompoundStatement(RCMRMT030101UKEhrExtract ehrExtract) {
-        return getEhrComposition(ehrExtract).getComponent().get(0).getCompoundStatement()
-            .getComponent().get(0).getCompoundStatement();
+        return getEhrComposition(ehrExtract).getComponent().getFirst().getCompoundStatement()
+            .getComponent().getFirst().getCompoundStatement();
     }
 
     private DiagnosticReport getDiagnosticReport(RCMRMT030101UKEhrExtract ehrExtract) {
-        var compoundStatement = getEhrComposition(ehrExtract).getComponent().get(0).getCompoundStatement();
+        var compoundStatement = getEhrComposition(ehrExtract).getComponent().getFirst().getCompoundStatement();
         var diagnosticReport = new DiagnosticReport();
-        diagnosticReport.setId(compoundStatement.getId().get(0).getRoot());
+        diagnosticReport.setId(compoundStatement.getId().getFirst().getRoot());
 
         if (compoundStatement.getAvailabilityTime() != null) {
             diagnosticReport.setIssued(
@@ -486,7 +486,7 @@ public class SpecimenBatteryMapperTest {
         return getEhrComposition(ehrExtract).getComponent()
             .stream()
             .flatMap(CompoundStatementResourceExtractors::extractAllCompoundStatements)
-            .filter(compoundStatement -> "BATTERY".equals(compoundStatement.getClassCode().get(0)))
+            .filter(compoundStatement -> "BATTERY".equals(compoundStatement.getClassCode().getFirst()))
             .findFirst()
             .orElseThrow();
     }
@@ -495,7 +495,7 @@ public class SpecimenBatteryMapperTest {
         return getEhrComposition(ehrExtract).getComponent()
             .stream()
             .flatMap(CompoundStatementResourceExtractors::extractAllCompoundStatements)
-            .filter(compoundStatement -> "BATTERY".equals(compoundStatement.getClassCode().get(0)))
+            .filter(compoundStatement -> "BATTERY".equals(compoundStatement.getClassCode().getFirst()))
             .toList();
     }
 

--- a/gp2gp-translator/src/test/java/uk/nhs/adaptors/pss/translator/mapper/diagnosticreport/SpecimenCompoundsMapperTest.java
+++ b/gp2gp-translator/src/test/java/uk/nhs/adaptors/pss/translator/mapper/diagnosticreport/SpecimenCompoundsMapperTest.java
@@ -3,6 +3,8 @@ package uk.nhs.adaptors.pss.translator.mapper.diagnosticreport;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertAll;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.AdditionalAnswers.answer;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.doAnswer;
@@ -165,7 +167,7 @@ public class SpecimenCompoundsMapperTest {
         assertThat(observationComments).hasSize(2);
         assertThat(observationComment.getComment()).isEqualTo(TEST_COMMENT_LINE_1);
         assertThat(observationComment.getRelated()).isNotEmpty();
-        assertThat(observationComment.getRelated().getFirst().getTarget().getResource()).isNotNull();
+        assertNotNull(observationComment.getRelated().getFirst().getTarget().getResource());
         assertThat(observationComment.getRelated().getFirst().getTarget().getResource().getIdElement().getValue())
                 .isEqualTo(observation.getId());
         assertThat(diagnosticReports.getFirst().getResult().size()).isOne();
@@ -240,7 +242,7 @@ public class SpecimenCompoundsMapperTest {
 
         final Observation observation = observations.getFirst();
 
-        assertThat(observation.getIssuedElement().asStringValue()).isNull();
+        assertNull(observation.getIssuedElement().asStringValue());
     }
 
     @Test void testOrderingIsPreservedForDiagnosticReportResults() {
@@ -292,8 +294,8 @@ public class SpecimenCompoundsMapperTest {
     }
 
     private void assertParentSpecimenIsReferenced(Observation observation) {
-        assertThat(observation.hasSpecimen()).isTrue();
-        assertThat(observation.getSpecimen().hasReference()).isTrue();
+        assertTrue(observation.hasSpecimen());
+        assertTrue(observation.getSpecimen().hasReference());
         assertThat(observation.getSpecimen().getReference()).contains(SPECIMEN_ID);
     }
 

--- a/gp2gp-translator/src/test/java/uk/nhs/adaptors/pss/translator/mapper/diagnosticreport/SpecimenMapperTest.java
+++ b/gp2gp-translator/src/test/java/uk/nhs/adaptors/pss/translator/mapper/diagnosticreport/SpecimenMapperTest.java
@@ -23,7 +23,6 @@ import org.hl7.fhir.dstu3.model.Observation;
 import org.hl7.fhir.dstu3.model.Patient;
 import org.hl7.fhir.dstu3.model.Reference;
 import org.hl7.fhir.dstu3.model.Specimen;
-import org.hl7.v3.CV;
 import org.hl7.v3.RCMRMT030101UKCompoundStatement;
 import org.hl7.v3.RCMRMT030101UKEhrComposition;
 import org.hl7.v3.RCMRMT030101UKEhrExtract;
@@ -35,7 +34,6 @@ import org.mockito.junit.jupiter.MockitoExtension;
 
 import lombok.SneakyThrows;
 import uk.nhs.adaptors.pss.translator.MetaFactory;
-import uk.nhs.adaptors.pss.translator.TestUtility;
 import uk.nhs.adaptors.pss.translator.mapper.DateTimeMapper;
 import uk.nhs.adaptors.pss.translator.service.ConfidentialityService;
 
@@ -57,11 +55,6 @@ public class SpecimenMapperTest {
     private static final DiagnosticReport DIAGNOSTIC_REPORT_WITHOUT_SPECIMEN = generateDiagnosticReportWithNoSpecimenReference();
     private static final String SPECIMEN_META_PROFILE = "Specimen-1";
     private static final Meta META_WITH_SECURITY_ADDED = MetaFactory.getMetaFor(META_WITH_SECURITY, SPECIMEN_META_PROFILE);
-    private static final CV NOPAT_CV = TestUtility.createCv(
-        "NOPAT",
-        "http://hl7.org/fhir/v3/ActCode",
-        "no disclosure to patient, family or caregivers without attending provider's authorization");
-
     private static final String NARRATIVE_STATEMENT_ID = "9326C01E-488B-4EDF-B9C9-529E69EE0361";
 
     @Mock

--- a/gp2gp-translator/src/test/java/uk/nhs/adaptors/pss/translator/mapper/medication/MedicationMapperTest.java
+++ b/gp2gp-translator/src/test/java/uk/nhs/adaptors/pss/translator/mapper/medication/MedicationMapperTest.java
@@ -91,7 +91,7 @@ public class MedicationMapperTest {
         assertThat(medication.getMeta()).isNotNull();
         assertThat(medication.getCode()).isNotNull();
         assertThat(medication.getCode().getCoding()).isNotNull();
-        assertThat(medication.getCode().getCoding().get(0)).isEqualTo(DegradedCodeableConcepts.DEGRADED_MEDICATION);
+        assertThat(medication.getCode().getCoding().getFirst()).isEqualTo(DegradedCodeableConcepts.DEGRADED_MEDICATION);
     }
 
     @SneakyThrows

--- a/gp2gp-translator/src/test/java/uk/nhs/adaptors/pss/translator/mapper/medication/MedicationRequestMapperTest.java
+++ b/gp2gp-translator/src/test/java/uk/nhs/adaptors/pss/translator/mapper/medication/MedicationRequestMapperTest.java
@@ -73,9 +73,9 @@ public class MedicationRequestMapperTest {
     public void When_MappingMedicationStatement_Expect_CorrectMappersToBeCalled() {
         final RCMRMT030101UKEhrExtract ehrExtract = unmarshallEhrExtract("ehrExtract1.xml");
         final RCMRMT030101UKEhrComposition ehrComposition =
-                ehrExtract.getComponent().get(0).getEhrFolder().getComponent().get(0).getEhrComposition();
+                ehrExtract.getComponent().getFirst().getEhrFolder().getComponent().getFirst().getEhrComposition();
         final RCMRMT030101UKMedicationStatement medicationStatement =
-                ehrComposition.getComponent().get(0).getMedicationStatement();
+                ehrComposition.getComponent().getFirst().getMedicationStatement();
 
         var resources = medicationRequestMapper
                 .mapResources(ehrExtract, (Patient) new Patient().setId(PATIENT_ID), List.of(), PRACTISE_CODE);
@@ -84,7 +84,7 @@ public class MedicationRequestMapperTest {
             eq(ehrExtract),
             eq(ehrComposition),
             eq(medicationStatement),
-            eq(medicationStatement.getComponent().get(0).getEhrSupplyAuthorise()),
+            eq(medicationStatement.getComponent().getFirst().getEhrSupplyAuthorise()),
             eq(PRACTISE_CODE)
         );
 
@@ -100,7 +100,7 @@ public class MedicationRequestMapperTest {
             eq(ehrExtract),
             eq(ehrComposition),
             eq(medicationStatement),
-            eq(medicationStatement.getComponent().get(0).getEhrSupplyAuthorise()),
+            eq(medicationStatement.getComponent().getFirst().getEhrSupplyAuthorise()),
             eq(PRACTISE_CODE),
             any(DateTimeType.class)
         );

--- a/gp2gp-translator/src/test/java/uk/nhs/adaptors/pss/translator/mapper/medication/MedicationRequestOrderMapperTest.java
+++ b/gp2gp-translator/src/test/java/uk/nhs/adaptors/pss/translator/mapper/medication/MedicationRequestOrderMapperTest.java
@@ -156,11 +156,11 @@ class MedicationRequestOrderMapperTest {
         assertAll(
             () -> assertThat(medicationRequest.getMeta()).usingRecursiveComparison().isEqualTo(META),
             () -> assertThat(confidentialityCodeArgumentCaptor
-                .getAllValues().get(1)
-                .orElseThrow()
-                .getCode()).isEqualTo("NOPAT"),
-            () -> assertThat(confidentialityCodeArgumentCaptor.getAllValues().get(0).orElseThrow()).usingRecursiveComparison()
-                    .isEqualTo(compositionConfidentialityCode)
+                                 .getAllValues().get(1)
+                                 .orElseThrow()
+                                 .getCode()).isEqualTo("NOPAT"),
+            () -> assertThat(confidentialityCodeArgumentCaptor.getAllValues().getFirst().orElseThrow()).usingRecursiveComparison()
+                .isEqualTo(compositionConfidentialityCode)
         );
     }
 
@@ -183,7 +183,7 @@ class MedicationRequestOrderMapperTest {
         assertAll(
             () -> assertThat(medicationRequest.getMeta()).usingRecursiveComparison().isEqualTo(META),
             () -> assertThat(confidentialityCodeArgumentCaptor.getAllValues().get(1).orElseThrow().getCode()).isEqualTo("NOSCRUB"),
-            () -> assertThat(confidentialityCodeArgumentCaptor.getAllValues().get(0)).isEmpty()
+            () -> assertThat(confidentialityCodeArgumentCaptor.getAllValues().getFirst()).isEmpty()
         );
     }
 

--- a/gp2gp-translator/src/test/java/uk/nhs/adaptors/pss/translator/mapper/medication/MedicationRequestPlanMapperTest.java
+++ b/gp2gp-translator/src/test/java/uk/nhs/adaptors/pss/translator/mapper/medication/MedicationRequestPlanMapperTest.java
@@ -195,16 +195,16 @@ class MedicationRequestPlanMapperTest {
 
         var repeatInformation = medicationRequest.getExtensionsByUrl(REPEAT_INFO_URL);
         assertThat(repeatInformation).hasSize(1);
-        assertRepeatInformation(repeatInformation.get(0));
+        assertRepeatInformation(repeatInformation.getFirst());
 
         var statusReason = medicationRequest.getExtensionsByUrl(MEDICATION_STATUS_REASON_URL);
         assertThat(statusReason).hasSize(1);
-        assertStatusReasonInformation(statusReason.get(0));
+        assertStatusReasonInformation(statusReason.getFirst());
 
         var prescriptionType = medicationRequest.getExtensionsByUrl(PRESCRIPTION_TYPE_URL);
         assertThat(prescriptionType).hasSize(1);
 
-        var codeableConcept = (CodeableConcept) prescriptionType.get(0).getValue();
+        var codeableConcept = (CodeableConcept) prescriptionType.getFirst().getValue();
         assertThat(codeableConcept.getCodingFirstRep().getDisplay()).isEqualTo("Repeat");
 
         assertThat(medicationRequest.getStatus()).isEqualTo(STOPPED);
@@ -238,7 +238,7 @@ class MedicationRequestPlanMapperTest {
         var repeatInformation = medicationRequest.getExtensionsByUrl(REPEAT_INFO_URL);
 
         assertThat(repeatInformation).hasSize(1);
-        assertThat(repeatInformation.get(0).getExtensionsByUrl(REPEATS_EXPIRY_DATE_URL)).isEmpty();
+        assertThat(repeatInformation.getFirst().getExtensionsByUrl(REPEATS_EXPIRY_DATE_URL)).isEmpty();
 
         assertMetaSecurityNotPresent(medicationRequest);
     }
@@ -263,7 +263,7 @@ class MedicationRequestPlanMapperTest {
         final var repeatInformation = medicationRequest.getExtensionsByUrl(REPEAT_INFO_URL);
 
         assertThat(repeatInformation).hasSize(1);
-        assertThat(repeatInformation.get(0).getExtensionsByUrl(REPEATS_EXPIRY_DATE_URL)).isEmpty();
+        assertThat(repeatInformation.getFirst().getExtensionsByUrl(REPEATS_EXPIRY_DATE_URL)).isEmpty();
 
         assertMetaSecurityNotPresent(medicationRequest);
     }
@@ -512,7 +512,7 @@ class MedicationRequestPlanMapperTest {
         assertAll(
             () -> assertThat(extensions).isEmpty(),
             () -> assertThat(medicationRequest.getMeta()).usingRecursiveComparison().isEqualTo(meta),
-            () -> assertThat(confidentialityCodeCaptor.getAllValues().get(0)).isEmpty(),
+            () -> assertThat(confidentialityCodeCaptor.getAllValues().getFirst()).isEmpty(),
             () -> assertThat(confidentialityCodeCaptor.getAllValues().get(1).orElseThrow().getCode()).isEqualTo("NOPAT")
         );
     }
@@ -548,7 +548,7 @@ class MedicationRequestPlanMapperTest {
         assertAll(
             () -> assertThat(extensions).isEmpty(),
             () -> assertThat(medicationRequest.getMeta()).usingRecursiveComparison().isEqualTo(meta),
-            () -> assertThat(confidentialityCodeCaptor.getAllValues().get(0).orElseThrow().getCode()).isEqualTo("NOPAT"),
+            () -> assertThat(confidentialityCodeCaptor.getAllValues().getFirst().orElseThrow().getCode()).isEqualTo("NOPAT"),
             () -> assertThat(confidentialityCodeCaptor.getAllValues().get(1)).isEmpty()
         );
     }
@@ -617,7 +617,7 @@ class MedicationRequestPlanMapperTest {
 
         assertAll(
             () -> assertThat(meta.getSecurity()).isEmpty(),
-            () -> assertThat(meta.getProfile().get(0).getValue()).isEqualTo(META_PROFILE)
+            () -> assertThat(meta.getProfile().getFirst().getValue()).isEqualTo(META_PROFILE)
         );
 
         verify(confidentialityService).createMetaAndAddSecurityIfConfidentialityCodesPresent(
@@ -651,26 +651,26 @@ class MedicationRequestPlanMapperTest {
     }
 
     private void assertStatusReasonInformation(Extension extension) {
-        var changeDate = extension.getExtensionsByUrl("statusChangeDate").get(0);
+        var changeDate = extension.getExtensionsByUrl("statusChangeDate").getFirst();
         var changeDateValue = (DateTimeType) changeDate.getValue();
         assertThat(changeDateValue.getValue()).isEqualTo(DateFormatUtil.parseToDateTimeType(AVAILABILITY_TIME).getValue());
 
-        var statusReason = extension.getExtensionsByUrl(STATUS_REASON).get(0);
+        var statusReason = extension.getExtensionsByUrl(STATUS_REASON).getFirst();
         assertThat(statusReason.hasValue()).isTrue();
     }
 
     private void assertRepeatInformation(Extension extension) {
         var repeatsAllowed = extension.getExtensionsByUrl(REPEATS_ALLOWED_URL);
         assertThat(repeatsAllowed).hasSize(1);
-        assertThat(((UnsignedIntType) repeatsAllowed.get(0).getValue()).getValue()).isEqualTo(new UnsignedIntType(SIX).getValue());
+        assertThat(((UnsignedIntType) repeatsAllowed.getFirst().getValue()).getValue()).isEqualTo(new UnsignedIntType(SIX).getValue());
 
         var repeatsIssued = extension.getExtensionsByUrl(REPEATS_ISSUED_URL);
         assertThat(repeatsIssued).hasSize(1);
-        assertThat(((UnsignedIntType) repeatsIssued.get(0).getValue()).getValue()).isEqualTo(new UnsignedIntType(1).getValue());
+        assertThat(((UnsignedIntType) repeatsIssued.getFirst().getValue()).getValue()).isEqualTo(new UnsignedIntType(1).getValue());
 
         var expiryDate = extension.getExtensionsByUrl(REPEATS_EXPIRY_DATE_URL);
         assertThat(expiryDate).hasSize(1);
-        var date = expiryDate.get(0).getValue().toString();
+        var date = expiryDate.getFirst().getValue().toString();
         assertThat(date).isEqualTo(DateFormatUtil.parseToDateTimeType("20060427").toString());
     }
 
@@ -678,7 +678,7 @@ class MedicationRequestPlanMapperTest {
         var statusExt = medicationRequest.getExtensionsByUrl(MEDICATION_STATUS_REASON_URL);
         assertThat(statusExt).hasSize(1);
 
-        assertThat(statusExt.get(0).getExtensionsByUrl(STATUS_REASON)).usingRecursiveComparison().isEqualTo(List.of(
+        assertThat(statusExt.getFirst().getExtensionsByUrl(STATUS_REASON)).usingRecursiveComparison().isEqualTo(List.of(
                 new Extension(STATUS_REASON, new CodeableConcept().setText(expectedReason))
         ));
     }

--- a/gp2gp-translator/src/test/java/uk/nhs/adaptors/pss/translator/mapper/medication/MedicationStatementMapperTest.java
+++ b/gp2gp-translator/src/test/java/uk/nhs/adaptors/pss/translator/mapper/medication/MedicationStatementMapperTest.java
@@ -113,7 +113,7 @@ class MedicationStatementMapperTest {
         var lastIssuedDate = result.getExtensionsByUrl(
             "https://fhir.nhs.uk/STU3/StructureDefinition/Extension-CareConnect-GPC-MedicationStatementLastIssueDate-1");
         assertThat(lastIssuedDate).hasSize(1);
-        var dateTime = (DateTimeType) lastIssuedDate.get(0).getValue();
+        var dateTime = (DateTimeType) lastIssuedDate.getFirst().getValue();
         assertThat(dateTime.getValue()).isEqualTo(DateFormatUtil.parseToDateTimeType("20060428").getValue());
 
         var prescribingAgency = result
@@ -368,7 +368,7 @@ class MedicationStatementMapperTest {
     }
 
     private Optional<CV> getMedicationStatementConfidentialityCode() {
-        return confidentialityCodeCaptor.getAllValues().get(0);
+        return confidentialityCodeCaptor.getAllValues().getFirst();
     }
 
     private Optional<CV> getEhrCompositionConfidentialityCode() {

--- a/gp2gp-translator/src/test/java/uk/nhs/adaptors/pss/translator/service/AttachmentHandlerServiceStoreAttachmentTests.java
+++ b/gp2gp-translator/src/test/java/uk/nhs/adaptors/pss/translator/service/AttachmentHandlerServiceStoreAttachmentTests.java
@@ -226,7 +226,7 @@ public class AttachmentHandlerServiceStoreAttachmentTests {
 
         List<String> dataStringList = dataWrapperCaptor.getAllValues().stream().map(dw -> new String(dw.getData(), UTF_8)).toList();
 
-        assertEquals(readFileAsString("InlineAttachments/text_attachment.txt"), dataStringList.get(0));
+        assertEquals(readFileAsString("InlineAttachments/text_attachment.txt"), dataStringList.getFirst());
     }
 
     @Test
@@ -239,7 +239,7 @@ public class AttachmentHandlerServiceStoreAttachmentTests {
 
         List<String> dataStringList = dataWrapperCaptor.getAllValues().stream().map(dw -> new String(dw.getData(), UTF_8)).toList();
 
-        assertEquals("Hello World from Scott Alexander", dataStringList.get(0));
+        assertEquals("Hello World from Scott Alexander", dataStringList.getFirst());
         assertEquals(readFileAsString("InlineAttachments/text_attachment.txt"), dataStringList.get(1));
     }
 
@@ -253,7 +253,7 @@ public class AttachmentHandlerServiceStoreAttachmentTests {
 
         List<String> captorValues = filenameCaptor.getAllValues();
 
-        assertEquals("277F29F1-FEAB-4D38-8266-FEB7A1E6227D_LICENSE.txt", captorValues.get(0));
+        assertEquals("277F29F1-FEAB-4D38-8266-FEB7A1E6227D_LICENSE.txt", captorValues.getFirst());
         assertEquals("text_attachment_encoded.txt", captorValues.get(1));
     }
 

--- a/gp2gp-translator/src/test/java/uk/nhs/adaptors/pss/translator/service/AttachmentHandlerServiceTests.java
+++ b/gp2gp-translator/src/test/java/uk/nhs/adaptors/pss/translator/service/AttachmentHandlerServiceTests.java
@@ -46,7 +46,7 @@ public class AttachmentHandlerServiceTests {
         List<InboundMessage.Attachment> attachmentsList = attachmentHandlerService
             .buildInboundAttachmentsFromAttachmentLogs(patientAttachmentLogs, payloads, conversationId);
 
-        assertThat(attachmentsList.get(0).getIsBase64()).isEqualTo("true");
+        assertThat(attachmentsList.getFirst().getIsBase64()).isEqualTo("true");
         assertThat(attachmentsList.get(1).getIsBase64()).isEqualTo("false");
 
     }

--- a/gp2gp-translator/src/test/java/uk/nhs/adaptors/pss/translator/service/ConfidentialityServiceTest.java
+++ b/gp2gp-translator/src/test/java/uk/nhs/adaptors/pss/translator/service/ConfidentialityServiceTest.java
@@ -103,7 +103,7 @@ class ConfidentialityServiceTest {
 
     private void assertMetaSecurityIsNotPresent(final Meta meta) {
         assertAll(
-            () -> assertThat(meta.getSecurity().size()).isEqualTo(0),
+            () -> assertThat(meta.getSecurity().size()).isZero(),
             () -> assertThat(meta.getProfile().getFirst().getValue()).isEqualTo(DUMMY_PROFILE_URI)
         );
     }

--- a/gp2gp-translator/src/test/java/uk/nhs/adaptors/pss/translator/task/COPCMessageHandlerTest.java
+++ b/gp2gp-translator/src/test/java/uk/nhs/adaptors/pss/translator/task/COPCMessageHandlerTest.java
@@ -176,7 +176,7 @@ class COPCMessageHandlerTest {
         // ASSERT
         verify(patientAttachmentLogService).addAttachmentLog(patientLogCaptor.capture());
 
-        PatientAttachmentLog actual = patientLogCaptor.getAllValues().get(0);
+        PatientAttachmentLog actual = patientLogCaptor.getAllValues().getFirst();
 
         assertThat(actual.getUploaded()).isTrue();
         assertEquals("047C22B4-613F-47D3-9A72-44A1758464FB", actual.getMid());
@@ -329,7 +329,7 @@ class COPCMessageHandlerTest {
                                               "ABC Not Required", CONVERSATION_ID, "text/plain");
         verify(patientAttachmentLogService, times(2)).addAttachmentLog(patientLogCaptor.capture());
 
-        PatientAttachmentLog actualCidAttachmentLog = patientLogCaptor.getAllValues().get(0);
+        PatientAttachmentLog actualCidAttachmentLog = patientLogCaptor.getAllValues().getFirst();
         PatientAttachmentLog actualMidAttachmentLog = patientLogCaptor.getAllValues().get(1);
 
         assertEquals(generatedCid, actualCidAttachmentLog.getMid());
@@ -373,7 +373,7 @@ class COPCMessageHandlerTest {
 
         verify(patientAttachmentLogService).updateAttachmentLog(patientLogCaptor.capture(), conversationIdCaptor.capture());
 
-        PatientAttachmentLog actual = patientLogCaptor.getAllValues().get(0);
+        PatientAttachmentLog actual = patientLogCaptor.getAllValues().getFirst();
         assertThat(actual.getUploaded()).isTrue();
         assertEquals(CONVERSATION_ID, conversationIdCaptor.getValue());
     }
@@ -1305,7 +1305,7 @@ class COPCMessageHandlerTest {
         message.setAttachments(Arrays.asList(new InboundMessage.Attachment("xml/text", "Yes", "Filename=E39E79A2-FA96-48FF-9373"
             + "-7BBCB9D036E7_1.messageattachment ContentType=text/plain Compressed=No LargeAttachment=No OriginalBase64=Yes", "this is a "
             + "payload")));
-        message.getAttachments().get(0).setPayload("This is a payload");
+        message.getAttachments().getFirst().setPayload("This is a payload");
 
         when(xPathService.parseDocumentFromXml(message.getEbXML())).thenReturn(ebXmlDocument);
         when(xPathService.getNodeValue(ebXmlDocument, "/Envelope/Header/MessageHeader/MessageData/MessageId"))
@@ -1374,7 +1374,7 @@ class COPCMessageHandlerTest {
         inboundMessage.setEbXML(readXmlFile("inbound_message_ebxml_fragment_index.xml"));
         inboundMessage.setAttachments(Arrays.asList(new InboundMessage.Attachment("xml/text", "Yes", "Filename=\"E39E79A2-FA96-48FF-9373"
             + "-7BBCB9D036E7_1.messageattachment\" ContentType=text/plain Compressed=No LargeAttachment=No OriginalBase64=Yes", "")));
-        inboundMessage.getAttachments().get(0).setPayload("This is a payload");
+        inboundMessage.getAttachments().getFirst().setPayload("This is a payload");
 
         when(xPathService.parseDocumentFromXml(inboundMessage.getEbXML())).thenReturn(ebXmlDocument);
         when(xPathService.getNodeValue(ebXmlDocument, "/Envelope/Header/MessageHeader/MessageData/MessageId")).thenReturn("CBBAE92D-C7E8"

--- a/gp2gp-translator/src/test/java/uk/nhs/adaptors/pss/translator/task/EhrExtractMessageHandlerTest.java
+++ b/gp2gp-translator/src/test/java/uk/nhs/adaptors/pss/translator/task/EhrExtractMessageHandlerTest.java
@@ -753,7 +753,7 @@ public class EhrExtractMessageHandlerTest {
 
         prepareMigrationRequestAndMigrationStatusMocks();
 
-        when(patientAttachmentLogService.findAttachmentLog(externalAttachmentsTestList.get(0).getMessageId(), CONVERSATION_ID))
+        when(patientAttachmentLogService.findAttachmentLog(externalAttachmentsTestList.getFirst().getMessageId(), CONVERSATION_ID))
             .thenReturn(null)
                 .thenReturn(patientAttachmentLog);
 

--- a/gp2gp-translator/src/test/java/uk/nhs/adaptors/pss/translator/util/AddressUtilTest.java
+++ b/gp2gp-translator/src/test/java/uk/nhs/adaptors/pss/translator/util/AddressUtilTest.java
@@ -22,7 +22,7 @@ public class AddressUtilTest {
 
         assertThat(address.getUse()).isEqualTo(Address.AddressUse.WORK);
         assertThat(address.getType()).isEqualTo(Address.AddressType.PHYSICAL);
-        assertThat(address.getLine().get(0).getValue()).isEqualTo("234 ASHTREE ROAD");
+        assertThat(address.getLine().getFirst().getValue()).isEqualTo("234 ASHTREE ROAD");
         assertThat(address.getLine().get(1).getValue()).isEqualTo("LEEDS");
         assertThat(address.getLine().get(2).getValue()).isEqualTo("YORKSHIRE");
         assertThat(address.getPostalCode()).isEqualTo("LS12 3RT");
@@ -36,7 +36,7 @@ public class AddressUtilTest {
 
         assertThat(address.getUse()).isEqualTo(Address.AddressUse.WORK);
         assertThat(address.getType()).isEqualTo(Address.AddressType.PHYSICAL);
-        assertThat(address.getLine().get(0).getValue()).isEqualTo("234 ASHTREE ROAD");
+        assertThat(address.getLine().getFirst().getValue()).isEqualTo("234 ASHTREE ROAD");
         assertThat(address.getLine().get(1).getValue()).isEqualTo("LEEDS");
         assertThat(address.getLine().get(2).getValue()).isEqualTo("YORKSHIRE");
         assertThat(address.getPostalCode()).isNull();

--- a/gp2gp-translator/src/test/java/uk/nhs/adaptors/pss/translator/util/ObservationUtilTest.java
+++ b/gp2gp-translator/src/test/java/uk/nhs/adaptors/pss/translator/util/ObservationUtilTest.java
@@ -48,19 +48,19 @@ public class ObservationUtilTest {
     }
 
     private RCMRMT030101UKObservationStatement getObservationStatementFromEhrExtract(RCMRMT030101UKEhrExtract ehrExtract) {
-        return ehrExtract.getComponent().get(0).getEhrFolder().getComponent().get(0).getEhrComposition().getComponent().get(0)
+        return ehrExtract.getComponent().getFirst().getEhrFolder().getComponent().getFirst().getEhrComposition().getComponent().getFirst()
             .getObservationStatement();
     }
 
     private RCMRMT030101UKEhrComposition getEhrCompositionFromEhrExtract(RCMRMT030101UKEhrExtract ehrExtract) {
-        return ehrExtract.getComponent().get(0).getEhrFolder().getComponent().get(0).getEhrComposition();
+        return ehrExtract.getComponent().getFirst().getEhrFolder().getComponent().getFirst().getEhrComposition();
     }
 
     private void assertInterpretation(CodeableConcept interpretation, String text, String code, String display) {
         assertThat(interpretation.getText()).isEqualTo(text);
-        assertThat(interpretation.getCoding().get(0).getCode()).isEqualTo(code);
-        assertThat(interpretation.getCoding().get(0).getDisplay()).isEqualTo(display);
-        assertThat(interpretation.getCoding().get(0).getSystem()).isEqualTo(INTERPRETATION_SYSTEM);
+        assertThat(interpretation.getCoding().getFirst().getCode()).isEqualTo(code);
+        assertThat(interpretation.getCoding().getFirst().getDisplay()).isEqualTo(display);
+        assertThat(interpretation.getCoding().getFirst().getSystem()).isEqualTo(INTERPRETATION_SYSTEM);
     }
 
     @Test
@@ -100,8 +100,8 @@ public class ObservationUtilTest {
         var quantity = ObservationUtil.getValueQuantity(observationStatement.getValue(),
             observationStatement.getUncertaintyCode());
 
-        assertThat(quantity.getExtension().get(0).getUrl()).isEqualTo(QUANTITY_EXTENSION_URL);
-        assertThat(quantity.getExtension().get(0).getValueAsPrimitive().getValue()).isEqualTo(true);
+        assertThat(quantity.getExtension().getFirst().getUrl()).isEqualTo(QUANTITY_EXTENSION_URL);
+        assertThat(quantity.getExtension().getFirst().getValueAsPrimitive().getValue()).isEqualTo(true);
     }
 
     @Test
@@ -259,9 +259,9 @@ public class ObservationUtilTest {
 
         var referenceRanges = ObservationUtil.getReferenceRange(observationStatement.getReferenceRange());
 
-        assertThat(referenceRanges.get(0).getText()).isEqualTo("Test Range 1");
-        assertThat(referenceRanges.get(0).getLow().getValue()).isEqualTo(REFERENCE_RANGE_LOW_VALUE_1);
-        assertThat(referenceRanges.get(0).getHigh().getValue()).isEqualTo(REFERENCE_RANGE_HIGH_VALUE_1);
+        assertThat(referenceRanges.getFirst().getText()).isEqualTo("Test Range 1");
+        assertThat(referenceRanges.getFirst().getLow().getValue()).isEqualTo(REFERENCE_RANGE_LOW_VALUE_1);
+        assertThat(referenceRanges.getFirst().getHigh().getValue()).isEqualTo(REFERENCE_RANGE_HIGH_VALUE_1);
     }
 
     @Test
@@ -271,8 +271,8 @@ public class ObservationUtilTest {
 
         var referenceRanges = ObservationUtil.getReferenceRange(observationStatement.getReferenceRange());
 
-        assertThat(referenceRanges.get(0).getLow().getValue()).isEqualTo(REFERENCE_RANGE_LOW_VALUE_1);
-        assertThat(referenceRanges.get(0).getHigh().getValue()).isNull();
+        assertThat(referenceRanges.getFirst().getLow().getValue()).isEqualTo(REFERENCE_RANGE_LOW_VALUE_1);
+        assertThat(referenceRanges.getFirst().getHigh().getValue()).isNull();
     }
 
     @Test
@@ -282,8 +282,8 @@ public class ObservationUtilTest {
 
         var referenceRanges = ObservationUtil.getReferenceRange(observationStatement.getReferenceRange());
 
-        assertThat(referenceRanges.get(0).getLow().getValue()).isNull();
-        assertThat(referenceRanges.get(0).getHigh().getValue()).isEqualTo(REFERENCE_RANGE_HIGH_VALUE_1);
+        assertThat(referenceRanges.getFirst().getLow().getValue()).isNull();
+        assertThat(referenceRanges.getFirst().getHigh().getValue()).isEqualTo(REFERENCE_RANGE_HIGH_VALUE_1);
     }
 
     @Test
@@ -293,7 +293,7 @@ public class ObservationUtilTest {
 
         var referenceRanges = ObservationUtil.getReferenceRange(observationStatement.getReferenceRange());
 
-        assertThat(StringUtils.isEmpty(referenceRanges.get(0).getText())).isTrue();
+        assertThat(StringUtils.isEmpty(referenceRanges.getFirst().getText())).isTrue();
     }
 
     @Test
@@ -303,9 +303,9 @@ public class ObservationUtilTest {
 
         var referenceRanges = ObservationUtil.getReferenceRange(observationStatement.getReferenceRange());
 
-        assertThat(referenceRanges.get(0).getText()).isEqualTo("Test Range 1");
-        assertThat(referenceRanges.get(0).getLow().getValue()).isEqualTo(REFERENCE_RANGE_LOW_VALUE_1);
-        assertThat(referenceRanges.get(0).getHigh().getValue()).isEqualTo(REFERENCE_RANGE_HIGH_VALUE_1);
+        assertThat(referenceRanges.getFirst().getText()).isEqualTo("Test Range 1");
+        assertThat(referenceRanges.getFirst().getLow().getValue()).isEqualTo(REFERENCE_RANGE_LOW_VALUE_1);
+        assertThat(referenceRanges.getFirst().getHigh().getValue()).isEqualTo(REFERENCE_RANGE_HIGH_VALUE_1);
         assertThat(referenceRanges.get(1).getText()).isEqualTo("Test Range 2");
         assertThat(referenceRanges.get(1).getLow().getValue()).isEqualTo(REFERENCE_RANGE_LOW_VALUE_2);
         assertThat(referenceRanges.get(1).getHigh().getValue()).isEqualTo(REFERENCE_RANGE_HIGH_VALUE_2);
@@ -318,8 +318,8 @@ public class ObservationUtilTest {
 
         var referenceRange = ObservationUtil.getReferenceRange(observationStatement.getReferenceRange());
 
-        assertThat(referenceRange.get(0).getText()).isEqualTo("Test Range 1");
-        assertThat(referenceRange.get(0).getLow().getValue().doubleValue()).isEqualTo(REFERENCE_RANGE_LOW_VALUE_DECIMAL);
-        assertThat(referenceRange.get(0).getHigh().getValue().doubleValue()).isEqualTo(REFERENCE_RANGE_HIGH_VALUE_DECIMAL);
+        assertThat(referenceRange.getFirst().getText()).isEqualTo("Test Range 1");
+        assertThat(referenceRange.getFirst().getLow().getValue().doubleValue()).isEqualTo(REFERENCE_RANGE_LOW_VALUE_DECIMAL);
+        assertThat(referenceRange.getFirst().getHigh().getValue().doubleValue()).isEqualTo(REFERENCE_RANGE_HIGH_VALUE_DECIMAL);
     }
 }

--- a/gp2gp-translator/src/test/java/uk/nhs/adaptors/pss/translator/util/ParticipantReferenceUtilTest.java
+++ b/gp2gp-translator/src/test/java/uk/nhs/adaptors/pss/translator/util/ParticipantReferenceUtilTest.java
@@ -21,7 +21,7 @@ public class ParticipantReferenceUtilTest {
     }
 
     private List<RCMRMT030101UKParticipant> getParticipants(RCMRMT030101UKEhrComposition ehrComposition) {
-        return ehrComposition.getComponent().get(0).getPlanStatement().getParticipant();
+        return ehrComposition.getComponent().getFirst().getPlanStatement().getParticipant();
     }
 
     @Test

--- a/gp2gp-translator/src/test/java/uk/nhs/adaptors/pss/translator/util/ResourceReferenceUtilTest.java
+++ b/gp2gp-translator/src/test/java/uk/nhs/adaptors/pss/translator/util/ResourceReferenceUtilTest.java
@@ -50,7 +50,7 @@ public class ResourceReferenceUtilTest {
         resourceReferenceUtil.extractChildReferencesFromEhrComposition(ehrComposition, references);
 
         assertThat(references).hasSize(TWO);
-        assertThat(references.get(0).getReference()).isEqualTo("MedicationRequest/A0A70B62-2649-4C8F-B3AB-618B8257C942");
+        assertThat(references.getFirst().getReference()).isEqualTo("MedicationRequest/A0A70B62-2649-4C8F-B3AB-618B8257C942");
         assertThat(references.get(1).getReference()).isEqualTo("MedicationRequest/9B4B797A-D674-4362-B666-2ADC8551EEDA");
     }
 
@@ -62,7 +62,7 @@ public class ResourceReferenceUtilTest {
         resourceReferenceUtil.extractChildReferencesFromCompoundStatement(compoundStatement, references);
 
         assertThat(references).hasSize(TWO);
-        assertThat(references.get(0).getReference()).isEqualTo("MedicationRequest/A0A70B62-2649-4C8F-B3AB-618B8257C942");
+        assertThat(references.getFirst().getReference()).isEqualTo("MedicationRequest/A0A70B62-2649-4C8F-B3AB-618B8257C942");
         assertThat(references.get(1).getReference()).isEqualTo("MedicationRequest/9B4B797A-D674-4362-B666-2ADC8551EEDA");
     }
 
@@ -75,7 +75,7 @@ public class ResourceReferenceUtilTest {
 //        resourceReferenceUtil.extractChildReferencesFromEhrComposition(ehrComposition, references);
 //
 //        assertThat(references.size()).isEqualTo(FOUR);
-//        assertThat(references.get(0).getReference()).isEqualTo("QuestionnaireResponse/7334D39A-BBB3-424A-B5D3-E841BCA39BF7-QRSP");
+//        assertThat(references.getFirst().getReference()).isEqualTo("QuestionnaireResponse/7334D39A-BBB3-424A-B5D3-E841BCA39BF7-QRSP");
 //        assertThat(references.get(1).getReference()).isEqualTo("Observation/7334D39A-BBB3-424A-B5D3-E841BCA39BF7");
 //        assertThat(references.get(2).getReference()).isEqualTo("Observation/3DCC9FC9-1873-4004-9789-C4E5C52B02B9");
 //        assertThat(references.get(THREE).getReference()).isEqualTo("Observation/278ADD5F-2AC7-48DC-966A-0BA7C029C793");
@@ -90,7 +90,7 @@ public class ResourceReferenceUtilTest {
 //        resourceReferenceUtil.extractChildReferencesFromCompoundStatement(compoundStatement, references);
 //
 //        assertThat(references.size()).isEqualTo(FOUR);
-//        assertThat(references.get(0).getReference()).isEqualTo("QuestionnaireResponse/7334D39A-BBB3-424A-B5D3-E841BCA39BF7-QRSP");
+//        assertThat(references.getFirst().getReference()).isEqualTo("QuestionnaireResponse/7334D39A-BBB3-424A-B5D3-E841BCA39BF7-QRSP");
 //        assertThat(references.get(1).getReference()).isEqualTo("Observation/7334D39A-BBB3-424A-B5D3-E841BCA39BF7");
 //        assertThat(references.get(2).getReference()).isEqualTo("Observation/3DCC9FC9-1873-4004-9789-C4E5C52B02B9");
 //        assertThat(references.get(THREE).getReference()).isEqualTo("Observation/278ADD5F-2AC7-48DC-966A-0BA7C029C793");
@@ -102,10 +102,10 @@ public class ResourceReferenceUtilTest {
 
         List<Reference> references = new ArrayList<>();
         resourceReferenceUtil.extractChildReferencesFromTemplate(
-            ehrComposition.getComponent().get(0).getCompoundStatement(), references);
+            ehrComposition.getComponent().getFirst().getCompoundStatement(), references);
 
         assertThat(references).hasSize(2);
-        assertThat(references.get(0).getReference()).isEqualTo("Observation/3DCC9FC9-1873-4004-9789-C4E5C52B02B9");
+        assertThat(references.getFirst().getReference()).isEqualTo("Observation/3DCC9FC9-1873-4004-9789-C4E5C52B02B9");
         assertThat(references.get(1).getReference()).isEqualTo("Observation/278ADD5F-2AC7-48DC-966A-0BA7C029C793");
     }
 
@@ -125,7 +125,7 @@ public class ResourceReferenceUtilTest {
         resourceReferenceUtil.extractChildReferencesFromEhrComposition(ehrComposition, references);
 
         assertThat(references.size()).isOne();
-        assertThat(references.get(0).getReference()).isEqualTo(referenceString);
+        assertThat(references.getFirst().getReference()).isEqualTo(referenceString);
     }
 
     private static Stream<Arguments> ehrCompositionResourceFiles() {
@@ -157,7 +157,7 @@ public class ResourceReferenceUtilTest {
         resourceReferenceUtil.extractChildReferencesFromCompoundStatement(compoundStatement, references);
 
         assertThat(references.size()).isOne();
-        assertThat(references.get(0).getReference()).isEqualTo(referenceString);
+        assertThat(references.getFirst().getReference()).isEqualTo(referenceString);
     }
 
     private static Stream<Arguments> compoundStatementResourceFiles() {

--- a/gpc-api-facade/src/test/java/uk/nhs/adaptors/pss/gpc/util/fhir/CodeableConceptUtilsTest.java
+++ b/gpc-api-facade/src/test/java/uk/nhs/adaptors/pss/gpc/util/fhir/CodeableConceptUtilsTest.java
@@ -56,7 +56,7 @@ public class CodeableConceptUtilsTest {
                 null,
                 extension);
 
-        assertThat(result.getCoding().get(0).getExtension().get(0).getUrlElement().getValue()).isEqualTo(EXTENSION_URL);
+        assertThat(result.getCoding().getFirst().getExtension().getFirst().getUrlElement().getValue()).isEqualTo(EXTENSION_URL);
     }
 
     @Test
@@ -67,7 +67,7 @@ public class CodeableConceptUtilsTest {
                 DISPLAY,
                 null,
                 GP2GP_SPECIFIC_CODE);
-        final var actualBaseCoding = result.getCoding().get(0);
+        final var actualBaseCoding = result.getCoding().getFirst();
         final var actualEhrRequestAckCoding = result.getCoding().get(1);
 
         assertAll(
@@ -92,6 +92,6 @@ public class CodeableConceptUtilsTest {
                 null,
                 GP2GP_SPECIFIC_CODE);
 
-        assertThat(result.getCoding().get(0).getSystem()).isEqualTo(expectedSystem);
+        assertThat(result.getCoding().getFirst().getSystem()).isEqualTo(expectedSystem);
     }
 }

--- a/gpc-api-facade/src/test/java/uk/nhs/adaptors/pss/gpc/util/fhir/OperationOutcomeUtilsTest.java
+++ b/gpc-api-facade/src/test/java/uk/nhs/adaptors/pss/gpc/util/fhir/OperationOutcomeUtilsTest.java
@@ -20,7 +20,7 @@ public class OperationOutcomeUtilsTest {
 
         var result = OperationOutcomeUtils.createOperationOutcome(NOTSUPPORTED, ERROR, details, diagnostics);
 
-        assertThat(result.getMeta().getProfile().get(0).equals(URI_TYPE)).isTrue();
+        assertThat(result.getMeta().getProfile().getFirst().equals(URI_TYPE)).isTrue();
         assertEquals(NOTSUPPORTED, result.getIssueFirstRep().getCode());
         assertEquals(ERROR, result.getIssueFirstRep().getSeverity());
         assertEquals(details, result.getIssueFirstRep().getDetails());

--- a/schema/src/main/java/org/hl7/v3/RCMRMT030101UKAuthorise.java
+++ b/schema/src/main/java/org/hl7/v3/RCMRMT030101UKAuthorise.java
@@ -342,7 +342,7 @@ public class RCMRMT030101UKAuthorise {
 
     public RCMRMT030101UKPredecessor getPredecessorFirstRep() {
         if (!predecessor.isEmpty()) {
-            return predecessor.get(0);
+            return predecessor.getFirst();
         }
         return null;
     }

--- a/schema/src/test/java/JaxbTest.java
+++ b/schema/src/test/java/JaxbTest.java
@@ -32,11 +32,11 @@ class JaxbTest {
             .getSubject()
             .getEhrExtract()
             .getComponent()
-            .get(0)
+            .getFirst()
             .getEhrFolder();
 
         var person = ehrFolder.getResponsibleParty().getAgentDirectory().getPart().get(2).getAgent().getAgentPerson();
-        var place = ehrFolder.getComponent().get(0).getEhrComposition().getLocation().getLocatedEntity().getLocatedPlace();
+        var place = ehrFolder.getComponent().getFirst().getEhrComposition().getLocation().getLocatedEntity().getLocatedPlace();
 
         // then
         assertThat(person.getName().getFamily()).isEqualTo("Whitcombe");
@@ -62,15 +62,15 @@ class JaxbTest {
             .getSubject()
             .getEhrExtract()
             .getComponent()
-            .get(0)
+            .getFirst()
             .getEhrFolder();
 
         final CV observationStatementConfidentialityCode = ehrFolder
             .getComponent()
-            .get(0)
+            .getFirst()
             .getEhrComposition()
             .getComponent()
-            .get(0)
+            .getFirst()
             .getObservationStatement()
             .getConfidentialityCode()
             .orElseThrow();


### PR DESCRIPTION
## What

<List>.get(0) was changed to <List>.getFirst()

## Why

<List>.get(0) was changed to <List>.getFirst() which gives a more intuitive reference to the first element of the list that was enabled in Java 21

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Internal change (non-breaking change with no effect on the functionality affecting end users)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:

- [x] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] I have updated the [Changelog](/CHANGELOG.md) with details of my change in the UNRELEASED section if this change will affect end users
- [ ] A corresponding change has been made to the [Mapping Documentation repository][mapping-docs]

[mapping-docs]: https://github.com/NHSDigital/patient-switching-adaptors-mapping-documentation