### PR TITLE
Niad-2913: Guidance around what happens with PS Adaptor in failure modes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## [Unreleased]
 
+### Added
+* Added a guidance that highlights the specific focus on the dependent services and how the PS Adaptor operates when those services are unavailable
+
 ### Fixed
 
 - In the event that an inbound MHS message cannot be processed and needs to be sent to the dead letter queue, the

--- a/OPERATING.md
+++ b/OPERATING.md
@@ -66,6 +66,10 @@ The adaptor checks incomplete transfers periodically, at a default frequency of 
 
 For more configuration see the [Migration timeout variables](#migration-timeout-variables) section.
 
+## Dependent Service Downtime and PS Adaptor Behavior
+This section highlights the specific focus on the dependent services and how the PS Adaptor operates when those services are unavailable.
+[PS Adaptor User Guide: Service Failures and Expected Behavior](./dependent-service-downtime-and-ps-adaptor-behavior.md)
+
 ## Database requirements
 
 * The adaptor requires a [PostgreSQL] database

--- a/dependent-service-downtime-and-ps-adaptor-behavior.md
+++ b/dependent-service-downtime-and-ps-adaptor-behavior.md
@@ -1,7 +1,7 @@
 ## Service Failures and Expected Behavior
 
 This guide outlines the expected behavior of the PS Adaptor when various dependent services are down. 
-The PS Adaptor works in conjunction with several services including the GP2GP Translator, MHS Adaptor, Facade, and others. 
+The PS Adaptor works in conjunction with several services including the GP2GP Translator, MHS Adaptor, and others. 
 The guide explains the effects of outages and how the system behaves in each case.
 
 ### System Overview
@@ -17,45 +17,32 @@ The PS Adaptor initiates a conversation for transferring patient records, relyin
    - Expected Behavior: No messages are sent to the incumbent system while the translator is down. Once the GP2GP Translator recovers, 
      the transfer process resumes, and messages are processed as normal.
    - Recovery: Automatic upon Translator recovery; transfer resumes without manual intervention.
-2. Queue is Down
-   - Scenario: The queue responsible for transferring data between the GP2GP Translator and PS Adaptor is down.
+2. Message Broker is Down
+   - Scenario: The message broker responsible for transferring data between the GP2GP Translator and PS Adaptor is down.
    - Expected Behavior: The initial request is never sent to the incumbent system because the queue is unavailable.
    - Recovery: After the queue is restored, the request can be processed normally, but any messages queued during downtime are not sent.
 3. PS Adaptor Database (DB) is Down
    - Scenario: The PS Adaptor's database is not operational.
-   - Expected Behavior: The initial request to the incumbent system is not sent because the adaptor cannot access the necessary data.
+   - Expected Behavior: The initial transfer request is not sent because the adaptor cannot access the necessary data.
    - Recovery: After the database is restored, the system may resume operations, but requests during the outage are not processed.
 4. Facade Application is Down
    - Scenario: The facade application that works with the PS Adaptor is down.
    - Expected Behavior: The initial request to the incumbent system is not sent. The communication between the PS Adaptor and the incumbent system is blocked.
    - Recovery: Once the facade application is operational, the system can process requests as normal.
-5. MHS Adaptor is Down
-   - Scenario: The MHS Adaptor (including its database) is not operational.
-   - Expected Behavior: The EHR request is not sent to the incumbent system while the MHS Adaptor is down. 
-     Once the MHS Adaptor's database recovers, the request is sent as normal.
-   - Recovery: Automatic upon recovery of the MHS Adaptor’s database.
-6. MHS Adaptor Inbound Queue is Down
+5. MHS Outbound Adaptor is down
+   - Scenario: The MHS Outbound adaptor is not operational.
+   - Expected Behavior: The EHR request is not sent to the incumbent system while the MHS Outbound Adaptor is down. 
+     Once the MHS Outbound adaptor recovers, the request is sent as normal.
+   - Recovery: Once the MHS Outbound Adaptor is operational, the system can process incoming requests as normal.
+6. Message Broker (Inbound Queue) is Down
    - Scenario: The inbound queue managed by the MHS Adaptor is down.
    - Expected Behavior: The EHR request is successfully sent to the incumbent system.
    - Recovery: No action is required as the request is still processed.
-7. MHS Adaptor Outbound Queue is Down
-   - Scenario: The outbound queue managed by the MHS Adaptor is down.
-   - Expected Behavior: The request is not sent to the incumbent system while the outbound queue is down. 
-     Once the outbound service recovers, the request is processed and sent.
-   - Recovery: The system automatically sends the request when the outbound queue becomes operational again.
-8. File Storage is Down
+7. File Storage is Down
    - Scenario: The file storage system is not operational.
    - Expected Behavior: Despite the outage, the EHR request is still sent to the incumbent system. 
      However, any operations that rely on file storage will fail.
    - Recovery: File storage recovery may be necessary for non-EHR-related operations, but the EHR transfer proceeds.
-9. Redis is Down
-   - Scenario: Redis, used for caching, is not operational.
-   - Expected Behavior: There are no negative effects on the transfer process. The translation of patient records continues as normal.
-   - Recovery: No specific recovery action is required for Redis as its absence does not hinder the transfer process.
-10. MHS Outbound SDS is Down
-    - Scenario: The MHS outbound SDS is down.
-    - Expected Behavior: The request is never sent to the incumbent system.
-    - Recovery: Once the MHS outbound SDS is operational again, the request will need to be manually retried or reprocessed.
 
 ### Conclusion
 In the event of a service outage, the PS Adaptor system behaves differently based on the specific service affected. 

--- a/dependent-service-downtime-and-ps-adaptor-behavior.md
+++ b/dependent-service-downtime-and-ps-adaptor-behavior.md
@@ -1,106 +1,149 @@
-## Service Failures and Expected Behavior
+# Service Failures and Expected Behavior
 
-This guide outlines the Behavior Of The Requesting Adaptor when various dependent services are down. 
-The Requesting Adaptor works in conjunction with several services including the GP2GP Translator, MHS Adaptor, and others. 
-The guide explains the effects of outages and how the system behaves in each case.
+This guide outlines the behavior of the Requesting Adaptor when various dependent components are down.
+In the event of a service outage, the Requesting Adaptor system behaves differently based on the specific service affected.
+The guide explains the effects of outages on different components and how the system behaves in each case.
+In some scenarios, the system will automatically recover and resume processing once the affected service is restored.
+However, some outages, particularly those involving the queue or MHS outbound, may require manual intervention to resend
+requests that were missed during downtime.
 
-### System Overview
+## System Overview
+
 The Requesting Adaptor initiates a conversation for transferring patient records, relying on several interconnected services:
+
 - GP2GP Translator: Sends patient records to the Requesting Adaptor via a queue.
 - Facade Application: Works with the Requesting Adaptor to manage transfer requests.
 - MHS Adaptor: Manages inbound and outbound queues, which are responsible for transferring patient records to the incumbent system.
 - Other Dependencies: Include Requesting Adaptor database, MHS inbound and outbound services and File storage.
 
-### Service Outage Scenarios And Behavior Of The Adaptor In Certain Scenarios
+## Service Outage Scenarios
+
+Initial Request - This describes what happen to the initial request made by the User to the Facade to start a GP2GP transfer. 
+
+Transfer in Progress - This describes what happens to a GP2GP transfer has already been requested from the sending system
+but is either still being transferred from the sending system, or is waiting for the User to acknowledge the transfer.
+
+Sending acknowledgement to sending system - This describes what happens to the GP2GP transfer when the User is making a
+request to the Facade acknowledgement endpoint during the stated scenario.
+
 1. GP2GP Translator is Down
     - Initial Request:
-      - Scenario: The GP2GP Translator is not operational and cannot send patient records.
-      - Expected Behavior: No messages are sent to the incumbent system while the translator is down. Once the GP2GP Translator recovers, 
-           the transfer process resumes, and messages are processed as normal.
+      - Scenario: The GP2GP Translator is not operational
+      - Expected Behavior: No request is made to the incumbent system to start the GP2GP process while the translator is down.
+        Once the GP2GP Translator recovers, the transfer process resumes.
       - Recovery: Automatic upon Translator recovery; transfer resumes without manual intervention.
    
     - Transfer in Progress:
-      - Scenario: The GP2GP Translator is not operational and cannot send patient records.
-      - Expected Behavior: Facade responds as it would if the GP2GP Translator was up and running.
+      - Scenario: The GP2GP Translator is not operational
+      - Expected Behaviour: GP2GP transfer is delayed while the Translator is not operational. 
+        Facade will continue to respond to requests without being affected.
       - Recovery: When the GP2GP Translator recovers the transfer is processed as normal.
-      
+
+   - Sending acknowledgement to sending system:
+     - Scenario: The GP2GP Translator is not operational
+     - Expected Behaviour: GP2GP acknowledgement is delayed while the Translator is not operational.
+       Facade will continue to respond to requests without being affected.
+     - Recovery: When the GP2GP Translator recovers the acknowledgement is sent as normal.
+ 
 2. Message Broker is Down
    - Initial Request:
       - Scenario: The message broker responsible for transferring data between the GP2GP Translator and Requesting Adaptor is down.
-      - Expected Behavior: The initial request is never sent to the incumbent system because the queue is unavailable.
-                           The facade responds with 500 "Internal Server Error". The transfer wasn't sent to the sending adapter.
-                           The transfer can be requested again once the message broker is up and running.
-      - Recovery: After the queue is restored, the request can be processed normally, but any messages queued during downtime are not sent.
-   
+      - Expected Behavior: The GP2GP transfer is never sent to the sending adapter.
+                           The Facade responds with 500 "Internal Server Error".
+      - Recovery: After the queue is restored, any transfers requested during downtime are not sent,
+                  but the transfer can be requested again by the user via the Facade.
+
    - Transfer in Progress:
+     - Scenario: The message broker responsible for storing MHS Inbound messages is down.
+     - Expected Behaviour: The MHS inbound responds with a 500 error to spine, and that inbound message is lost.
+         The GP2GP transfer will appear stuck even after the message broker is restored as the Requesting Adaptor is
+         waiting for a message it won't get. The Facade responds with a 204 status code.
+     - Recovery: The transfer is non-recoverable.
+
+   - Sending acknowledgement to sending system:
       - Scenario: The message broker responsible for transferring data between the GP2GP Translator and Requesting Adaptor is down.
-      - Expected Behavior: Facade responds with 204, indicating the migration is still in progress.
-      - Recovery: This is non-recoverable as retries with the same message ID will produce the same error, even after the queue comes back up.
-     
+      - Expected Behavior: Facade responds with 500 and no acknowledgement is sent to the sending system.
+      - Recovery: Once the queue is working again another acknowledgement request can be made for the transfer which will be sent to the sending system.
+
 4. Requesting Adaptor Database (DB) is Down
    - Initial Request:
       - Scenario: The Requesting Adaptor's database is not operational.
-      - Expected Behavior: The initial transfer request is not sent because the adaptor cannot access the necessary data.
-      - Recovery: After the database is restored the transfer is processed as normal.
+      - Expected Behavior: The GP2GP transfer is never sent to the sending adapter.
+          The Facade responds with 500 "Internal Server Error".
+      - Recovery: After the DB is restored, any transfers requested during downtime are not sent,
+        but the transfer can be requested again by the user via the Facade.
      
    - Transfer in Progress:
       - Scenario: The Requesting Adaptor's database is not operational.
-      - Expected Behavior: Facade responds with 500 "Internal Server Error"
+      - Expected Behavior: Facade responds with 500 "Internal Server Error".
+          GP2GP transfer is delayed while the Translator is not operational. 
       - Recovery: After the database is restored the transfer is processed as normal.
-     
+
+   - Sending acknowledgement to sending system:
+     - Scenario: The Requesting Adaptor's database is not operational.
+     - Expected Behavior: Facade responds with 500 and no acknowledgement is sent to the sending system.
+     - Recovery: Once the DB is working again another acknowledgement request can be made for the transfer which will be sent to the sending system.
+
 4. Facade Application is Down
    - Initial Request:
-      - Scenario: The facade application that works with the Requesting Adaptor is down.
-      - Expected Behavior: The initial transfer request is not sent. The communication between the Requesting Adaptor and the incumbent system is blocked.
-      - Recovery: Once the facade application is operational, the system can process requests as normal.
+      - Scenario: The Facade Application is down.
+      - Expected Behavior: The GP2GP transfer is never sent to the sending adapter.
+      - Recovery: Once the Facade Application is working again another transfer request can be made which will be sent to the sending system.
      
    - Transfer in Progress:
-      - Scenario: The facade application that works with the Requesting Adaptor is down.
-      - Expected Behavior: No negative effects on the ongoing transfer and it proceeds as normal however the final ACK won't be sent until
-                            the facade is operational again.
-      - Recovery: Once the facade application is operational, the system can process requests and finish workflows as normal.
+      - Scenario: The Facade Application is down.
+      - Expected Behavior: No negative effects on the ongoing transfer and it proceeds as normal
+      - Recovery: Once the Facade Application is operational, the status of the transfer can be checked as normal.
+
+   - Sending acknowledgement to sending system:
+       - Scenario: The Facade Application is down.
+       - Expected Behavior: No acknowledgement is sent to the sending system.
+       - Recovery: Once the Facade Application is working again another acknowledgement request can be made for the transfer which will be sent to the sending system.
 
 5. MHS Outbound Adaptor is down
    - Initial Request:
       - Scenario: The MHS Outbound adaptor is not operational.
       - Expected Behavior: The EHR request is not sent to the incumbent system while the MHS Outbound Adaptor is down. 
-        Facade responds with 204 indicating the migration is still in progress. Once the MHS Outbound adaptor recovers, the request is sent as normal.
-      - Recovery: Once the MHS Outbound Adaptor is operational, the system can process incoming requests as normal.
+        Facade responds with 204 indicating the migration is still in progress.
+      - Recovery: Once the MHS Outbound adaptor recovers, the transfer is resumed as normal.
    
    - Transfer in Progress:
       - Scenario: The MHS Outbound adaptor is not operational.
       - Expected Behavior: Facade responds with 204, indicating the migration is still in progress.
-      - Recovery: When the MHS Outbound service recovers, the migration is processed as normal.
-     
+      - Recovery: When the MHS Outbound service recovers, the transfer is processed as normal.
+
+   - Sending acknowledgement to sending system:
+     - Scenario: The MHS Outbound adaptor is not operational.
+     - Expected Behavior: The acknowledgement is queued up but not sent to the sending system.
+     - Recovery: When the MHS Outbound service recovers, the acknowledgement is sent as normal.
+
+
 6. MHS Inbound Adaptor is Down
    - Initial Request:
       - Scenario: The MHS Inbound adaptor is not operational.
-      - Expected Behavior: As the EHR extract never reaches the adaptor, the facade receives 204 "No Content" response.
-      - Recovery: After the service is restored, the transfer request can be requested manually once again.
-     
+      - Expected Behavior: Facade responds with 204, indicating the migration is still in progress.
+      - Recovery: After the service is restored, any transfers requested during downtime remain pending.
+                  The transfer is non-recoverable.
+
    - Transfer in Progress:
       - Scenario: The MHS Inbound adaptor is not operational.
       - Expected Behavior: As the EHR extract never reaches the adaptor, the facade receives 204 "No Content" response.
-      - Recovery: After the service is restored, the transfer request can be requested manually once again.
+      - Recovery: After the service is restored, any transfers requested during downtime remain pending.
+                  The transfer is non-recoverable.
 
 7. File Storage is Down
    - Initial Request:
       - Scenario: The file storage system is not operational.
       - Expected Behavior: 
-                       - If the EHR Extract doesn't contain inline attachments, the Facade responds with 204, to indicate the migration is in progress.
-                       - If the EHR Extract does contain inline attachments, the Facacde responds with 500 "Internal Server Error" 
+                       - If the EHR Extract doesn't contain attachments, the Facade responds with 204, to indicate the migration is in progress.
+                       - If the EHR Extract does contain attachments, the Facacde responds with 500 "Internal Server Error" 
                          and the body doesn't have any error details.
-      - Recovery: After the file storage is restored, the transfer request should be repeated.
+      - Recovery: After the file storage is restored, the transfer request can be repeated.
 
    - Transfer in Progress:
       - Scenario: The file storage system is not operational.
-      - Expected Behavior: The Facade responds with 204, indicating the migration is in progress.
-                           The migration will eventually be failed by the scheulded timeout check. 
-                           After which, the Facade will return 500 "Internal Server Error".
-      - Recovery: When the file storage service is up and running, the transfer request should be repeated.
-
-### Conclusion
-In the event of a service outage, the Requesting Adaptor system behaves differently based on the specific service affected. 
-In some cases, the system will automatically recover and resume processing once the affected service is restored. 
-However, some outages, particularly those involving the queue or MHS outbound, 
-may require manual intervention to resend requests that were missed during downtime.
+      - Expected Behavior:
+          - If the EHR Extract doesn't contain attachments, the transfer will complete successfully.
+          - If the EHR Extract does contain attachments, the Facade responds with 500 "Internal Server Error"
+              and the body doesn't have any error details.
+      - Recovery: After the file storage is restored, the transfer request can be repeated.

--- a/dependent-service-downtime-and-ps-adaptor-behavior.md
+++ b/dependent-service-downtime-and-ps-adaptor-behavior.md
@@ -1,15 +1,15 @@
 ## Service Failures and Expected Behavior
 
-This guide outlines the expected behavior of the PS Adaptor when various dependent services are down. 
-The PS Adaptor works in conjunction with several services including the GP2GP Translator, MHS Adaptor, and others. 
+This guide outlines the Behavior Of The Requesting Adaptor when various dependent services are down. 
+The Requesting Adaptor works in conjunction with several services including the GP2GP Translator, MHS Adaptor, and others. 
 The guide explains the effects of outages and how the system behaves in each case.
 
 ### System Overview
-The PS Adaptor initiates a conversation for transferring patient records, relying on several interconnected services:
-- GP2GP Translator: Sends patient records to the PS Adaptor via a queue.
-- Facade Application: Works with the PS Adaptor to manage transfer requests.
+The Requesting Adaptor initiates a conversation for transferring patient records, relying on several interconnected services:
+- GP2GP Translator: Sends patient records to the Requesting Adaptor via a queue.
+- Facade Application: Works with the Requesting Adaptor to manage transfer requests.
 - MHS Adaptor: Manages inbound and outbound queues, which are responsible for transferring patient records to the incumbent system.
-- Other Dependencies: Include PS Adaptor database, MHS inbound and outbound services, file storage, Redis cache, and MHS outbound SDS.
+- Other Dependencies: Include Requesting Adaptor database, MHS inbound and outbound services and File storage.
 
 ### Service Outage Scenarios And Behavior Of The Adaptor In Certain Scenarios
 1. GP2GP Translator is Down
@@ -18,18 +18,18 @@ The PS Adaptor initiates a conversation for transferring patient records, relyin
      the transfer process resumes, and messages are processed as normal.
    - Recovery: Automatic upon Translator recovery; transfer resumes without manual intervention.
 2. Message Broker is Down
-   - Scenario: The message broker responsible for transferring data between the GP2GP Translator and PS Adaptor is down.
+   - Scenario: The message broker responsible for transferring data between the GP2GP Translator and Requesting Adaptor is down.
    - Expected Behavior: The initial request is never sent to the incumbent system because the queue is unavailable.
                         The facade responds with 500 "Internal Server Error". The transfer wasn't sent to the sending adapter.
                         The transfer can be requested again once the message broker is up and running.
    - Recovery: After the queue is restored, the request can be processed normally, but any messages queued during downtime are not sent.
-3. PS Adaptor Database (DB) is Down
-   - Scenario: The PS Adaptor's database is not operational.
+3. Requesting Adaptor Database (DB) is Down
+   - Scenario: The Requesting Adaptor's database is not operational.
    - Expected Behavior: The initial transfer request is not sent because the adaptor cannot access the necessary data.
    - Recovery: After the database is restored the transfer is processed as normal.
 4. Facade Application is Down
-   - Scenario: The facade application that works with the PS Adaptor is down.
-   - Expected Behavior: The initial transfer request is not sent. The communication between the PS Adaptor and the incumbent system is blocked.
+   - Scenario: The facade application that works with the Requesting Adaptor is down.
+   - Expected Behavior: The initial transfer request is not sent. The communication between the Requesting Adaptor and the incumbent system is blocked.
    - Recovery: Once the facade application is operational, the system can process requests as normal.
 5. MHS Outbound Adaptor is down
    - Scenario: The MHS Outbound adaptor is not operational.
@@ -49,7 +49,7 @@ The PS Adaptor initiates a conversation for transferring patient records, relyin
    - Recovery: After the file storage is restored, the request can be processed normally.
 
 ### Conclusion
-In the event of a service outage, the PS Adaptor system behaves differently based on the specific service affected. 
+In the event of a service outage, the Requesting Adaptor system behaves differently based on the specific service affected. 
 In some cases, the system will automatically recover and resume processing once the affected service is restored. 
 However, some outages, particularly those involving the queue or MHS outbound, 
 may require manual intervention to resend requests that were missed during downtime.

--- a/dependent-service-downtime-and-ps-adaptor-behavior.md
+++ b/dependent-service-downtime-and-ps-adaptor-behavior.md
@@ -1,0 +1,64 @@
+## Service Failures and Expected Behavior
+
+This guide outlines the expected behavior of the PS Adaptor when various dependent services are down. 
+The PS Adaptor works in conjunction with several services including the GP2GP Translator, MHS Adaptor, Facade, and others. 
+The guide explains the effects of outages and how the system behaves in each case.
+
+### System Overview
+The PS Adaptor initiates a conversation for transferring patient records, relying on several interconnected services:
+- GP2GP Translator: Sends patient records to the PS Adaptor via a queue.
+- Facade Application: Works with the PS Adaptor to manage transfer requests.
+- MHS Adaptor: Manages inbound and outbound queues, which are responsible for transferring patient records to the incumbent system.
+- Other Dependencies: Include PS Adaptor database, MHS inbound and outbound services, file storage, Redis cache, and MHS outbound SDS.
+
+### Service Outage Scenarios and Expected Behavior
+1. GP2GP Translator is Down
+   - Scenario: The GP2GP Translator is not operational and cannot send patient records.
+   - Expected Behavior: No messages are sent to the incumbent system while the translator is down. Once the GP2GP Translator recovers, 
+     the transfer process resumes, and messages are processed as normal.
+   - Recovery: Automatic upon Translator recovery; transfer resumes without manual intervention.
+2. Queue is Down
+   - Scenario: The queue responsible for transferring data between the GP2GP Translator and PS Adaptor is down.
+   - Expected Behavior: The initial request is never sent to the incumbent system because the queue is unavailable.
+   - Recovery: After the queue is restored, the request can be processed normally, but any messages queued during downtime are not sent.
+3. PS Adaptor Database (DB) is Down
+   - Scenario: The PS Adaptor's database is not operational.
+   - Expected Behavior: The initial request to the incumbent system is not sent because the adaptor cannot access the necessary data.
+   - Recovery: After the database is restored, the system may resume operations, but requests during the outage are not processed.
+4. Facade Application is Down
+   - Scenario: The facade application that works with the PS Adaptor is down.
+   - Expected Behavior: The initial request to the incumbent system is not sent. The communication between the PS Adaptor and the incumbent system is blocked.
+   - Recovery: Once the facade application is operational, the system can process requests as normal.
+5. MHS Adaptor is Down
+   - Scenario: The MHS Adaptor (including its database) is not operational.
+   - Expected Behavior: The EHR request is not sent to the incumbent system while the MHS Adaptor is down. 
+     Once the MHS Adaptor's database recovers, the request is sent as normal.
+   - Recovery: Automatic upon recovery of the MHS Adaptor’s database.
+6. MHS Adaptor Inbound Queue is Down
+   - Scenario: The inbound queue managed by the MHS Adaptor is down.
+   - Expected Behavior: The EHR request is successfully sent to the incumbent system.
+   - Recovery: No action is required as the request is still processed.
+7. MHS Adaptor Outbound Queue is Down
+   - Scenario: The outbound queue managed by the MHS Adaptor is down.
+   - Expected Behavior: The request is not sent to the incumbent system while the outbound queue is down. 
+     Once the outbound service recovers, the request is processed and sent.
+   - Recovery: The system automatically sends the request when the outbound queue becomes operational again.
+8. File Storage is Down
+   - Scenario: The file storage system is not operational.
+   - Expected Behavior: Despite the outage, the EHR request is still sent to the incumbent system. 
+     However, any operations that rely on file storage will fail.
+   - Recovery: File storage recovery may be necessary for non-EHR-related operations, but the EHR transfer proceeds.
+9. Redis is Down
+   - Scenario: Redis, used for caching, is not operational.
+   - Expected Behavior: There are no negative effects on the transfer process. The translation of patient records continues as normal.
+   - Recovery: No specific recovery action is required for Redis as its absence does not hinder the transfer process.
+10. MHS Outbound SDS is Down
+    - Scenario: The MHS outbound SDS is down.
+    - Expected Behavior: The request is never sent to the incumbent system.
+    - Recovery: Once the MHS outbound SDS is operational again, the request will need to be manually retried or reprocessed.
+
+### Conclusion
+In the event of a service outage, the PS Adaptor system behaves differently based on the specific service affected. 
+In many cases, the system will automatically recover and resume processing once the affected service is restored. 
+However, some outages, particularly those involving the queue or MHS outbound, 
+may require manual intervention to resend requests that were missed during downtime.

--- a/dependent-service-downtime-and-ps-adaptor-behavior.md
+++ b/dependent-service-downtime-and-ps-adaptor-behavior.md
@@ -74,12 +74,12 @@ The Requesting Adaptor initiates a conversation for transferring patient records
      
 6. MHS Inbound Adaptor is Down
    - Initial Request:
-      - Scenario: The MHS Inboound adaptor is not operational.
+      - Scenario: The MHS Inbound adaptor is not operational.
       - Expected Behavior: As the EHR extract never reaches the adaptor, the facade receives 204 "No Content" response.
       - Recovery: After the service is restored, the transfer request can be requested manually once again.
      
    - Transfer in Progress:
-      - Scenario: The MHS Inboound adaptor is not operational.
+      - Scenario: The MHS Inbound adaptor is not operational.
       - Expected Behavior: As the EHR extract never reaches the adaptor, the facade receives 204 "No Content" response.
       - Recovery: After the service is restored, the transfer request can be requested manually once again.
 

--- a/dependent-service-downtime-and-ps-adaptor-behavior.md
+++ b/dependent-service-downtime-and-ps-adaptor-behavior.md
@@ -13,40 +13,91 @@ The Requesting Adaptor initiates a conversation for transferring patient records
 
 ### Service Outage Scenarios And Behavior Of The Adaptor In Certain Scenarios
 1. GP2GP Translator is Down
-   - Scenario: The GP2GP Translator is not operational and cannot send patient records.
-   - Expected Behavior: No messages are sent to the incumbent system while the translator is down. Once the GP2GP Translator recovers, 
-     the transfer process resumes, and messages are processed as normal.
-   - Recovery: Automatic upon Translator recovery; transfer resumes without manual intervention.
+    - Initial Request:
+      - Scenario: The GP2GP Translator is not operational and cannot send patient records.
+      - Expected Behavior: No messages are sent to the incumbent system while the translator is down. Once the GP2GP Translator recovers, 
+           the transfer process resumes, and messages are processed as normal.
+      - Recovery: Automatic upon Translator recovery; transfer resumes without manual intervention.
+   
+    - Transfer in Progress:
+      - Scenario: The GP2GP Translator is not operational and cannot send patient records.
+      - Expected Behavior: Facade responds as it would if the GP2GP Translator was up and running.
+      - Recovery: When the GP2GP Translator recovers the transfer is processed as normal.
+      
 2. Message Broker is Down
-   - Scenario: The message broker responsible for transferring data between the GP2GP Translator and Requesting Adaptor is down.
-   - Expected Behavior: The initial request is never sent to the incumbent system because the queue is unavailable.
-                        The facade responds with 500 "Internal Server Error". The transfer wasn't sent to the sending adapter.
-                        The transfer can be requested again once the message broker is up and running.
-   - Recovery: After the queue is restored, the request can be processed normally, but any messages queued during downtime are not sent.
-3. Requesting Adaptor Database (DB) is Down
-   - Scenario: The Requesting Adaptor's database is not operational.
-   - Expected Behavior: The initial transfer request is not sent because the adaptor cannot access the necessary data.
-   - Recovery: After the database is restored the transfer is processed as normal.
+   - Initial Request:
+      - Scenario: The message broker responsible for transferring data between the GP2GP Translator and Requesting Adaptor is down.
+      - Expected Behavior: The initial request is never sent to the incumbent system because the queue is unavailable.
+                           The facade responds with 500 "Internal Server Error". The transfer wasn't sent to the sending adapter.
+                           The transfer can be requested again once the message broker is up and running.
+      - Recovery: After the queue is restored, the request can be processed normally, but any messages queued during downtime are not sent.
+   
+   - Transfer in Progress:
+      - Scenario: The message broker responsible for transferring data between the GP2GP Translator and Requesting Adaptor is down.
+      - Expected Behavior: Facade responds with 204, indicating the migration is still in progress.
+      - Recovery: This is non-recoverable as retries with the same message ID will produce the same error, even after the queue comes back up.
+     
+4. Requesting Adaptor Database (DB) is Down
+   - Initial Request:
+      - Scenario: The Requesting Adaptor's database is not operational.
+      - Expected Behavior: The initial transfer request is not sent because the adaptor cannot access the necessary data.
+      - Recovery: After the database is restored the transfer is processed as normal.
+     
+   - Transfer in Progress:
+      - Scenario: The Requesting Adaptor's database is not operational.
+      - Expected Behavior: Facade responds with 500 "Internal Server Error"
+      - Recovery: After the database is restored the transfer is processed as normal.
+     
 4. Facade Application is Down
-   - Scenario: The facade application that works with the Requesting Adaptor is down.
-   - Expected Behavior: The initial transfer request is not sent. The communication between the Requesting Adaptor and the incumbent system is blocked.
-   - Recovery: Once the facade application is operational, the system can process requests as normal.
+   - Initial Request:
+      - Scenario: The facade application that works with the Requesting Adaptor is down.
+      - Expected Behavior: The initial transfer request is not sent. The communication between the Requesting Adaptor and the incumbent system is blocked.
+      - Recovery: Once the facade application is operational, the system can process requests as normal.
+     
+   - Transfer in Progress:
+      - Scenario: The facade application that works with the Requesting Adaptor is down.
+      - Expected Behavior: No negative effects on the ongoing transfer and it proceeds as normal however the final ACK won't be sent until
+                            the facade is operational again.
+      - Recovery: Once the facade application is operational, the system can process requests and finish workflows as normal.
+
 5. MHS Outbound Adaptor is down
-   - Scenario: The MHS Outbound adaptor is not operational.
-   - Expected Behavior: The EHR request is not sent to the incumbent system while the MHS Outbound Adaptor is down. 
-     Facade responds with 204 indicating the migration is still in progress. Once the MHS Outbound adaptor recovers, the request is sent as normal.
-   - Recovery: Once the MHS Outbound Adaptor is operational, the system can process incoming requests as normal.
+   - Initial Request:
+      - Scenario: The MHS Outbound adaptor is not operational.
+      - Expected Behavior: The EHR request is not sent to the incumbent system while the MHS Outbound Adaptor is down. 
+        Facade responds with 204 indicating the migration is still in progress. Once the MHS Outbound adaptor recovers, the request is sent as normal.
+      - Recovery: Once the MHS Outbound Adaptor is operational, the system can process incoming requests as normal.
+   
+   - Transfer in Progress:
+      - Scenario: The MHS Outbound adaptor is not operational.
+      - Expected Behavior: Facade responds with 204, indicating the migration is still in progress.
+      - Recovery: When the MHS Outbound service recovers, the migration is processed as normal.
+     
 6. Message Broker (Inbound Queue) is Down
-   - Scenario: The inbound queue managed by the MHS Adaptor is down.
-   - Expected Behavior: As the EHR extract never reaches the adaptor, the facade receives 204 "No Content" response.
-   - Recovery: No action is required as the request is still processed.
+   - Initial Request:
+      - Scenario: The inbound queue managed by the MHS Adaptor is down.
+      - Expected Behavior: As the EHR extract never reaches the adaptor, the facade receives 204 "No Content" response.
+      - Recovery: No action is required as the request is still processed.
+     
+   - Transfer in Progress:
+      - Scenario: The inbound queue managed by the MHS Adaptor is down.
+      - Expected Behavior: As the EHR extract never reaches the adaptor, the facade receives 204 "No Content" response.
+      - Recovery: After the service is restored, the transfer request can be requested manually once again.
+
 7. File Storage is Down
-   - Scenario: The file storage system is not operational.
-   - Expected Behavior: 
-                   - If the EHR Extract doesn't contain inline attachments, the Facade responds with 204, to indicate the migration is in progress.
-                   - If the EHR Extract does contain inline attachments, the Facacde responds with 500 "Internal Server Error" 
-                     and the body doesn't have any error details.
-   - Recovery: After the file storage is restored, the request can be processed normally.
+   - Initial Request:
+      - Scenario: The file storage system is not operational.
+      - Expected Behavior: 
+                       - If the EHR Extract doesn't contain inline attachments, the Facade responds with 204, to indicate the migration is in progress.
+                       - If the EHR Extract does contain inline attachments, the Facacde responds with 500 "Internal Server Error" 
+                         and the body doesn't have any error details.
+      - Recovery: After the file storage is restored, the transfer request should be repeated.
+
+   - Transfer in Progress:
+      - Scenario: The file storage system is not operational.
+      - Expected Behavior: The Facade responds with 204, indicating the migration is in progress.
+                           The migration will eventually be failed by the scheulded timeout check. 
+                           After which, the Facade will return 500 "Internal Server Error".
+      - Recovery: When the file storage service is up and running, the transfer request should be repeated.
 
 ### Conclusion
 In the event of a service outage, the Requesting Adaptor system behaves differently based on the specific service affected. 

--- a/dependent-service-downtime-and-ps-adaptor-behavior.md
+++ b/dependent-service-downtime-and-ps-adaptor-behavior.md
@@ -76,7 +76,7 @@ The Requesting Adaptor initiates a conversation for transferring patient records
    - Initial Request:
       - Scenario: The MHS Inboound adaptor is not operational.
       - Expected Behavior: As the EHR extract never reaches the adaptor, the facade receives 204 "No Content" response.
-      - Recovery: No action is required as the request is still processed.
+      - Recovery: After the service is restored, the transfer request can be requested manually once again.
      
    - Transfer in Progress:
       - Scenario: The MHS Inboound adaptor is not operational.

--- a/dependent-service-downtime-and-ps-adaptor-behavior.md
+++ b/dependent-service-downtime-and-ps-adaptor-behavior.md
@@ -11,7 +11,7 @@ The PS Adaptor initiates a conversation for transferring patient records, relyin
 - MHS Adaptor: Manages inbound and outbound queues, which are responsible for transferring patient records to the incumbent system.
 - Other Dependencies: Include PS Adaptor database, MHS inbound and outbound services, file storage, Redis cache, and MHS outbound SDS.
 
-### Service Outage Scenarios and Expected Behavior
+### Service Outage Scenarios And Behavior Of The Adaptor In Certain Scenarios
 1. GP2GP Translator is Down
    - Scenario: The GP2GP Translator is not operational and cannot send patient records.
    - Expected Behavior: No messages are sent to the incumbent system while the translator is down. Once the GP2GP Translator recovers, 
@@ -20,6 +20,8 @@ The PS Adaptor initiates a conversation for transferring patient records, relyin
 2. Message Broker is Down
    - Scenario: The message broker responsible for transferring data between the GP2GP Translator and PS Adaptor is down.
    - Expected Behavior: The initial request is never sent to the incumbent system because the queue is unavailable.
+                        The facade responds with 500 "Internal Server Error". The transfer wasn't sent to the sending adapter.
+                        The transfer can be requested again once the message broker is up and running.
    - Recovery: After the queue is restored, the request can be processed normally, but any messages queued during downtime are not sent.
 3. PS Adaptor Database (DB) is Down
    - Scenario: The PS Adaptor's database is not operational.

--- a/dependent-service-downtime-and-ps-adaptor-behavior.md
+++ b/dependent-service-downtime-and-ps-adaptor-behavior.md
@@ -72,14 +72,14 @@ The Requesting Adaptor initiates a conversation for transferring patient records
       - Expected Behavior: Facade responds with 204, indicating the migration is still in progress.
       - Recovery: When the MHS Outbound service recovers, the migration is processed as normal.
      
-6. Message Broker (Inbound Queue) is Down
+6. MHS Inbound Adaptor is Down
    - Initial Request:
-      - Scenario: The inbound queue managed by the MHS Adaptor is down.
+      - Scenario: The MHS Inboound adaptor is not operational.
       - Expected Behavior: As the EHR extract never reaches the adaptor, the facade receives 204 "No Content" response.
       - Recovery: No action is required as the request is still processed.
      
    - Transfer in Progress:
-      - Scenario: The inbound queue managed by the MHS Adaptor is down.
+      - Scenario: The MHS Inboound adaptor is not operational.
       - Expected Behavior: As the EHR extract never reaches the adaptor, the facade receives 204 "No Content" response.
       - Recovery: After the service is restored, the transfer request can be requested manually once again.
 

--- a/dependent-service-downtime-and-ps-adaptor-behavior.md
+++ b/dependent-service-downtime-and-ps-adaptor-behavior.md
@@ -29,7 +29,7 @@ The PS Adaptor initiates a conversation for transferring patient records, relyin
    - Recovery: After the database is restored, the system may resume operations, but requests during the outage are not processed.
 4. Facade Application is Down
    - Scenario: The facade application that works with the PS Adaptor is down.
-   - Expected Behavior: The initial request to the incumbent system is not sent. The communication between the PS Adaptor and the incumbent system is blocked.
+   - Expected Behavior: The initial transfer request is not sent. The communication between the PS Adaptor and the incumbent system is blocked.
    - Recovery: Once the facade application is operational, the system can process requests as normal.
 5. MHS Outbound Adaptor is down
    - Scenario: The MHS Outbound adaptor is not operational.


### PR DESCRIPTION
## What

A guidance was added that highlights the specific focus on the dependent services and how the PS Adaptor operates when those services are unavailable

## Why

This guide outlines the expected behavior of the PS Adaptor when various dependent services are down. 
The PS Adaptor works in conjunction with several services including the GP2GP Translator, MHS Adaptor, Facade, and others. 
The guide explains the effects of outages and how the system behaves in each case that might be very helpful while investigating different issues related to the PS Adaptor.

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Internal change (non-breaking change with no effect on the functionality affecting end users)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:

- [x] I have performed a self-review of my code
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] I have updated the [Changelog](/CHANGELOG.md) with details of my change in the UNRELEASED section if this change will affect end users
- [ ] A corresponding change has been made to the [Mapping Documentation repository][mapping-docs]

[mapping-docs]: https://github.com/NHSDigital/patient-switching-adaptors-mapping-documentation