### PR TITLE
NIAD-2194: Add logging to `MedicationRequestMapper`

### DIFF
--- a/gp2gp-translator/src/main/java/uk/nhs/adaptors/pss/translator/mapper/medication/MedicationRequestMapper.java
+++ b/gp2gp-translator/src/main/java/uk/nhs/adaptors/pss/translator/mapper/medication/MedicationRequestMapper.java
@@ -15,6 +15,7 @@ import java.util.TreeMap;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
+import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.lang3.StringUtils;
 import org.hl7.fhir.dstu3.model.CodeableConcept;
 import org.hl7.fhir.dstu3.model.DateTimeType;
@@ -41,6 +42,7 @@ import uk.nhs.adaptors.pss.translator.mapper.AbstractMapper;
 import uk.nhs.adaptors.pss.translator.service.IdGeneratorService;
 import uk.nhs.adaptors.pss.translator.util.DateFormatUtil;
 
+@Slf4j
 @Service
 @AllArgsConstructor
 public class MedicationRequestMapper extends AbstractMapper<DomainResource> {
@@ -124,6 +126,12 @@ public class MedicationRequestMapper extends AbstractMapper<DomainResource> {
         var validityPeriod = orders.get(index).getDispenseRequest().getValidityPeriod();
         duplicatedPlan.getDispenseRequest().setValidityPeriod(validityPeriod);
 
+        LOGGER.info(
+            "Generated MedicationRequest(Plan) with Id: {} for MedicationRequest(Order) with Id: {}",
+            duplicatedPlan.getId(),
+            orders.get(index).getId()
+        );
+
         return duplicatedPlan;
     }
 
@@ -158,6 +166,12 @@ public class MedicationRequestMapper extends AbstractMapper<DomainResource> {
         updateBasedOnReferenceToReferenceDuplicatedPlan(
             duplicatedMedicationStatement.getBasedOn(),
             duplicatedPlan.getId()
+        );
+
+        LOGGER.info(
+            "Generated MedicationStatement with Id: {} for MedicationRequest(Order) with Id: {}",
+            duplicatedPlan.getId(),
+            order.getId()
         );
 
         return duplicatedMedicationStatement;


### PR DESCRIPTION

## What

* Add Slf4j to `MedicationRequestMapper`
* Add a log message to indicate that a `MedicationRequest(Plan)` has been generated for a particular `MedicationRequest(Order)`.
* Add a log message to indicate that a `MedicationStatement` has been generated for a particular `MedicationRequest(Order)`.

## Why

To indicate in the logs when `MedicationRequest(Plan)` or `MedicationStatement` has been generated for a particular `MedicationRequest(Order)` when mapping acute plans.

## Type of change

Please delete options that are not relevant.

- [x] Internal change (non-breaking change with no effect on the functionality affecting end users)

## Checklist:

- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes