### PR TITLE
refactor-spelling-error-practise-to-practice

### DIFF
--- a/gp2gp-translator/src/main/java/uk/nhs/adaptors/pss/translator/mapper/AbstractMapper.java
+++ b/gp2gp-translator/src/main/java/uk/nhs/adaptors/pss/translator/mapper/AbstractMapper.java
@@ -31,5 +31,5 @@ public abstract class AbstractMapper<T> {
     }
 
     public abstract List<T> mapResources(RCMRMT030101UKEhrExtract ehrExtract, Patient patient,
-        List<Encounter> encounters, String practiseCode);
+        List<Encounter> encounters, String practiceCode);
 }

--- a/gp2gp-translator/src/main/java/uk/nhs/adaptors/pss/translator/mapper/AllergyIntoleranceMapper.java
+++ b/gp2gp-translator/src/main/java/uk/nhs/adaptors/pss/translator/mapper/AllergyIntoleranceMapper.java
@@ -62,7 +62,7 @@ public class AllergyIntoleranceMapper extends AbstractMapper<AllergyIntolerance>
 
     @Override
     public List<AllergyIntolerance> mapResources(RCMRMT030101UKEhrExtract ehrExtract, Patient patient, List<Encounter> encounters,
-                                                 String practiseCode) {
+                                                 String practiceCode) {
         return mapEhrExtractToFhirResource(
                 ehrExtract,
                 (extract, composition, component) -> extractAllCompoundStatements(component)
@@ -71,7 +71,7 @@ public class AllergyIntoleranceMapper extends AbstractMapper<AllergyIntolerance>
                         .map(compoundStatement -> mapAllergyIntolerance(
                             composition,
                                 compoundStatement,
-                                practiseCode,
+                            practiceCode,
                                 encounters,
                                 patient))
         ).toList();
@@ -79,7 +79,7 @@ public class AllergyIntoleranceMapper extends AbstractMapper<AllergyIntolerance>
 
     private AllergyIntolerance mapAllergyIntolerance(RCMRMT030101UKEhrComposition ehrComposition,
                                                      RCMRMT030101UKCompoundStatement compoundStatement,
-                                                     String practiseCode,
+                                                     String practiceCode,
                                                      List<Encounter> encounters,
                                                      Patient patient) {
 
@@ -92,7 +92,7 @@ public class AllergyIntoleranceMapper extends AbstractMapper<AllergyIntolerance>
             ehrComposition.getConfidentialityCode(),
             observationStatement.getConfidentialityCode());
 
-        initializeAllergyIntolerance(allergyIntolerance, compoundStatement, ehrComposition, patient, practiseCode, id, meta);
+        initializeAllergyIntolerance(allergyIntolerance, compoundStatement, ehrComposition, patient, practiceCode, id, meta);
         buildAdditionalFields(allergyIntolerance, compoundStatement, ehrComposition, encounters, observationStatement);
 
         return allergyIntolerance;
@@ -103,7 +103,7 @@ public class AllergyIntoleranceMapper extends AbstractMapper<AllergyIntolerance>
         RCMRMT030101UKCompoundStatement compoundStatement,
         RCMRMT030101UKEhrComposition ehrComposition,
         Patient patient,
-        String practiseCode,
+        String practiceCode,
         String id,
         Meta meta) {
 
@@ -113,7 +113,7 @@ public class AllergyIntoleranceMapper extends AbstractMapper<AllergyIntolerance>
             .setPatient(new Reference(patient))
             .setClinicalStatus(ACTIVE)
             .setVerificationStatus(UNCONFIRMED)
-            .addIdentifier(buildIdentifier(id, practiseCode))
+            .addIdentifier(buildIdentifier(id, practiceCode))
             .setMeta(meta)
             .setId(id);
     }

--- a/gp2gp-translator/src/main/java/uk/nhs/adaptors/pss/translator/mapper/BloodPressureMapper.java
+++ b/gp2gp-translator/src/main/java/uk/nhs/adaptors/pss/translator/mapper/BloodPressureMapper.java
@@ -63,25 +63,25 @@ public class BloodPressureMapper extends AbstractMapper<Observation> {
     private ConfidentialityService confidentialityService;
 
     public List<Observation> mapResources(RCMRMT030101UKEhrExtract ehrExtract, Patient patient, List<Encounter> encounters,
-                                          String practiseCode) {
+                                          String practiceCode) {
         return mapEhrExtractToFhirResource(ehrExtract, (extract, composition, component) ->
             extractAllCompoundStatements(component)
                 .filter(Objects::nonNull)
                 .filter(BloodPressureValidatorUtil::isBloodPressureWithBatteryAndBloodPressureTriple)
                 .filter(compoundStatement -> !isDiagnosticReport(compoundStatement)
                     && !hasDiagnosticReportParent(ehrExtract, compoundStatement))
-                .map(compoundStatement -> mapObservation(composition, compoundStatement, patient, encounters, practiseCode)))
+                .map(compoundStatement -> mapObservation(composition, compoundStatement, patient, encounters, practiceCode)))
             .toList();
     }
 
     private Observation mapObservation(RCMRMT030101UKEhrComposition ehrComposition,
                                        RCMRMT030101UKCompoundStatement compoundStatement, Patient patient, List<Encounter> encounters,
-                                       String practiseCode) {
+                                       String practiceCode) {
         var observationStatements = getObservationStatementsFromCompoundStatement(compoundStatement);
         var id = compoundStatement.getId().getFirst();
 
         Observation observation = new Observation()
-            .addIdentifier(buildIdentifier(id.getRoot(), practiseCode))
+            .addIdentifier(buildIdentifier(id.getRoot(), practiceCode))
             .setStatus(ObservationStatus.FINAL)
             .setCode(getCode(compoundStatement.getCode()))
             .setComponent(getComponent(observationStatements))

--- a/gp2gp-translator/src/main/java/uk/nhs/adaptors/pss/translator/mapper/ConditionMapper.java
+++ b/gp2gp-translator/src/main/java/uk/nhs/adaptors/pss/translator/mapper/ConditionMapper.java
@@ -91,7 +91,7 @@ public class ConditionMapper extends AbstractMapper<Condition> {
     private final ConfidentialityService confidentialityService;
 
     public List<Condition> mapResources(RCMRMT030101UKEhrExtract ehrExtract, Patient patient, List<Encounter> encounters,
-                                        String practiseCode) {
+                                        String practiceCode) {
 
         return mapEhrExtractToFhirResource(ehrExtract, (extract, composition, component) ->
                 extractAllLinkSets(component)
@@ -101,7 +101,7 @@ public class ConditionMapper extends AbstractMapper<Condition> {
                         encounters,
                         composition,
                         linkSet,
-                        practiseCode
+                        practiceCode
                     )))
             .toList();
     }

--- a/gp2gp-translator/src/main/java/uk/nhs/adaptors/pss/translator/mapper/DocumentReferenceMapper.java
+++ b/gp2gp-translator/src/main/java/uk/nhs/adaptors/pss/translator/mapper/DocumentReferenceMapper.java
@@ -260,7 +260,7 @@ public class DocumentReferenceMapper extends AbstractMapper<DocumentReference> {
 
     // stubbed method for abstract class
     public List<DocumentReference> mapResources(RCMRMT030101UKEhrExtract ehrExtract, Patient patient,
-        List<Encounter> encounterList, String practiseCode) {
+        List<Encounter> encounterList, String practiceCode) {
         return List.of();
     }
 }

--- a/gp2gp-translator/src/main/java/uk/nhs/adaptors/pss/translator/mapper/EncounterMapper.java
+++ b/gp2gp-translator/src/main/java/uk/nhs/adaptors/pss/translator/mapper/EncounterMapper.java
@@ -85,7 +85,7 @@ public class EncounterMapper {
     public Map<String, List<? extends DomainResource>> mapEncounters(
             RCMRMT030101UKEhrExtract ehrExtract,
             Patient patient,
-            String practiseCode,
+            String practiceCode,
             List<Location> entryLocations
     ) {
         List<Encounter> encounters = new ArrayList<>();
@@ -98,7 +98,7 @@ public class EncounterMapper {
         List<RCMRMT030101UKEhrComposition> ehrCompositionList = getEncounterEhrCompositions(ehrExtract);
 
         ehrCompositionList.forEach(ehrComposition -> {
-            var encounter = mapToEncounter(ehrComposition, patient, practiseCode, entryLocations);
+            var encounter = mapToEncounter(ehrComposition, patient, practiceCode, entryLocations);
             var consultation = consultationListMapper.mapToConsultation(ehrComposition, encounter);
 
             var topicCompoundStatementList = getTopicCompoundStatements(ehrComposition);
@@ -284,7 +284,7 @@ public class EncounterMapper {
     private Encounter mapToEncounter(
         RCMRMT030101UKEhrComposition ehrComposition,
         Patient patient,
-        String practiseCode,
+        String practiceCode,
         List<Location> entryLocations) {
 
         var id = ehrComposition.getId().getRoot();
@@ -294,14 +294,14 @@ public class EncounterMapper {
             ehrComposition.getConfidentialityCode()
         );
 
-        var encounter = initializeEncounter(ehrComposition, patient, practiseCode, id, meta);
+        var encounter = initializeEncounter(ehrComposition, patient, practiceCode, id, meta);
         setEncounterLocation(encounter, ehrComposition, entryLocations);
 
         return encounter;
     }
 
     private Encounter initializeEncounter(RCMRMT030101UKEhrComposition ehrComposition, Patient patient,
-                                                   String practiseCode, String id, Meta meta) {
+                                                   String practiceCode, String id, Meta meta) {
         var encounter = new Encounter();
         encounter
             .setParticipant(getParticipants(ehrComposition.getAuthor(), ehrComposition.getParticipant2()))
@@ -309,7 +309,7 @@ public class EncounterMapper {
             .setSubject(new Reference(patient))
             .setType(getType(ehrComposition.getCode()))
             .setPeriod(getPeriod(ehrComposition))
-            .addIdentifier(buildIdentifier(id, practiseCode))
+            .addIdentifier(buildIdentifier(id, practiceCode))
             .setMeta(meta)
             .setId(id);
         return encounter;

--- a/gp2gp-translator/src/main/java/uk/nhs/adaptors/pss/translator/mapper/ImmunizationMapper.java
+++ b/gp2gp-translator/src/main/java/uk/nhs/adaptors/pss/translator/mapper/ImmunizationMapper.java
@@ -56,13 +56,13 @@ public class ImmunizationMapper extends AbstractMapper<Immunization> {
     private final ConfidentialityService confidentialityService;
 
     public List<Immunization> mapResources(RCMRMT030101UKEhrExtract ehrExtract, Patient patientResource,
-                                           List<Encounter> encounterList, String practiseCode) {
+                                           List<Encounter> encounterList, String practiceCode) {
         return mapEhrExtractToFhirResource(ehrExtract, (extract, composition, component) ->
             extractAllObservationStatements(component)
                 .filter(Objects::nonNull)
                 .filter(this::isImmunization)
                 .map(observationStatement ->
-                    mapImmunization(composition, observationStatement, patientResource, encounterList, practiseCode)))
+                    mapImmunization(composition, observationStatement, patientResource, encounterList, practiceCode)))
             .toList();
     }
 

--- a/gp2gp-translator/src/main/java/uk/nhs/adaptors/pss/translator/mapper/LocationMapper.java
+++ b/gp2gp-translator/src/main/java/uk/nhs/adaptors/pss/translator/mapper/LocationMapper.java
@@ -26,9 +26,9 @@ public class LocationMapper {
 
     private final IdGeneratorService idGeneratorService;
 
-    public Location mapToLocation(RCMRMT030101UKLocation location, String practiseCode) {
+    public Location mapToLocation(RCMRMT030101UKLocation location, String practiceCode) {
         var id = idGeneratorService.generateUuid().toUpperCase();
-        var identifier = buildIdentifier(id, practiseCode);
+        var identifier = buildIdentifier(id, practiceCode);
 
         if (location.getLocatedEntity() != null && location.getLocatedEntity().getLocatedPlace() != null) {
             var locatedPlace = location.getLocatedEntity().getLocatedPlace();

--- a/gp2gp-translator/src/main/java/uk/nhs/adaptors/pss/translator/mapper/ObservationCommentMapper.java
+++ b/gp2gp-translator/src/main/java/uk/nhs/adaptors/pss/translator/mapper/ObservationCommentMapper.java
@@ -40,19 +40,19 @@ public class ObservationCommentMapper extends AbstractMapper<Observation> {
     private static final String CODING_DISPLAY = "Comment note";
 
     public ArrayList<Observation> mapResources(RCMRMT030101UKEhrExtract ehrExtract, Patient patient, List<Encounter> encounters,
-                                               String practiseCode) {
+                                               String practiceCode) {
 
         return mapEhrExtractToFhirResource(ehrExtract, (extract, composition, component) ->
             extractAllNonBloodPressureNarrativeStatements(component)
                 .filter(Objects::nonNull)
                 .filter(narrativeStatement -> !isDocumentReference(narrativeStatement))
-                .map(narrativeStatement -> mapObservation(composition, narrativeStatement, patient, encounters, practiseCode)))
+                .map(narrativeStatement -> mapObservation(composition, narrativeStatement, patient, encounters, practiceCode)))
                 .collect((Collectors.toCollection(ArrayList::new)));
     }
 
     private Observation mapObservation(RCMRMT030101UKEhrComposition ehrComposition,
                                        RCMRMT030101UKNarrativeStatement narrativeStatement, Patient patient, List<Encounter> encounters,
-                                       String practiseCode) {
+                                       String practiceCode) {
 
         var narrativeStatementId = narrativeStatement.getId();
         var observation = new Observation();
@@ -63,7 +63,7 @@ public class ObservationCommentMapper extends AbstractMapper<Observation> {
         observation.setIssuedElement(createIssued(narrativeStatement));
         observation.setCode(createCodeableConcept());
         observation.addPerformer(createPerformer(ehrComposition, narrativeStatement));
-        observation.addIdentifier(buildIdentifier(narrativeStatementId.getRoot(), practiseCode));
+        observation.addIdentifier(buildIdentifier(narrativeStatementId.getRoot(), practiceCode));
 
         setObservationEffective(observation, narrativeStatement.getAvailabilityTime());
         setObservationComment(observation, narrativeStatement.getText());

--- a/gp2gp-translator/src/main/java/uk/nhs/adaptors/pss/translator/mapper/ObservationMapper.java
+++ b/gp2gp-translator/src/main/java/uk/nhs/adaptors/pss/translator/mapper/ObservationMapper.java
@@ -72,7 +72,7 @@ public class ObservationMapper extends AbstractMapper<Observation> {
     private final ConfidentialityService confidentialityService;
 
     public List<Observation> mapResources(RCMRMT030101UKEhrExtract ehrExtract, Patient patient, List<Encounter> encounters,
-                                          String practiseCode) {
+                                          String practiceCode) {
 
         List<Observation> selfReferralObservations =
                 mapEhrExtractToFhirResource(ehrExtract, (extract, composition, component) ->
@@ -81,7 +81,7 @@ public class ObservationMapper extends AbstractMapper<Observation> {
                         .filter(this::isSelfReferral)
                         .map(observationStatement
                                 -> mapObservationFromRequestStatement(composition, observationStatement,
-                                                                      patient, encounters, practiseCode)))
+                                                                      patient, encounters, practiceCode)))
                 .toList();
 
         List<Observation> observations =
@@ -90,7 +90,7 @@ public class ObservationMapper extends AbstractMapper<Observation> {
                 .filter(Objects::nonNull)
                 .filter(this::isNotImmunization)
                 .map(observationStatement
-                    -> mapObservation(composition, observationStatement, patient, encounters, practiseCode)))
+                    -> mapObservation(composition, observationStatement, patient, encounters, practiceCode)))
             .toList();
 
         return Stream.concat(selfReferralObservations.stream(), observations.stream()).collect(Collectors.toList());
@@ -100,7 +100,7 @@ public class ObservationMapper extends AbstractMapper<Observation> {
                                        RCMRMT030101UKObservationStatement observationStatement,
                                        Patient patient,
                                        List<Encounter> encounters,
-                                       String practiseCode) {
+                                       String practiceCode) {
 
         var compoundStatement = ehrComposition
             .getComponent()
@@ -116,7 +116,7 @@ public class ObservationMapper extends AbstractMapper<Observation> {
             observationStatement.getConfidentialityCode(),
             compoundStatement.getConfidentialityCode());
 
-        var observation = buildBaseObservation(ehrComposition, observationStatement, patient, practiseCode, id, meta);
+        var observation = buildBaseObservation(ehrComposition, observationStatement, patient, practiceCode, id, meta);
 
         addContextToObservation(observation, encounters, ehrComposition);
         addValue(observation, getValueQuantity(observationStatement.getValue(), observationStatement.getUncertaintyCode()),
@@ -130,12 +130,12 @@ public class ObservationMapper extends AbstractMapper<Observation> {
     private @NotNull Observation buildBaseObservation(RCMRMT030101UKEhrComposition ehrComposition,
                                                 RCMRMT030101UKObservationStatement observationStatement,
                                                 Patient patient,
-                                                String practiseCode,
+                                                String practiceCode,
                                                 String id,
                                                 Meta meta) {
         var observation = new Observation()
             .setStatus(FINAL)
-            .addIdentifier(buildIdentifier(id, practiseCode))
+            .addIdentifier(buildIdentifier(id, practiceCode))
             .setCode(getCode(observationStatement.getCode()))
             .setIssuedElement(getIssued(ehrComposition))
             .addPerformer(getParticipantReference(observationStatement.getParticipant(), ehrComposition))
@@ -162,9 +162,9 @@ public class ObservationMapper extends AbstractMapper<Observation> {
 
     private Observation mapObservationFromRequestStatement(RCMRMT030101UKEhrComposition ehrComposition,
                                                            RCMRMT030101UKRequestStatement requestStatement, Patient patient,
-                                                           List<Encounter> encounters, String practiseCode) {
+                                                           List<Encounter> encounters, String practiceCode) {
 
-        var observation = initializeObservation(ehrComposition, requestStatement, patient, practiseCode);
+        var observation = initializeObservation(ehrComposition, requestStatement, patient, practiceCode);
 
         addContextToObservation(observation, encounters, ehrComposition);
         addEffective(observation, getEffective(requestStatement.getEffectiveTime(), requestStatement.getAvailabilityTime()));

--- a/gp2gp-translator/src/main/java/uk/nhs/adaptors/pss/translator/mapper/ProcedureRequestMapper.java
+++ b/gp2gp-translator/src/main/java/uk/nhs/adaptors/pss/translator/mapper/ProcedureRequestMapper.java
@@ -44,12 +44,12 @@ public class ProcedureRequestMapper extends AbstractMapper<ProcedureRequest> {
     private final ConfidentialityService confidentialityService;
 
     public List<ProcedureRequest> mapResources(RCMRMT030101UKEhrExtract ehrExtract, Patient patient, List<Encounter> encounters,
-                                               String practiseCode) {
+                                               String practiceCode) {
 
         return mapEhrExtractToFhirResource(ehrExtract, (extract, composition, component) ->
             extractAllPlanStatements(component)
                 .filter(Objects::nonNull)
-                .map(planStatement -> mapToProcedureRequest(composition, planStatement, patient, encounters, practiseCode)))
+                .map(planStatement -> mapToProcedureRequest(composition, planStatement, patient, encounters, practiceCode)))
             .map(ProcedureRequest.class::cast)
             .toList();
     }
@@ -59,7 +59,7 @@ public class ProcedureRequestMapper extends AbstractMapper<ProcedureRequest> {
             RCMRMT030101UKPlanStatement planStatement,
             Patient patient,
             List<Encounter> encounters,
-            String practiseCode) {
+            String practiceCode) {
 
         var id = planStatement.getId().getRoot();
         Meta meta = confidentialityService.createMetaAndAddSecurityIfConfidentialityCodesPresent(
@@ -67,7 +67,7 @@ public class ProcedureRequestMapper extends AbstractMapper<ProcedureRequest> {
             ehrComposition.getConfidentialityCode(),
             planStatement.getConfidentialityCode());
         var procedureRequest = buildBaseProcedureRequest(ehrComposition, planStatement, patient, id, meta);
-        addAdditionalInformationToProcedureRequest(procedureRequest, planStatement, id, practiseCode, ehrComposition, encounters);
+        addAdditionalInformationToProcedureRequest(procedureRequest, planStatement, id, practiceCode, ehrComposition, encounters);
 
         return handleDegradedCode(procedureRequest);
     }

--- a/gp2gp-translator/src/main/java/uk/nhs/adaptors/pss/translator/mapper/ReferralRequestMapper.java
+++ b/gp2gp-translator/src/main/java/uk/nhs/adaptors/pss/translator/mapper/ReferralRequestMapper.java
@@ -63,14 +63,14 @@ public class ReferralRequestMapper extends AbstractMapper<ReferralRequest> {
     public List<ReferralRequest> mapResources(RCMRMT030101UKEhrExtract ehrExtract,
                                               Patient patient,
                                               List<Encounter> encounters,
-                                              String practiseCode) {
+                                              String practiceCode) {
 
         return mapEhrExtractToFhirResource(ehrExtract, (extract, composition, component) ->
             extractAllRequestStatements(component)
                 .filter(Objects::nonNull)
                 .filter(this::isNotSelfReferral)
                 .map(requestStatement
-                         -> mapToReferralRequest(ehrExtract, composition, requestStatement, patient, encounters, practiseCode)))
+                         -> mapToReferralRequest(ehrExtract, composition, requestStatement, patient, encounters, practiceCode)))
             .toList();
     }
 
@@ -79,9 +79,9 @@ public class ReferralRequestMapper extends AbstractMapper<ReferralRequest> {
                                                 RCMRMT030101UKRequestStatement requestStatement,
                                                 Patient patient,
                                                 List<Encounter> encounters,
-                                                String practiseCode) {
+                                                String practiceCode) {
 
-        var referralRequest = initializeReferralRequest(ehrComposition, requestStatement, patient, practiseCode);
+        var referralRequest = initializeReferralRequest(ehrComposition, requestStatement, patient, practiceCode);
 
         setReferralRequestContext(referralRequest, ehrComposition, encounters);
         setReferralRequestRecipient(ehrExtract, requestStatement, referralRequest);

--- a/gp2gp-translator/src/main/java/uk/nhs/adaptors/pss/translator/mapper/TemplateMapper.java
+++ b/gp2gp-translator/src/main/java/uk/nhs/adaptors/pss/translator/mapper/TemplateMapper.java
@@ -50,14 +50,14 @@ public class TemplateMapper extends AbstractMapper<DomainResource> {
 
     @Override
     public List<DomainResource> mapResources(RCMRMT030101UKEhrExtract ehrExtract, Patient patient,
-                                             List<Encounter> encounters, String practiseCode) {
+                                             List<Encounter> encounters, String practiceCode) {
 
         return  mapEhrExtractToFhirResource(ehrExtract, (extract, composition, component) ->
             extractAllCompoundStatements(component)
                 .filter(Objects::nonNull)
                 .filter(ResourceFilterUtil::isTemplate)
                 .filter(compoundStatement -> !hasDiagnosticReportParent(ehrExtract, compoundStatement))
-                .map(compoundStatement -> mapTemplate(composition, compoundStatement, patient, encounters, practiseCode))
+                .map(compoundStatement -> mapTemplate(composition, compoundStatement, patient, encounters, practiceCode))
                 .flatMap(List::stream)
         ).toList();
 
@@ -115,11 +115,11 @@ public class TemplateMapper extends AbstractMapper<DomainResource> {
                                              RCMRMT030101UKCompoundStatement compoundStatement,
                                              Patient patient,
                                              List<Encounter> encounters,
-                                             String practiseCode) {
+                                             String practiceCode) {
         var encounter = getEncounter(encounters, ehrComposition);
 
         return List.of(
-            createParentObservation(compoundStatement, practiseCode, patient, encounter, ehrComposition)
+            createParentObservation(compoundStatement, practiceCode, patient, encounter, ehrComposition)
         );
     }
 
@@ -131,7 +131,7 @@ public class TemplateMapper extends AbstractMapper<DomainResource> {
             .findFirst();
     }
 
-    private Observation createParentObservation(RCMRMT030101UKCompoundStatement compoundStatement, String practiseCode, Patient patient,
+    private Observation createParentObservation(RCMRMT030101UKCompoundStatement compoundStatement, String practiceCode, Patient patient,
         Optional<Reference> encounter, RCMRMT030101UKEhrComposition ehrComposition) {
 
         var parentObservation = new Observation();
@@ -146,7 +146,7 @@ public class TemplateMapper extends AbstractMapper<DomainResource> {
             .addPerformer(getParticipantReference(compoundStatement.getParticipant(), ehrComposition))
             .setCode(codeableConcept)
             .setStatus(FINAL)
-            .addIdentifier(buildIdentifier(id, practiseCode))
+            .addIdentifier(buildIdentifier(id, practiceCode))
             .setMeta(generateMeta(OBSERVATION_META_PROFILE))
             .setId(id);
 

--- a/gp2gp-translator/src/main/java/uk/nhs/adaptors/pss/translator/mapper/diagnosticreport/SpecimenBatteryMapper.java
+++ b/gp2gp-translator/src/main/java/uk/nhs/adaptors/pss/translator/mapper/diagnosticreport/SpecimenBatteryMapper.java
@@ -75,7 +75,7 @@ public class SpecimenBatteryMapper {
         final String id = batteryParameters.getBatteryCompoundStatement().getId().getFirst().getRoot();
         observation.setId(id);
         observation.setMeta(generateMeta(META_PROFILE_URL_SUFFIX));
-        observation.addIdentifier(buildIdentifier(id, batteryParameters.getPractiseCode()));
+        observation.addIdentifier(buildIdentifier(id, batteryParameters.getPracticeCode()));
         observation.setSubject(new Reference(batteryParameters.getPatient()));
         observation.setSpecimen(createSpecimenReference(batteryParameters.getSpecimenCompoundStatement()));
         observation.setStatus(Observation.ObservationStatus.FINAL);
@@ -293,6 +293,6 @@ public class SpecimenBatteryMapper {
         private List<Encounter> encounters;
         private List<Observation> observations;
         private List<Observation> observationComments;
-        private String practiseCode;
+        private String practiceCode;
     }
 }

--- a/gp2gp-translator/src/main/java/uk/nhs/adaptors/pss/translator/mapper/diagnosticreport/SpecimenCompoundsMapper.java
+++ b/gp2gp-translator/src/main/java/uk/nhs/adaptors/pss/translator/mapper/diagnosticreport/SpecimenCompoundsMapper.java
@@ -62,7 +62,7 @@ public class SpecimenCompoundsMapper {
         List<DiagnosticReport> diagnosticReports,
         Patient patient,
         List<Encounter> encounters,
-        String practiseCode) {
+        String practiceCode) {
 
         final List<Observation> batteryObservations = new ArrayList<>();
 
@@ -112,7 +112,7 @@ public class SpecimenCompoundsMapper {
                             .encounters(encounters)
                             .observations(observations)
                             .observationComments(observationComments)
-                            .practiseCode(practiseCode)
+                            .practiceCode(practiceCode)
                             .build();
 
                         batteryObservations.add(batteryMapper.mapBatteryObservation(batteryParameters));

--- a/gp2gp-translator/src/main/java/uk/nhs/adaptors/pss/translator/util/ResourceUtil.java
+++ b/gp2gp-translator/src/main/java/uk/nhs/adaptors/pss/translator/util/ResourceUtil.java
@@ -26,9 +26,9 @@ public class ResourceUtil {
         return meta;
     }
 
-    public static Identifier buildIdentifier(String rootId, String practiseCode) {
+    public static Identifier buildIdentifier(String rootId, String practiceCode) {
         Identifier identifier = new Identifier();
-        identifier.setSystem(IDENTIFIER_SYSTEM.formatted(practiseCode));
+        identifier.setSystem(IDENTIFIER_SYSTEM.formatted(practiceCode));
         identifier.setValue(rootId);
 
         return identifier;

--- a/gp2gp-translator/src/main/java/uk/nhs/adaptors/pss/translator/util/XmlParseUtilService.java
+++ b/gp2gp-translator/src/main/java/uk/nhs/adaptors/pss/translator/util/XmlParseUtilService.java
@@ -168,11 +168,11 @@ public class XmlParseUtilService {
                 .getAny()
                 .getFirst();
 
-        return getFromPractiseValue(gp2gpElement);
+        return getFromPracticeValue(gp2gpElement);
     }
 
 
-    public static String getFromPractiseValue(Element gp2gpElement) {
+    public static String getFromPracticeValue(Element gp2gpElement) {
         for (int i = 0; i < gp2gpElement.getChildNodes().getLength(); i++) {
             Node currNode = gp2gpElement.getChildNodes().item(i);
             if (currNode.getLocalName().equals("From")) {

--- a/gp2gp-translator/src/test/java/uk/nhs/adaptors/pss/translator/mapper/diagnosticreport/SpecimenBatteryMapperTest.java
+++ b/gp2gp-translator/src/test/java/uk/nhs/adaptors/pss/translator/mapper/diagnosticreport/SpecimenBatteryMapperTest.java
@@ -446,7 +446,7 @@ public class SpecimenBatteryMapperTest {
             .diagnosticReport(getDiagnosticReport(ehrExtract))
             .patient((Patient) new Patient().setId("TEST_PATIENT_ID"))
             .encounters(List.of((Encounter) new Encounter().setId("ENCOUNTER_ID")))
-            .practiseCode("TEST_PRACTISE_CODE")
+            .practiceCode("TEST_PRACTISE_CODE")
             .observations(observations)
             .observationComments(observationComments)
             .build();


### PR DESCRIPTION
## What

Replaced misspelling of `practise` to `practice` when used to refer to a medical practice / code in mappers.

## Why

The incorrect spelling of  `practise` is used in many places.  When referring to a medical practice / code this spelling should be `practice`.

## Type of change

Please delete options that are not relevant.

- [x] Internal change (non-breaking change with no effect on the functionality affecting end users)

## Checklist:

- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes