### PR TITLE
NIAD-2194: Update `validityPeriod` in generated `Plan`s when multiple `Orders` reference the same acute `Plan`

### DIFF
--- a/gp2gp-translator/src/integrationTest/resources/e2e-mapping/output-json/PWTP2-output.json
+++ b/gp2gp-translator/src/integrationTest/resources/e2e-mapping/output-json/PWTP2-output.json
@@ -6656,7 +6656,7 @@
       } ],
       "dispenseRequest": {
         "validityPeriod": {
-          "start": "2010-01-13"
+          "start": "2010-02-26"
         },
         "quantity": {
           "value": 1.0,

--- a/gp2gp-translator/src/integrationTest/resources/e2e-mapping/output-json/PWTP4-output.json
+++ b/gp2gp-translator/src/integrationTest/resources/e2e-mapping/output-json/PWTP4-output.json
@@ -18394,7 +18394,7 @@
       } ],
       "dispenseRequest": {
         "validityPeriod": {
-          "start": "2010-01-14"
+          "start": "2013-01-03"
         },
         "quantity": {
           "value": 150.0,
@@ -18591,7 +18591,7 @@
       } ],
       "dispenseRequest": {
         "validityPeriod": {
-          "start": "2010-01-18"
+          "start": "2010-05-21"
         },
         "quantity": {
           "value": 56.0,

--- a/gp2gp-translator/src/main/java/uk/nhs/adaptors/pss/translator/mapper/medication/MedicationRequestMapper.java
+++ b/gp2gp-translator/src/main/java/uk/nhs/adaptors/pss/translator/mapper/medication/MedicationRequestMapper.java
@@ -121,6 +121,8 @@ public class MedicationRequestMapper extends AbstractMapper<DomainResource> {
         var previousOrderBasedOn = orders.get(index - 1).getBasedOn();
         var previousBasedOnReference = getMedicationRequestBasedOnReference(previousOrderBasedOn);
         previousBasedOnReference.ifPresent(duplicatedPlan::setPriorPrescription);
+        var validityPeriod = orders.get(index).getDispenseRequest().getValidityPeriod();
+        duplicatedPlan.getDispenseRequest().setValidityPeriod(validityPeriod);
 
         return duplicatedPlan;
     }

--- a/gp2gp-translator/src/test/java/uk/nhs/adaptors/pss/translator/mapper/medication/MedicationRequestMapperTest.java
+++ b/gp2gp-translator/src/test/java/uk/nhs/adaptors/pss/translator/mapper/medication/MedicationRequestMapperTest.java
@@ -479,6 +479,29 @@ public class MedicationRequestMapperTest {
     }
 
     @Test
+    void When_MultipleOrdersAreBasedOnOneAcutePlan_Expect_GeneratedPlanDispenseRequestValidityPeriodIsCopiedFromTheLatestOrder() {
+        setupMultipleOrdersToOnePlanStubs(ACUTE_PRESCRIPTION_EXTENSION);
+        var ehrExtract = unmarshallEhrExtract(
+            "ehrExtract_MultipleSupplyPrescribeInFulfilmentOfSingleAcuteSupplyAuthorise.xml"
+        );
+
+        var resources = medicationRequestMapper
+            .mapResources(ehrExtract, (Patient) new Patient().setId(PATIENT_ID), List.of(), PRACTISE_CODE);
+
+        var latestOrderValidityPeriod = getMedicationRequestById(resources, LATEST_ORDER_ID)
+            .getDispenseRequest()
+            .getValidityPeriod();
+
+        var generatedPlanValidityPeriod = getMedicationRequestById(resources, GENERATED_PLAN_ID)
+            .getDispenseRequest()
+            .getValidityPeriod();
+
+        assertThat(generatedPlanValidityPeriod)
+            .usingRecursiveComparison()
+            .isEqualTo(latestOrderValidityPeriod);
+    }
+
+    @Test
     void When_MultipleOrdersAreBasedOnOneAcutePlan_Expect_TheLatestOrderUnchangedPropertiesAreCopiedToGeneratedPlan() {
         setupMultipleOrdersToOnePlanStubs(ACUTE_PRESCRIPTION_EXTENSION);
         var ehrExtract = unmarshallEhrExtract(


### PR DESCRIPTION
## What

Add functionality when generating `MedicationRequest[plan]`s so that `validityPeriod` is copied from the original `MedicationRequest[Order]. Add a unit test for this functionality.
Update the integration test output files to reflect these changes.

## Why

The original requirements of:

> dispenseRequest.validityPeriod - Is generated by copying same field from over the MedicationRequest[intent=**plan**]

were a mistype and should have read:

>dispenseRequest.validityPeriod - Is generated by copying same field from over the MedicationRequest[intent=**order**]

This change introduces the functionality and tests for this.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes