### PR TITLE
Replace obsolete and incorrect `micrometer` implementation of `StringUtil`

### DIFF
--- a/gp2gp-translator/src/main/java/uk/nhs/adaptors/pss/translator/util/AddressUtil.java
+++ b/gp2gp-translator/src/main/java/uk/nhs/adaptors/pss/translator/util/AddressUtil.java
@@ -5,7 +5,7 @@ import lombok.NoArgsConstructor;
 import org.hl7.fhir.dstu3.model.Address;
 import org.hl7.v3.AD;
 
-import io.micrometer.core.instrument.util.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
 public class AddressUtil {


### PR DESCRIPTION
## What

Replace obsolete and incorrect `micrometer` implementation of `StringUtils` with the `apache.commons` version.

## Why

'micrometer' version of StringUtils is being used which is the incorrect implementation and is now marked as obsolete.

## Type of change

- [x] Internal change (non-breaking change with no effect on the functionality affecting end users)

## Checklist:

- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes