### PR TITLE
NIAD-3170: Create duplicate MedicationStatements when multiple Orders reference the same acute Plan

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Fixed a bug when mapping `MedicationRequest` where multiple `MedicationRequest [Order]` are based on the same acute
 `MedicationRequest [Plan]`. Now the `Order` with the earliest `DispenseRequest` validity period start date will remain
 referencing the original `Plan` whilst later `Orders` will instead reference a generated `Plan` instead.
+-Fixed a bug when mapping `MedicationRequest` where multiple `MedicationRequest [Order]` are based on the same acute
+`MedicationRequest [Plan]`. Now the `Order` with the earliest `DispenseRequest` validity period start date will remain
+ referencing the original `MedicationStatement` whilst later `Orders` will instead reference a generated `MedicationRequest` instead.
 
 ## [3.0.3] - 2024-08-23
 

--- a/gp2gp-translator/src/integrationTest/resources/e2e-mapping/output-json/PWTP2-output.json
+++ b/gp2gp-translator/src/integrationTest/resources/e2e-mapping/output-json/PWTP2-output.json
@@ -6669,6 +6669,49 @@
     }
   }, {
     "resource": {
+      "resourceType": "MedicationStatement",
+      "id": "00000000-0000-0000-0000-000000000019-MS",
+      "meta": {
+        "profile": [ "https://fhir.nhs.uk/STU3/StructureDefinition/CareConnect-GPC-MedicationStatement-1" ]
+      },
+      "extension": [ {
+        "url": "https://fhir.nhs.uk/STU3/StructureDefinition/Extension-CareConnect-GPC-PrescribingAgency-1",
+        "valueCodeableConcept": {
+          "coding": [ {
+            "system": "https://fhir.nhs.uk/STU3/CodeSystem/CareConnect-PrescribingAgency-1",
+            "code": "prescribed-at-gp-practice",
+            "display": "Prescribed at GP practice"
+          } ]
+        }
+      }, {
+        "url": "https://fhir.nhs.uk/STU3/StructureDefinition/Extension-CareConnect-GPC-MedicationStatementLastIssueDate-1",
+        "valueDateTime": "2010-02-26"
+      } ],
+      "identifier": [ {
+        "system": "https://PSSAdaptor/B83002",
+        "value": "00000000-0000-0000-0000-000000000019-MS"
+      } ],
+      "basedOn": [ {
+        "reference": "MedicationRequest/00000000-0000-0000-0000-000000000019"
+      } ],
+      "status": "completed",
+      "medicationReference": {
+        "reference": "Medication/00000000-0000-0000-0000-000000000013"
+      },
+      "effectivePeriod": {
+        "start": "2010-02-26"
+      },
+      "dateAsserted": "2010-01-13T11:37:31+00:00",
+      "subject": {
+        "reference": "Patient/00000000-0000-0000-0000-000000000010"
+      },
+      "taken": "unk",
+      "dosage": [ {
+        "text": "n/a"
+      } ]
+    }
+  }, {
+    "resource": {
       "resourceType": "Observation",
       "id": "E2115A83-12C6-4C12-8261-D32A776339E8",
       "meta": {

--- a/gp2gp-translator/src/integrationTest/resources/e2e-mapping/output-json/PWTP4-output.json
+++ b/gp2gp-translator/src/integrationTest/resources/e2e-mapping/output-json/PWTP4-output.json
@@ -18310,6 +18310,49 @@
     }
   }, {
     "resource": {
+      "resourceType": "MedicationStatement",
+      "id": "00000000-0000-0000-0000-000000000084-MS",
+      "meta": {
+        "profile": [ "https://fhir.nhs.uk/STU3/StructureDefinition/CareConnect-GPC-MedicationStatement-1" ]
+      },
+      "extension": [ {
+        "url": "https://fhir.nhs.uk/STU3/StructureDefinition/Extension-CareConnect-GPC-PrescribingAgency-1",
+        "valueCodeableConcept": {
+          "coding": [ {
+            "system": "https://fhir.nhs.uk/STU3/CodeSystem/CareConnect-PrescribingAgency-1",
+            "code": "prescribed-at-gp-practice",
+            "display": "Prescribed at GP practice"
+          } ]
+        }
+      }, {
+        "url": "https://fhir.nhs.uk/STU3/StructureDefinition/Extension-CareConnect-GPC-MedicationStatementLastIssueDate-1",
+        "valueDateTime": "2011-11-15"
+      } ],
+      "identifier": [ {
+        "system": "https://PSSAdaptor/B83002",
+        "value": "00000000-0000-0000-0000-000000000084-MS"
+      } ],
+      "basedOn": [ {
+        "reference": "MedicationRequest/00000000-0000-0000-0000-000000000084"
+      } ],
+      "status": "stopped",
+      "medicationReference": {
+        "reference": "Medication/00000000-0000-0000-0000-000000000079"
+      },
+      "effectivePeriod": {
+        "start": "2011-11-15"
+      },
+      "dateAsserted": "2011-11-15T14:55:59+00:00",
+      "subject": {
+        "reference": "Patient/00000000-0000-0000-0000-000000000007"
+      },
+      "taken": "unk",
+      "dosage": [ {
+        "text": "One To Be Taken Every Four To Six Hours When Required"
+      } ]
+    }
+  }, {
+    "resource": {
       "resourceType": "MedicationRequest",
       "id": "00000000-0000-0000-0000-000000000085",
       "meta": {
@@ -18361,6 +18404,49 @@
       "priorPrescription": {
         "reference": "MedicationRequest/386FBA83-24D2-44C4-8EA3-B2BCDA30B16C"
       }
+    }
+  }, {
+    "resource": {
+      "resourceType": "MedicationStatement",
+      "id": "00000000-0000-0000-0000-000000000085-MS",
+      "meta": {
+        "profile": [ "https://fhir.nhs.uk/STU3/StructureDefinition/CareConnect-GPC-MedicationStatement-1" ]
+      },
+      "extension": [ {
+        "url": "https://fhir.nhs.uk/STU3/StructureDefinition/Extension-CareConnect-GPC-PrescribingAgency-1",
+        "valueCodeableConcept": {
+          "coding": [ {
+            "system": "https://fhir.nhs.uk/STU3/CodeSystem/CareConnect-PrescribingAgency-1",
+            "code": "prescribed-at-gp-practice",
+            "display": "Prescribed at GP practice"
+          } ]
+        }
+      }, {
+        "url": "https://fhir.nhs.uk/STU3/StructureDefinition/Extension-CareConnect-GPC-MedicationStatementLastIssueDate-1",
+        "valueDateTime": "2013-01-03"
+      } ],
+      "identifier": [ {
+        "system": "https://PSSAdaptor/B83002",
+        "value": "00000000-0000-0000-0000-000000000085-MS"
+      } ],
+      "basedOn": [ {
+        "reference": "MedicationRequest/00000000-0000-0000-0000-000000000085"
+      } ],
+      "status": "completed",
+      "medicationReference": {
+        "reference": "Medication/00000000-0000-0000-0000-000000000024"
+      },
+      "effectivePeriod": {
+        "start": "2013-01-03"
+      },
+      "dateAsserted": "2010-01-14T10:30:03+00:00",
+      "subject": {
+        "reference": "Patient/00000000-0000-0000-0000-000000000007"
+      },
+      "taken": "unk",
+      "dosage": [ {
+        "text": "One To Be Taken At Night"
+      } ]
     }
   }, {
     "resource": {
@@ -18418,6 +18504,49 @@
     }
   }, {
     "resource": {
+      "resourceType": "MedicationStatement",
+      "id": "00000000-0000-0000-0000-000000000086-MS",
+      "meta": {
+        "profile": [ "https://fhir.nhs.uk/STU3/StructureDefinition/CareConnect-GPC-MedicationStatement-1" ]
+      },
+      "extension": [ {
+        "url": "https://fhir.nhs.uk/STU3/StructureDefinition/Extension-CareConnect-GPC-PrescribingAgency-1",
+        "valueCodeableConcept": {
+          "coding": [ {
+            "system": "https://fhir.nhs.uk/STU3/CodeSystem/CareConnect-PrescribingAgency-1",
+            "code": "prescribed-at-gp-practice",
+            "display": "Prescribed at GP practice"
+          } ]
+        }
+      }, {
+        "url": "https://fhir.nhs.uk/STU3/StructureDefinition/Extension-CareConnect-GPC-MedicationStatementLastIssueDate-1",
+        "valueDateTime": "2010-03-23"
+      } ],
+      "identifier": [ {
+        "system": "https://PSSAdaptor/B83002",
+        "value": "00000000-0000-0000-0000-000000000086-MS"
+      } ],
+      "basedOn": [ {
+        "reference": "MedicationRequest/00000000-0000-0000-0000-000000000086"
+      } ],
+      "status": "completed",
+      "medicationReference": {
+        "reference": "Medication/00000000-0000-0000-0000-000000000009"
+      },
+      "effectivePeriod": {
+        "start": "2010-03-23"
+      },
+      "dateAsserted": "2010-03-23T15:47:58+00:00",
+      "subject": {
+        "reference": "Patient/00000000-0000-0000-0000-000000000007"
+      },
+      "taken": "unk",
+      "dosage": [ {
+        "text": "One To Be Taken Each Day After Food"
+      } ]
+    }
+  }, {
+    "resource": {
       "resourceType": "MedicationRequest",
       "id": "00000000-0000-0000-0000-000000000087",
       "meta": {
@@ -18472,6 +18601,49 @@
       "priorPrescription": {
         "reference": "MedicationRequest/9F4841C2-563B-4D0F-A288-66175258B641"
       }
+    }
+  }, {
+    "resource": {
+      "resourceType": "MedicationStatement",
+      "id": "00000000-0000-0000-0000-000000000087-MS",
+      "meta": {
+        "profile": [ "https://fhir.nhs.uk/STU3/StructureDefinition/CareConnect-GPC-MedicationStatement-1" ]
+      },
+      "extension": [ {
+        "url": "https://fhir.nhs.uk/STU3/StructureDefinition/Extension-CareConnect-GPC-PrescribingAgency-1",
+        "valueCodeableConcept": {
+          "coding": [ {
+            "system": "https://fhir.nhs.uk/STU3/CodeSystem/CareConnect-PrescribingAgency-1",
+            "code": "prescribed-at-gp-practice",
+            "display": "Prescribed at GP practice"
+          } ]
+        }
+      }, {
+        "url": "https://fhir.nhs.uk/STU3/StructureDefinition/Extension-CareConnect-GPC-MedicationStatementLastIssueDate-1",
+        "valueDateTime": "2010-05-21"
+      } ],
+      "identifier": [ {
+        "system": "https://PSSAdaptor/B83002",
+        "value": "00000000-0000-0000-0000-000000000087-MS"
+      } ],
+      "basedOn": [ {
+        "reference": "MedicationRequest/00000000-0000-0000-0000-000000000087"
+      } ],
+      "status": "completed",
+      "medicationReference": {
+        "reference": "Medication/00000000-0000-0000-0000-000000000043"
+      },
+      "effectivePeriod": {
+        "start": "2010-05-21"
+      },
+      "dateAsserted": "2010-01-18T09:16:52+00:00",
+      "subject": {
+        "reference": "Patient/00000000-0000-0000-0000-000000000007"
+      },
+      "taken": "unk",
+      "dosage": [ {
+        "text": "One Or Two To Be Taken At Night"
+      } ]
     }
   }, {
     "resource": {

--- a/gp2gp-translator/src/main/java/uk/nhs/adaptors/pss/translator/mapper/medication/MedicationRequestMapper.java
+++ b/gp2gp-translator/src/main/java/uk/nhs/adaptors/pss/translator/mapper/medication/MedicationRequestMapper.java
@@ -157,9 +157,9 @@ public class MedicationRequestMapper extends AbstractMapper<DomainResource> {
             .orElseThrow(() ->
                 // there should always be a medication statement associated with an order, but we have to handle
                 // the possibility it is not found.
-                new IllegalStateException("""
-                    MedicationStatement referenced from MedicationRequest[Order] (%s) is missing when mapping Acute
-                    Prescriptions""".formatted(order.getId())
+                new IllegalStateException(
+                    "MedicationStatement referenced from MedicationRequest[Order] (%s) is not found."
+                        .formatted(order.getId())
                 )
             );
 

--- a/gp2gp-translator/src/test/java/uk/nhs/adaptors/pss/translator/mapper/medication/MedicationRequestMapperTest.java
+++ b/gp2gp-translator/src/test/java/uk/nhs/adaptors/pss/translator/mapper/medication/MedicationRequestMapperTest.java
@@ -60,10 +60,10 @@ import uk.nhs.adaptors.pss.translator.util.DateFormatUtil;
 @ExtendWith(MockitoExtension.class)
 public class MedicationRequestMapperTest {
 
-    private static final String INITIAL_PLAN_ID = "000EEA41-289B-4B1C-A5AB-421A666A0D2C";
-    private static final String GENERATED_PLAN_ID = "00000000-0000-4000-0000-000000000001";
-    private static final String EARLIEST_ORDER_ID = "00000000-0000-4000-0000-100000000001";
-    private static final String LATEST_ORDER_ID = "00000000-0000-4000-0000-100000000002";
+    public static final String INITIAL_PLAN_ID = "000EEA41-289B-4B1C-A5AB-421A666A0D2C";
+    public static final String GENERATED_PLAN_ID = "00000000-0000-4000-0000-000000000001";
+    public static final String EARLIEST_ORDER_ID = "00000000-0000-4000-0000-100000000001";
+    public static final String LATEST_ORDER_ID = "00000000-0000-4000-0000-100000000002";
     private static final String INITIAL_MEDICATION_STATEMENT_ID = INITIAL_PLAN_ID + "-MS";
     private static final String GENERATED_MEDICATION_STATEMENT_ID = GENERATED_PLAN_ID + "-MS";
 
@@ -840,8 +840,8 @@ public class MedicationRequestMapperTest {
                 any(RCMRMT030101UKPrescribe.class),
                 any(String.class)
             )
-        ).thenReturn(
-            buildMedicationRequestOrder(LATEST_ORDER_ID, "20240102"),
+        ).thenReturn(buildMedicationRequestOrder(
+            LATEST_ORDER_ID, "20240102"),
             buildMedicationRequestOrder(EARLIEST_ORDER_ID, "20240101")
         );
 

--- a/gp2gp-translator/src/test/java/uk/nhs/adaptors/pss/translator/mapper/medication/MedicationRequestMapperTest.java
+++ b/gp2gp-translator/src/test/java/uk/nhs/adaptors/pss/translator/mapper/medication/MedicationRequestMapperTest.java
@@ -96,10 +96,6 @@ public class MedicationRequestMapperTest {
             )
         )
     );
-    private static final Extension MEDICATION_STATEMENT_LAST_ISSUE_DATE_EXTENSION = new Extension(
-        "https://fhir.nhs.uk/STU3/StructureDefinition/Extension-CareConnect-GPC-MedicationStatementLastIssueDate-1",
-        DateFormatUtil.parseToDateTimeType("20240726")
-    );
     private static final Reference REFERENCE_TO_PLAN = new Reference(
         new IdType(
             ResourceType.MedicationRequest.name(),
@@ -792,7 +788,10 @@ public class MedicationRequestMapperTest {
             .setEffective(new Period().setStartElement(DateFormatUtil.parseToDateTimeType("20240101")))
             .setStatus(MedicationStatementStatus.COMPLETED)
             .addExtension(new Extension("TEST_EXTENSION", new StringType("TEST_VALUE")))
-            .addExtension(MEDICATION_STATEMENT_LAST_ISSUE_DATE_EXTENSION)
+            .addExtension(new Extension(
+                "https://fhir.nhs.uk/STU3/StructureDefinition/Extension-CareConnect-GPC-MedicationStatementLastIssueDate-1",
+                DateFormatUtil.parseToDateTimeType("20240726")
+            ))
             .setId(INITIAL_MEDICATION_STATEMENT_ID)
             .setMeta(new Meta().addSecurity("TEST_SYSTEM", "TEST_CODE", "TEST_DISPLAY"));
     }


### PR DESCRIPTION
## What

* Add functionality to ensure that a new `MedicationStatement` is generated when multiple `MedicationRequest[Order]`s share the same acute `MedicationRequest[Plan]`.
* Add functionality to duplicate the existing `MedicationStatement` and copy the contained values using the existing MedicationStatement.copy() method.
* Add functionality to generate and set a new `id` and `identifier` for the generated `MedicationStatement` based on the ID of the associated generated `MedicationRequest[Plan]`.
* Add functionality to update the `basedOn` reference to instead reference the generated `MedicationRequest[Plan]`.
* Add functionality to update `effectivePeriod` to match that of `dispenseRequest.validityPeriod` from the associated `MedicationRequest[Order]`.
* Add functionality to update the value for the `LastIssueDate` extension to match the `dispenseRequest.validityPeriod.start` value from the associated `MedicationRequest[Order]`.
* Add unit tests for the above functionality.
* Update Integration test files to reflect the changes to functionality made.

## Why

When EMIS prescriptions are post-dated, multiple prescriptions are generated.
When a post-dated prescription is transferred from it can contain multiple MedicationStatements with `ehrSupplyPrescribe` which point to a single `ehrSupplyAuthorise.`
The adaptor until now has had an assumption that each `ehrSupplyAuthorise` is only referenced by one `ehrSupplyPrescribe`.
The result of which is that the Adaptor is generating acute medications which don’t match up to a valid GP Connect representation of an acute medication.

For every acute `MedicationRequest[intent=plan]` which is referenced via the basedOn field by multiple `MedicationRequest[intent=order]`s, the Adaptor will generate N new `MedicationRequest[intent=plan]`, where N is the the total number of `MedicationRequest[intent=order]`s referencing the `MedicationRequest[intent=plan]` - 1.

For each MedicationStatement which is generated, it's fields are copied from the original MedicationStatement. With the following modifications:

* A unique Id is generated for the id `field`.
* `basedOn` field references the generated `MedicationRequest[intent=plan]`.
* `effectivePeriod` gets copied over from the `MedicationRequest[intent=order]` `dispenseRequest.validityPeriod`.
* The extension for `MedicationStatementLastIssueDate` needs to match the `MedicationRequest[intent=order]` `dispenseRequest.validityPeriod.start` value.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes