### PR TITLE
NIAD-2671: Output dead letter message at INFO level

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## [Unreleased]
 
+### Fixed
+
+- In the event that an inbound MHS message cannot be processed and needs to be sent to the dead letter queue, the
+  adaptor will now emit a log message at INFO level as opposed to DEBUG level.
+
 ## [3.0.3] - 2024-08-23
 
 > [!NOTE]

--- a/gp2gp-translator/src/main/java/uk/nhs/adaptors/pss/translator/amqp/MhsDaisyChainingQueueConsumer.java
+++ b/gp2gp-translator/src/main/java/uk/nhs/adaptors/pss/translator/amqp/MhsDaisyChainingQueueConsumer.java
@@ -39,7 +39,7 @@ public class MhsDaisyChainingQueueConsumer {
                 message.acknowledge();
                 LOGGER.debug("Acknowledged MHSQueue message_id=[{}]", messageId);
             } else {
-                LOGGER.debug("Sending message_id=[{}] to the dead letter queue", messageId);
+                LOGGER.info("Sending message_id=[{}] to the dead letter queue", messageId);
                 mhsDlqPublisher.sendToMhsDlq(message);
             }
 

--- a/gp2gp-translator/src/main/java/uk/nhs/adaptors/pss/translator/amqp/MhsQueueConsumer.java
+++ b/gp2gp-translator/src/main/java/uk/nhs/adaptors/pss/translator/amqp/MhsQueueConsumer.java
@@ -39,7 +39,7 @@ public class MhsQueueConsumer {
                 message.acknowledge();
                 LOGGER.debug("Acknowledged MHSQueue message_id=[{}]", messageId);
             } else {
-                LOGGER.debug("Sending message_id=[{}] to the dead letter queue", messageId);
+                LOGGER.info("Sending message_id=[{}] to the dead letter queue", messageId);
                 mhsDlqPublisher.sendToMhsDlq(message);
             }
         } catch (ConversationIdNotFoundException e) {


### PR DESCRIPTION
## Why

In the event that an MHS inbound message cannot be processed it would be useful to be clear what happens to the message once the error happens.

By outputing this at DEBUG level this message wouldn't have been displayed in a production like environment, making it harder for the NME to know what's happened to the corrupt message.

## Type of change

Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [x] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I have updated the [Changelog](/CHANGELOG.md) with details of my change in the UNRELEASED section if this change will affect end users
- [ ] A corresponding change has been made to the [Mapping Documentation repository][mapping-docs]

[mapping-docs]: https://github.com/NHSDigital/patient-switching-adaptors-mapping-documentation