### PR TITLE
Logging: Incorrect ID output when generating `MedicationStatements`

### DIFF
--- a/gp2gp-translator/src/main/java/uk/nhs/adaptors/pss/translator/mapper/medication/MedicationRequestMapper.java
+++ b/gp2gp-translator/src/main/java/uk/nhs/adaptors/pss/translator/mapper/medication/MedicationRequestMapper.java
@@ -175,7 +175,7 @@ public class MedicationRequestMapper extends AbstractMapper<DomainResource> {
 
         LOGGER.info(
             "Generated MedicationStatement with Id: {} for MedicationRequest(Order) with Id: {}",
-            duplicatedPlan.getId(),
+            duplicatedMedicationStatement.getId(),
             order.getId()
         );
 


### PR DESCRIPTION
## What

* Fix issue with incorrect ID being output when logging that a `medicationStatement` has been generated during `MedicationRequest` mapping

## Why

Recently introduced logging to notify that a `MedicationStatement` had been generated during the mapping process (when multiple `Order`s reference the same acute `Plan`) included the id of the generated `Plan` not the generated `MedicationStatement` as expected.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
