### PR TITLE
NIAD-3145: PS Adaptor should reject request with an invalid `ConversationId` header

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,8 @@ that immunizations are correctly identified when a match is found.
 ### Fixed
 * Resolved issue where the SNOMED import script would reject a password containing a '%' character.
 * Fixed some Test Results being given a duplicated `Observation.category` entries for `Laboratory`.
+* Fixed issue where the GPC Facade was not returning an error when an invalid `ConversationId` header 
+was provided.
 
 ## [3.0.2] - 2024-07-18
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,7 +29,6 @@ that immunizations are correctly identified when a match is found.
 ### Fixed
 * Resolved issue where the SNOMED import script would reject a password containing a '%' character.
 * Fixed some Test Results being given a duplicated `Observation.category` entries for `Laboratory`.
-
 * Fixed issue where the GPC Facade was not returning an error when an invalid `ConversationId` header 
 was provided.
 * Filing Comments were creating with incorrect `effectiveDateTime`, this is now set from the 

--- a/README.md
+++ b/README.md
@@ -39,8 +39,32 @@ To use this endpoint, you need to provide the following headers:
 - FROM-ASID : ASID identifier of the winning New Market Entrant (NME)
 - TO-ODS : ODS identifier of the losing incumbent
 - FROM-ODS : ODS identifier of the winning New Market Entrant (NME)
-- ConversationId : A unique GUID for the request. If not provided, the adaptor will generate one and include it in the response headers.
+- ConversationId : A unique UUID for the request. If not provided, the adaptor will generate one and include it in the response headers.
   It must be used for all further calls for the patient's NHS number.
+
+If a `ConversationId` header is provided where the value is populated but does not contain a valid UUID, then the 
+following response will be returned:
+
+```json
+{
+	"resourceType": "OperationOutcome",
+	"meta": {
+		"profile": ["https://fhir.nhs.uk/STU3/StructureDefinition/GPConnect-OperationOutcome-1"]
+	},
+	"issue": [{
+		"severity": "error",
+		"code": "invalid",
+		"details": {
+			"coding": [{
+				"system": "https://fhir.nhs.uk/STU3/ValueSet/Spine-ErrorOrWarningCode-1",
+				"code": "BAD_REQUEST",
+				"display": "Bad request"
+			}]
+		},
+		"diagnostics": "ConversationId header must be either be empty or a valid UUID"
+	}]
+}
+```
 
 For more details on how to query the losing practice details, see the [requesting site requirements].
 
@@ -64,7 +88,7 @@ Request Body Example:
             "name": "includeFullRecord",
             "part": [
                {
-                  "name": "includeSensitiveInfomation",
+                  "name": "includeSensitiveInformation",
                   "valueBoolean": true
                }
             ]

--- a/gpc-api-facade/src/main/java/uk/nhs/adaptors/pss/gpc/config/filter/ConversationIdFilter.java
+++ b/gpc-api-facade/src/main/java/uk/nhs/adaptors/pss/gpc/config/filter/ConversationIdFilter.java
@@ -1,10 +1,14 @@
 package uk.nhs.adaptors.pss.gpc.config.filter;
 
+import static com.google.common.net.HttpHeaders.CONTENT_TYPE;
+import static jakarta.servlet.http.HttpServletResponse.SC_BAD_REQUEST;
 import static java.net.URLEncoder.encode;
 import static java.nio.charset.StandardCharsets.UTF_8;
-import static java.util.UUID.randomUUID;
 
+import static org.hl7.fhir.dstu3.model.OperationOutcome.IssueSeverity.ERROR;
+import static org.hl7.fhir.dstu3.model.OperationOutcome.IssueType.INVALID;
 import static org.springframework.util.ObjectUtils.isEmpty;
+import static uk.nhs.adaptors.pss.gpc.controller.handler.FhirMediaTypes.APPLICATION_FHIR_JSON_VALUE;
 
 import jakarta.servlet.FilterChain;
 import jakarta.servlet.ServletException;
@@ -17,24 +21,42 @@ import org.springframework.web.filter.OncePerRequestFilter;
 
 import lombok.RequiredArgsConstructor;
 import uk.nhs.adaptors.common.service.MDCService;
+import uk.nhs.adaptors.common.util.CodeableConceptUtils;
+import uk.nhs.adaptors.common.util.fhir.FhirParser;
+import uk.nhs.adaptors.pss.gpc.util.fhir.OperationOutcomeUtils;
+
+import java.io.IOException;
+import java.util.UUID;
 
 
 @RequiredArgsConstructor(onConstructor = @__(@Autowired))
 @Component
 public class ConversationIdFilter extends OncePerRequestFilter {
+    private final MDCService mdcService;
+    private final FhirParser fhirParser;
 
+    private static final String UUID_REGEX =
+        "^[0-9a-fA-F]{8}\\b-[0-9a-fA-F]{4}\\b-[0-9a-fA-F]{4}\\b-[0-9a-fA-F]{4}\\b-[0-9a-fA-F]{12}$";
     private static final String CONVERSATION_ID = "ConversationId";
 
-    private final MDCService mdcService;
-
     @Override
-    protected void doFilterInternal(final HttpServletRequest request, final HttpServletResponse response, final FilterChain chain)
+    protected void doFilterInternal(
+        final HttpServletRequest request,
+        final HttpServletResponse response,
+        final FilterChain chain)
         throws java.io.IOException, ServletException {
         try {
             var token = request.getHeader(CONVERSATION_ID);
             if (isEmpty(token)) {
-                token = getRandomCorrelationId();
+                token = UUID.randomUUID().toString();
             }
+            token = token.toUpperCase();
+
+            if (!token.matches(UUID_REGEX)) {
+                setInvalidConversationIdResponse(response);
+                return;
+            }
+
             mdcService.applyConversationId(token);
             token = encode(token, UTF_8);
             response.addHeader(CONVERSATION_ID, token);
@@ -44,7 +66,25 @@ public class ConversationIdFilter extends OncePerRequestFilter {
         }
     }
 
-    public String getRandomCorrelationId() {
-        return randomUUID().toString().toUpperCase();
+    private void setInvalidConversationIdResponse(
+        final HttpServletResponse response
+    ) throws IOException {
+        var content = fhirParser.encodeToJson(
+            OperationOutcomeUtils.createOperationOutcome(
+                INVALID,
+                ERROR,
+                CodeableConceptUtils.createCodeableConcept(
+                    "BAD_REQUEST",
+                    "https://fhir.nhs.uk/STU3/ValueSet/Spine-ErrorOrWarningCode-1",
+                    "Bad Request"
+                ),
+                "ConversationId header must be either be absent, empty or a valid UUID"
+            )
+        );
+        response.resetBuffer();
+        response.setStatus(SC_BAD_REQUEST);
+        response.setHeader(CONTENT_TYPE, APPLICATION_FHIR_JSON_VALUE);
+        response.getOutputStream().print(content);
+        response.flushBuffer();
     }
 }

--- a/gpc-api-facade/src/main/java/uk/nhs/adaptors/pss/gpc/config/filter/package-info.java
+++ b/gpc-api-facade/src/main/java/uk/nhs/adaptors/pss/gpc/config/filter/package-info.java
@@ -1,0 +1,4 @@
+@NonNullApi
+package uk.nhs.adaptors.pss.gpc.config.filter;
+
+import org.springframework.lang.NonNullApi;

--- a/gpc-api-facade/src/test/java/config/filter/ConversationIdFilterTest.java
+++ b/gpc-api-facade/src/test/java/config/filter/ConversationIdFilterTest.java
@@ -72,8 +72,7 @@ public class ConversationIdFilterTest {
     @EmptySource
     public void When_ConversationIdFilter_Expect_MdcServiceIsReset(
         String conversationId
-    ) throws ServletException, IOException
-    {
+    ) throws ServletException, IOException {
         request.addHeader(CONVERSATION_ID, conversationId);
 
         conversationIdFilter.doFilter(request, response, filterChain);
@@ -89,8 +88,7 @@ public class ConversationIdFilterTest {
     })
     public void When_ConversationIdFilterWithValidConversationId_Expect_UppercaseIdIsAppliedToMdcService(
         String conversationId
-    ) throws ServletException, IOException
-    {
+    ) throws ServletException, IOException {
         request.addHeader(CONVERSATION_ID, conversationId);
 
         conversationIdFilter.doFilter(request, response, filterChain);
@@ -106,8 +104,7 @@ public class ConversationIdFilterTest {
     })
     public void When_ConversationIdFilterWithValidConversationId_Expect_UppercaseIdIsAddedToResponseHeaders(
         String conversationId
-    ) throws ServletException, IOException
-    {
+    ) throws ServletException, IOException {
         request.addHeader(CONVERSATION_ID, conversationId);
 
         conversationIdFilter.doFilter(request, response, filterChain);
@@ -118,8 +115,8 @@ public class ConversationIdFilterTest {
 
     @Test
     public void When_ConversationIdFilterWithNoConversationIdHeader_Expect_UppercaseIdIsAppliedToMdcService()
-        throws ServletException, IOException
-    {
+        throws ServletException, IOException {
+
         conversationIdFilter.doFilter(request, response, filterChain);
 
         Mockito.verify(mdcService, Mockito.times(1))
@@ -128,8 +125,8 @@ public class ConversationIdFilterTest {
 
     @Test
     public void When_ConversationIdFilterWithNoConversationIdHeader_Expect_UppercaseIdIsAddedToResponseHeaders()
-        throws ServletException, IOException
-    {
+        throws ServletException, IOException {
+
         conversationIdFilter.doFilter(request, response, filterChain);
 
         assertThat(response.getHeader(CONVERSATION_ID))
@@ -153,35 +150,35 @@ public class ConversationIdFilterTest {
     }
 
     @Test
-    public void WhenConversationIdFilterWithInvalidConversationId_Expect_BadRequestOperationOutcomeResponse()
-        throws ServletException, IOException
-    {
+    public void When_ConversationIdFilterWithInvalidConversationId_Expect_BadRequestOperationOutcomeResponse()
+        throws ServletException, IOException {
+
         request.addHeader(CONVERSATION_ID, "this-is-quite-clearly-not-a-conversation-id");
         var expectedContent = """
-        {
-            "resourceType": "OperationOutcome",
-            "meta": {
-                "profile": [
-                    "https://fhir.nhs.uk/STU3/StructureDefinition/GPConnect-OperationOutcome-1"
+            {
+                "resourceType": "OperationOutcome",
+                "meta": {
+                    "profile": [
+                        "https://fhir.nhs.uk/STU3/StructureDefinition/GPConnect-OperationOutcome-1"
+                    ]
+                },
+                "issue": [
+                    {
+                        "severity": "error",
+                        "code": "invalid",
+                        "details": {
+                            "coding": [
+                                {
+                                    "system": "https://fhir.nhs.uk/STU3/ValueSet/Spine-ErrorOrWarningCode-1",
+                                    "code": "BAD_REQUEST",
+                                    "display": "ConversationId header must be either be absent, empty or a valid UUID"
+                                }
+                            ]
+                        },
+                        "diagnostics": "ConversationId header must be either be absent, empty or a valid UUID"
+                    }
                 ]
-            },
-            "issue": [
-                {
-                    "severity": "error",
-                    "code": "invalid",
-                    "details": {
-                        "coding": [
-                            {
-                                "system": "https://fhir.nhs.uk/STU3/ValueSet/Spine-ErrorOrWarningCode-1",
-                                "code": "BAD_REQUEST",
-                                "display": "ConversationId header must be either be absent, empty or a valid UUID"
-                            }
-                        ]
-                    },
-                    "diagnostics": "ConversationId header must be either be absent, empty or a valid UUID"
-                }
-            ]
-        }""";
+            }""";
         when(fhirParser.encodeToJson(any())).thenReturn(expectedContent);
 
         conversationIdFilter.doFilter(request, response, filterChain);

--- a/gpc-api-facade/src/test/java/config/filter/ConversationIdFilterTest.java
+++ b/gpc-api-facade/src/test/java/config/filter/ConversationIdFilterTest.java
@@ -1,0 +1,198 @@
+package config.filter;
+
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletResponse;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EmptySource;
+import org.junit.jupiter.params.provider.ValueSource;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.mock.web.MockHttpServletResponse;
+import uk.nhs.adaptors.common.service.MDCService;
+import uk.nhs.adaptors.common.util.fhir.FhirParser;
+import uk.nhs.adaptors.pss.gpc.config.filter.ConversationIdFilter;
+
+import java.io.IOException;
+import java.util.UUID;
+
+import static org.apache.http.HttpHeaders.CONTENT_TYPE;
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+import static org.junit.jupiter.api.Assertions.assertAll;
+import static org.mockito.Mockito.any;
+import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.when;
+import static uk.nhs.adaptors.pss.gpc.controller.handler.FhirMediaTypes.APPLICATION_FHIR_JSON_VALUE;
+
+@ExtendWith(MockitoExtension.class)
+public class ConversationIdFilterTest {
+
+    @Mock
+    private MDCService mdcService;
+
+    @Mock
+    private FhirParser fhirParser;
+
+    @Mock
+    private FilterChain filterChain;
+
+    private ConversationIdFilter conversationIdFilter;
+    private MockHttpServletRequest request;
+    private MockHttpServletResponse response;
+
+    private static final String CONVERSATION_ID = "ConversationId";
+    private static final UUID GENERATED_CONVERSATION_ID = UUID.randomUUID();
+
+    @BeforeAll
+    public static void setup() {
+        mockStatic(UUID.class)
+            .when(UUID::randomUUID)
+            .thenReturn(GENERATED_CONVERSATION_ID);
+    }
+
+    @BeforeEach
+    public void setUp() {
+        conversationIdFilter = new ConversationIdFilter(mdcService, fhirParser);
+        request = new MockHttpServletRequest();
+        response = new MockHttpServletResponse();
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {
+        "f099635b-5d8b-4dd1-af2e-16b2e492bb03",
+        "FEDE0DCA-9D6A-42B6-B34F-DB4ADF6FDE2B",
+        "this-is-quite-clearly-not-a-conversation-id"
+    })
+    @EmptySource
+    public void When_ConversationIdFilter_Expect_MdcServiceIsReset(
+        String conversationId
+    ) throws ServletException, IOException
+    {
+        request.addHeader(CONVERSATION_ID, conversationId);
+
+        conversationIdFilter.doFilter(request, response, filterChain);
+
+        Mockito.verify(mdcService, Mockito.times(1))
+            .resetAllMdcKeys();
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {
+        "f099635b-5d8b-4dd1-af2e-16b2e492bb03",
+        "FEDE0DCA-9D6A-42B6-B34F-DB4ADF6FDE2B"
+    })
+    public void When_ConversationIdFilterWithValidConversationId_Expect_UppercaseIdIsAppliedToMdcService(
+        String conversationId
+    ) throws ServletException, IOException
+    {
+        request.addHeader(CONVERSATION_ID, conversationId);
+
+        conversationIdFilter.doFilter(request, response, filterChain);
+
+        Mockito.verify(mdcService, Mockito.times(1))
+            .applyConversationId(conversationId.toUpperCase());
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {
+        "f099635b-5d8b-4dd1-af2e-16b2e492bb03",
+        "FEDE0DCA-9D6A-42B6-B34F-DB4ADF6FDE2B"
+    })
+    public void When_ConversationIdFilterWithValidConversationId_Expect_UppercaseIdIsAddedToResponseHeaders(
+        String conversationId
+    ) throws ServletException, IOException
+    {
+        request.addHeader(CONVERSATION_ID, conversationId);
+
+        conversationIdFilter.doFilter(request, response, filterChain);
+
+        assertThat(response.getHeader(CONVERSATION_ID))
+            .isEqualTo(conversationId.toUpperCase());
+    }
+
+    @Test
+    public void When_ConversationIdFilterWithNoConversationIdHeader_Expect_UppercaseIdIsAppliedToMdcService()
+        throws ServletException, IOException
+    {
+        conversationIdFilter.doFilter(request, response, filterChain);
+
+        Mockito.verify(mdcService, Mockito.times(1))
+            .applyConversationId(GENERATED_CONVERSATION_ID.toString().toUpperCase());
+    }
+
+    @Test
+    public void When_ConversationIdFilterWithNoConversationIdHeader_Expect_UppercaseIdIsAddedToResponseHeaders()
+        throws ServletException, IOException
+    {
+        conversationIdFilter.doFilter(request, response, filterChain);
+
+        assertThat(response.getHeader(CONVERSATION_ID))
+            .isEqualTo(GENERATED_CONVERSATION_ID.toString().toUpperCase());
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {
+        "f099635b-5d8b-4dd1-af2e-16b2e492bb03",
+        "FEDE0DCA-9D6A-42B6-B34F-DB4ADF6FDE2B"
+    })
+    public void When_ConversationIdFilterWithValidConversationId_Expect_NextFilterInChainIsCalled(
+        String conversationId
+    ) throws ServletException, IOException {
+        request.addHeader(CONVERSATION_ID, conversationId);
+
+        conversationIdFilter.doFilter(request, response, filterChain);
+
+        Mockito.verify(filterChain, Mockito.times(1))
+            .doFilter(request, response);
+    }
+
+    @Test
+    public void WhenConversationIdFilterWithInvalidConversationId_Expect_BadRequestOperationOutcomeResponse()
+        throws ServletException, IOException
+    {
+        request.addHeader(CONVERSATION_ID, "this-is-quite-clearly-not-a-conversation-id");
+        var expectedContent = """
+        {
+            "resourceType": "OperationOutcome",
+            "meta": {
+                "profile": [
+                    "https://fhir.nhs.uk/STU3/StructureDefinition/GPConnect-OperationOutcome-1"
+                ]
+            },
+            "issue": [
+                {
+                    "severity": "error",
+                    "code": "invalid",
+                    "details": {
+                        "coding": [
+                            {
+                                "system": "https://fhir.nhs.uk/STU3/ValueSet/Spine-ErrorOrWarningCode-1",
+                                "code": "BAD_REQUEST",
+                                "display": "ConversationId header must be either be absent, empty or a valid UUID"
+                            }
+                        ]
+                    },
+                    "diagnostics": "ConversationId header must be either be absent, empty or a valid UUID"
+                }
+            ]
+        }""";
+        when(fhirParser.encodeToJson(any())).thenReturn(expectedContent);
+
+        conversationIdFilter.doFilter(request, response, filterChain);
+
+        assertAll(
+            () -> assertThat(response.getStatus())
+                .isEqualTo(HttpServletResponse.SC_BAD_REQUEST),
+            () -> assertThat(response.getHeader(CONTENT_TYPE))
+                .isEqualTo(APPLICATION_FHIR_JSON_VALUE),
+            () -> assertThat(response.getContentAsString())
+                .isEqualTo(expectedContent)
+        );
+    }
+}

--- a/gpc-api-facade/src/test/java/uk/nhs/adaptors/pss/gpc/service/PatientTransferServiceTest.java
+++ b/gpc-api-facade/src/test/java/uk/nhs/adaptors/pss/gpc/service/PatientTransferServiceTest.java
@@ -204,7 +204,7 @@ public class PatientTransferServiceTest {
     @ParameterizedTest
     @MethodSource("generateInProgressStatuses")
     public void checkExistingPatientMigrationRequestInProgressWhenExistingMigrationInProcess(MigrationStatus status) {
-        final String newConversationId = UUID.randomUUID().toString();
+        final String newConversationId = "00000000-0000-4001-0000-000000000000";
         final PatientMigrationRequest patientMigrationRequest = createPatientMigrationRequest();
         final MigrationStatusLog migrationStatusLog = createMigrationStatusLog(status);
 


### PR DESCRIPTION
## What

*Create Unit Tests for ConversationIdFilter
* Add Unit Tests to ensure that `Bad Request` operational outcomes are returned when an invalid `ConversationId` is provided. 
* Add package-info.java to resolve warnings around @NonNullApi 
* Update ConversationIdFilter to return `Bad Request` operational outcomes are returned when an invalid `ConversationId` is provided. 
* Update README.md to document updated response
* Update CHANGELOG.md

## Why

Currently the GPC Facade endpoint will accept `ConversationId` headers, where the value is populated but with a value is not a valid UUID. 
When given an invalid argument, or missing argument which is required the adaptor should be returning a 400 Bad Request HTTP Error.
This should provide the `OperationalOutcome` in the content (as specified by GP Connect) detailing the error which has occurred.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [x] I have performed a self-review of my code
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have updated the [Changelog](/CHANGELOG.md) with details of my change in the UNRELEASED section if this change will affect end users