### PR TITLE
Update original MedicationStatement lastIssueDate for multiple acute med

### DIFF
--- a/gp2gp-translator/src/integrationTest/resources/e2e-mapping/output-json/PWTP2-output.json
+++ b/gp2gp-translator/src/integrationTest/resources/e2e-mapping/output-json/PWTP2-output.json
@@ -2414,7 +2414,7 @@
         }
       }, {
         "url": "https://fhir.nhs.uk/STU3/StructureDefinition/Extension-CareConnect-GPC-MedicationStatementLastIssueDate-1",
-        "valueDateTime": "2010-02-26"
+        "valueDateTime": "2010-01-13"
       } ],
       "identifier": [ {
         "system": "https://PSSAdaptor/B83002",

--- a/gp2gp-translator/src/integrationTest/resources/e2e-mapping/output-json/PWTP4-output.json
+++ b/gp2gp-translator/src/integrationTest/resources/e2e-mapping/output-json/PWTP4-output.json
@@ -3434,7 +3434,7 @@
         }
       }, {
         "url": "https://fhir.nhs.uk/STU3/StructureDefinition/Extension-CareConnect-GPC-MedicationStatementLastIssueDate-1",
-        "valueDateTime": "2013-01-03"
+        "valueDateTime": "2010-01-14"
       } ],
       "identifier": [ {
         "system": "https://PSSAdaptor/B83002",
@@ -5953,7 +5953,7 @@
         }
       }, {
         "url": "https://fhir.nhs.uk/STU3/StructureDefinition/Extension-CareConnect-GPC-MedicationStatementLastIssueDate-1",
-        "valueDateTime": "2010-05-21"
+        "valueDateTime": "2010-01-18"
       } ],
       "identifier": [ {
         "system": "https://PSSAdaptor/B83002",

--- a/gp2gp-translator/src/main/java/uk/nhs/adaptors/pss/translator/mapper/medication/MedicationRequestMapper.java
+++ b/gp2gp-translator/src/main/java/uk/nhs/adaptors/pss/translator/mapper/medication/MedicationRequestMapper.java
@@ -105,6 +105,11 @@ public class MedicationRequestMapper extends AbstractMapper<DomainResource> {
                         resources.add(duplicatedPlan);
                         resources.add(duplicatedMedicationStatement);
                     }
+
+                    final var originalMedicationStatement = getMedicationStatementByPlanId(medicationStatements, plan.getId());
+                    originalMedicationStatement.getExtensionByUrl(MEDICATION_STATEMENT_LAST_ISSUE_DATE_URL).setValue(
+                        orders.get(0).getDispenseRequest().getValidityPeriod().getStartElement()
+                    );
                 }
             });
     }

--- a/gp2gp-translator/src/test/java/uk/nhs/adaptors/pss/translator/mapper/medication/MedicationRequestMapperTest.java
+++ b/gp2gp-translator/src/test/java/uk/nhs/adaptors/pss/translator/mapper/medication/MedicationRequestMapperTest.java
@@ -667,6 +667,19 @@ public class MedicationRequestMapperTest {
         }
 
         @Test
+        void expectOriginalMedicationStatementLastIssueDateExtensionSetToValidityPeriodStart() {
+            var resources = medicationRequestMapper
+                    .mapResources(ehrExtract, (Patient) new Patient().setId(PATIENT_ID), List.of(), PRACTISE_CODE
+                    );
+
+            var earliestOrder = getMedicationRequestById(resources, EARLIEST_ORDER_ID);
+            var originalMedicationStatement = getMedicationStatementById(resources, INITIAL_MEDICATION_STATEMENT_ID);
+
+            assertThat(originalMedicationStatement.getExtensionByUrl(MEDICATION_STATEMENT_LAST_ISSUE_DATE_URL).getValue())
+                .isEqualTo(earliestOrder.getDispenseRequest().getValidityPeriod().getStartElement());
+        }
+
+        @Test
         void expectOriginalMedicationStatementUnchangedPropertiesAreCopiedToGeneratedMedicationStatement() {
             var resources = medicationRequestMapper
                 .mapResources(ehrExtract, (Patient) new Patient().setId(PATIENT_ID), List.of(), PRACTISE_CODE


### PR DESCRIPTION
## What

When an accute med has multiple issues, we generate individual plan/statement for each order.

This updates the original statements lastIssueDate to correspond to the date on its corresponding MedicationRequest[order].

## Why

Previously the lastIssueDate was the most recent date of all the orders.

## Type of change

Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [x] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I have updated the [Changelog](/CHANGELOG.md) with details of my change in the UNRELEASED section if this change will affect end users
- [ ] A corresponding change has been made to the [Mapping Documentation repository][mapping-docs]

[mapping-docs]: https://github.com/NHSDigital/patient-switching-adaptors-mapping-documentation