### PR TITLE
Fix issue where IntelliJ reports an assertion issue in the `SpecimenCompoundsMapper`

### DIFF
--- a/gp2gp-translator/src/test/java/uk/nhs/adaptors/pss/translator/mapper/diagnosticreport/SpecimenBatteryMapperTest.java
+++ b/gp2gp-translator/src/test/java/uk/nhs/adaptors/pss/translator/mapper/diagnosticreport/SpecimenBatteryMapperTest.java
@@ -117,10 +117,13 @@ public class SpecimenBatteryMapperTest {
         final var ehrExtract = unmarshallEhrExtractFromEhrCompositionXml(ehrCompositionXml);
         final var batteryCompoundStatements = getBatteryCompoundStatements(ehrExtract);
 
-        assertThat(batteryCompoundStatements).map(r -> r.getId().getFirst().getRoot())
-                    .isEqualTo(List.of("SPECIMEN_CHILD_BATTERY_COMPOUND_STATEMENT_ID_1",
-                                       "SPECIMEN_CHILD_BATTERY_COMPOUND_STATEMENT_ID_2",
-                                       "SPECIMEN_CHILD_BATTERY_COMPOUND_STATEMENT_ID_3"));
+        assertThat(batteryCompoundStatements)
+            .extracting(batteryCompoundStatement -> batteryCompoundStatement.getId().getFirst().getRoot())
+            .containsExactly(
+                "SPECIMEN_CHILD_BATTERY_COMPOUND_STATEMENT_ID_1",
+                "SPECIMEN_CHILD_BATTERY_COMPOUND_STATEMENT_ID_2",
+                "SPECIMEN_CHILD_BATTERY_COMPOUND_STATEMENT_ID_3"
+            );
     }
 
     @Test void When_MappingObservationWithAvailabilityTimeInBatteryCompoundStatement_Expect_IssuedUsesThisValue() {


### PR DESCRIPTION
## What

Fix issue with IntelliJ reporting a problem with `isEqualTo` when comparing the `actual` in the assertation to the expected valued in the `isEqualTo`

## Why

IntelliJ reports a problem with `isEqualTo` when comparing the `actual` in the assertation to the expected valued in the `isEqualTo`.  This is not a java problem but will prevent IntelliJ displaying a yellow waring.

The IntelliJ warning is:
```
'isEqualTo()' between objects of inconvertible types 'List<RCMRMT030101UKCompoundStatement>' and 'List<String>' 
```

## Type of change

Please delete options that are not relevant.

- [x] Internal change (non-breaking change with no effect on the functionality affecting end users)

## Checklist:

- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes