### PR TITLE
NIAD-3170: Set effective end date to start date in generated `MedicationStatement` when status is `active` when mapping acute plans.

### DIFF
--- a/gp2gp-translator/src/integrationTest/resources/e2e-mapping/output-json/PWTP2-output.json
+++ b/gp2gp-translator/src/integrationTest/resources/e2e-mapping/output-json/PWTP2-output.json
@@ -6699,7 +6699,8 @@
         "reference": "Medication/00000000-0000-0000-0000-000000000013"
       },
       "effectivePeriod": {
-        "start": "2010-02-26"
+        "start": "2010-02-26",
+        "end": "2010-02-26"
       },
       "dateAsserted": "2010-01-13T11:37:31+00:00",
       "subject": {

--- a/gp2gp-translator/src/integrationTest/resources/e2e-mapping/output-json/PWTP4-output.json
+++ b/gp2gp-translator/src/integrationTest/resources/e2e-mapping/output-json/PWTP4-output.json
@@ -18340,7 +18340,8 @@
         "reference": "Medication/00000000-0000-0000-0000-000000000079"
       },
       "effectivePeriod": {
-        "start": "2011-11-15"
+        "start": "2011-11-15",
+        "end": "2011-11-15"
       },
       "dateAsserted": "2011-11-15T14:55:59+00:00",
       "subject": {
@@ -18437,7 +18438,8 @@
         "reference": "Medication/00000000-0000-0000-0000-000000000024"
       },
       "effectivePeriod": {
-        "start": "2013-01-03"
+        "start": "2013-01-03",
+        "end": "2013-01-03"
       },
       "dateAsserted": "2010-01-14T10:30:03+00:00",
       "subject": {
@@ -18534,7 +18536,8 @@
         "reference": "Medication/00000000-0000-0000-0000-000000000009"
       },
       "effectivePeriod": {
-        "start": "2010-03-23"
+        "start": "2010-03-23",
+        "end": "2010-03-23"
       },
       "dateAsserted": "2010-03-23T15:47:58+00:00",
       "subject": {
@@ -18634,7 +18637,8 @@
         "reference": "Medication/00000000-0000-0000-0000-000000000043"
       },
       "effectivePeriod": {
-        "start": "2010-05-21"
+        "start": "2010-05-21",
+        "end": "2010-05-21"
       },
       "dateAsserted": "2010-01-18T09:16:52+00:00",
       "subject": {

--- a/gp2gp-translator/src/test/java/uk/nhs/adaptors/pss/translator/mapper/medication/MedicationRequestMapperTest.java
+++ b/gp2gp-translator/src/test/java/uk/nhs/adaptors/pss/translator/mapper/medication/MedicationRequestMapperTest.java
@@ -1,5 +1,6 @@
 package uk.nhs.adaptors.pss.translator.mapper.medication;
 
+import org.apache.commons.lang3.StringUtils;
 import org.hl7.fhir.dstu3.model.Annotation;
 import org.hl7.fhir.dstu3.model.CodeableConcept;
 import org.hl7.fhir.dstu3.model.Coding;
@@ -383,7 +384,7 @@ public class MedicationRequestMapperTest {
 
         @BeforeEach
         void beforeEach() {
-            setupMultipleOrdersToOnePlanStubs(REPEAT_PRESCRIPTION_EXTENSION);
+            setupMultipleOrdersToOnePlanStubs(REPEAT_PRESCRIPTION_EXTENSION, MedicationStatementStatus.ACTIVE, true);
         }
 
         @Test
@@ -446,7 +447,7 @@ public class MedicationRequestMapperTest {
         }
         @BeforeEach
         void beforeEach() {
-            setupMultipleOrdersToOnePlanStubs(ACUTE_PRESCRIPTION_EXTENSION);
+            setupMultipleOrdersToOnePlanStubs(ACUTE_PRESCRIPTION_EXTENSION, MedicationStatementStatus.ACTIVE, true);
         }
 
         @Test
@@ -638,7 +639,7 @@ public class MedicationRequestMapperTest {
         }
 
         @Test
-        void expectGeneratedMedicationStatementEffectivePeriodSetToOrderValidityPeriod() {
+        void expectGeneratedMedicationStatementWhenActiveHasEffectivePeriodSetToOrderValidityPeriod() {
             var resources = medicationRequestMapper
                 .mapResources(ehrExtract, (Patient) new Patient().setId(PATIENT_ID), List.of(), PRACTISE_CODE
                 );
@@ -650,6 +651,44 @@ public class MedicationRequestMapperTest {
                 () -> assertThat(generatedMedicationStatement.getEffectivePeriod())
                     .usingRecursiveComparison()
                     .isEqualTo(latestOrder.getDispenseRequest().getValidityPeriod())
+            );
+        }
+
+        @Test
+        void expectGeneratedStatementWhenNotActiveHasEffectiveTimeSetToOrderValidityPeriodWhenEndIsPresent() {
+            setupMultipleOrdersToOnePlanStubs(ACUTE_PRESCRIPTION_EXTENSION, MedicationStatementStatus.COMPLETED, true);
+
+            var resources = medicationRequestMapper
+                .mapResources(ehrExtract, (Patient) new Patient().setId(PATIENT_ID), List.of(), PRACTISE_CODE
+                );
+
+            var latestOrder = getMedicationRequestById(resources, LATEST_ORDER_ID);
+            var generatedMedicationStatement = getMedicationStatementById(resources, GENERATED_MEDICATION_STATEMENT_ID);
+
+            assertAll(
+                () -> assertThat(generatedMedicationStatement.getEffectivePeriod())
+                    .usingRecursiveComparison()
+                    .isEqualTo(latestOrder.getDispenseRequest().getValidityPeriod())
+            );
+        }
+
+        @Test
+        void expectGeneratedStatementWhenNotActiveHasEffectiveTimeEndSetToOrderValidityPeriodStartWhenEndIsNotPresent() {
+            setupMultipleOrdersToOnePlanStubs(ACUTE_PRESCRIPTION_EXTENSION, MedicationStatementStatus.COMPLETED, false);
+
+            var resources = medicationRequestMapper
+                .mapResources(ehrExtract, (Patient) new Patient().setId(PATIENT_ID), List.of(), PRACTISE_CODE
+                );
+
+            var latestOrder = getMedicationRequestById(resources, LATEST_ORDER_ID);
+            var generatedMedicationStatement = getMedicationStatementById(resources, GENERATED_MEDICATION_STATEMENT_ID);
+            assertAll(
+                () -> assertThat(generatedMedicationStatement.getEffectivePeriod().getStart())
+                    .as("Start")
+                    .isEqualTo(latestOrder.getDispenseRequest().getValidityPeriod().getStart()),
+                () -> assertThat(generatedMedicationStatement.getEffectivePeriod().getEnd())
+                    .as("End")
+                    .isEqualTo(latestOrder.getDispenseRequest().getValidityPeriod().getStart())
             );
         }
 
@@ -744,14 +783,23 @@ public class MedicationRequestMapperTest {
         assertThat(medicationRequestId).isEqualTo(PATIENT_ID);
     }
 
-    private MedicationRequest buildMedicationRequestOrder(String id, String validityPeriodStartDate) {
+    private MedicationRequest buildMedicationRequestOrder(
+        String id,
+        String validityPeriodStartDate,
+        String validityPeriodEndDate
+    ) {
         return (MedicationRequest) new MedicationRequest()
             .setIntent(MedicationRequestIntent.ORDER)
             .addBasedOn(REFERENCE_TO_PLAN)
             .setDispenseRequest(
                 new MedicationRequestDispenseRequestComponent()
                     .setValidityPeriod(
-                        new Period().setStartElement(DateFormatUtil.parseToDateTimeType(validityPeriodStartDate))
+                        new Period()
+                            .setStartElement(DateFormatUtil.parseToDateTimeType(validityPeriodStartDate))
+                            .setEndElement(StringUtils.isNotEmpty(validityPeriodEndDate)
+                                ? DateFormatUtil.parseToDateTimeType(validityPeriodEndDate)
+                                : null
+                            )
                     )
             )
             .setId(id);
@@ -779,7 +827,7 @@ public class MedicationRequestMapperTest {
         return plan;
     }
 
-    private MedicationStatement buildMedicationStatement() {
+    private MedicationStatement buildMedicationStatement(MedicationStatementStatus status) {
         return (MedicationStatement) new MedicationStatement()
             .addIdentifier(new Identifier().setValue(INITIAL_MEDICATION_STATEMENT_ID))
             .setTaken(MedicationStatementTaken.UNK)
@@ -787,7 +835,7 @@ public class MedicationRequestMapperTest {
             .addDosage(new Dosage().setText("TEST_DOSAGE"))
             .setMedication(new Reference("MedicationRequest/00000000-0000-4000-0000-200000000000"))
             .setEffective(new Period().setStartElement(DateFormatUtil.parseToDateTimeType("20240101")))
-            .setStatus(MedicationStatementStatus.COMPLETED)
+            .setStatus(status)
             .addExtension(new Extension("TEST_EXTENSION", new StringType("TEST_VALUE")))
             .addExtension(new Extension(
                 "https://fhir.nhs.uk/STU3/StructureDefinition/Extension-CareConnect-GPC-MedicationStatementLastIssueDate-1",
@@ -821,8 +869,12 @@ public class MedicationRequestMapperTest {
             .orElseThrow();
     }
 
-    private void setupMultipleOrdersToOnePlanStubs(Extension planExtension) {
-        when(
+    private void setupMultipleOrdersToOnePlanStubs(
+        Extension planExtension,
+        MedicationStatementStatus medicationStatementStatus,
+        boolean hasOrderValidityPeriodEnd
+    ) {
+        lenient().when(
             medicationRequestPlanMapper.mapToPlanMedicationRequest(
                 any(RCMRMT030101UKEhrExtract.class),
                 any(RCMRMT030101UKEhrComposition.class),
@@ -832,7 +884,11 @@ public class MedicationRequestMapperTest {
             )
         ).thenReturn(buildMedicationRequestPlan(planExtension));
 
-        when(
+        var orderValidityPeriodEnd = hasOrderValidityPeriodEnd
+            ? "20240103"
+            : null;
+
+        lenient().when(
             medicationRequestOrderMapper.mapToOrderMedicationRequest(
                 any(RCMRMT030101UKEhrExtract.class),
                 any(RCMRMT030101UKEhrComposition.class),
@@ -840,14 +896,14 @@ public class MedicationRequestMapperTest {
                 any(RCMRMT030101UKPrescribe.class),
                 any(String.class)
             )
-        ).thenReturn(buildMedicationRequestOrder(
-            LATEST_ORDER_ID, "20240102"),
-            buildMedicationRequestOrder(EARLIEST_ORDER_ID, "20240101")
+        ).thenReturn(
+            buildMedicationRequestOrder(LATEST_ORDER_ID, "20240102", orderValidityPeriodEnd),
+            buildMedicationRequestOrder(EARLIEST_ORDER_ID, "20240101", orderValidityPeriodEnd)
         );
 
         lenient().when(idGeneratorService.generateUuid()).thenReturn(GENERATED_PLAN_ID);
 
-        when(
+        lenient().when(
             medicationStatementMapper.mapToMedicationStatement(
                 any(RCMRMT030101UKEhrExtract.class),
                 any(RCMRMT030101UKEhrComposition.class),
@@ -856,7 +912,7 @@ public class MedicationRequestMapperTest {
                 any(String.class),
                 any(DateTimeType.class)
             )
-        ).thenReturn(buildMedicationStatement());
+        ).thenReturn(buildMedicationStatement(medicationStatementStatus));
     }
 
     private void setupCommonStubs() {

--- a/gp2gp-translator/src/test/java/uk/nhs/adaptors/pss/translator/mapper/medication/MedicationRequestMapperTest.java
+++ b/gp2gp-translator/src/test/java/uk/nhs/adaptors/pss/translator/mapper/medication/MedicationRequestMapperTest.java
@@ -639,7 +639,7 @@ public class MedicationRequestMapperTest {
         }
 
         @Test
-        void expectGeneratedMedicationStatementWhenActiveHasEffectivePeriodSetToOrderValidityPeriod() {
+        void When_Active_Expect_GeneratedMedicationStatementHasEffectivePeriodSetToOrderValidityPeriod() {
             var resources = medicationRequestMapper
                 .mapResources(ehrExtract, (Patient) new Patient().setId(PATIENT_ID), List.of(), PRACTISE_CODE
                 );
@@ -655,7 +655,7 @@ public class MedicationRequestMapperTest {
         }
 
         @Test
-        void expectGeneratedStatementWhenNotActiveHasEffectiveTimeSetToOrderValidityPeriodWhenEndIsPresent() {
+        void When_NotActive_Expect_GeneratedStatementHasEffectiveTimeSetToOrderValidityPeriodWhenEndIsPresent() {
             setupMultipleOrdersToOnePlanStubs(ACUTE_PRESCRIPTION_EXTENSION, MedicationStatementStatus.COMPLETED, true);
 
             var resources = medicationRequestMapper
@@ -673,7 +673,7 @@ public class MedicationRequestMapperTest {
         }
 
         @Test
-        void expectGeneratedStatementWhenNotActiveHasEffectiveTimeEndSetToOrderValidityPeriodStartWhenEndIsNotPresent() {
+        void When_NotActive_Expect_GeneratedStatementHasEffectiveTimeEndSetToOrderValidityPeriodStartWhenEndIsNotPresent() {
             setupMultipleOrdersToOnePlanStubs(ACUTE_PRESCRIPTION_EXTENSION, MedicationStatementStatus.COMPLETED, false);
 
             var resources = medicationRequestMapper


### PR DESCRIPTION
## What

* Add unit tests to ensure that the generated `MedicationStatement` has an `effective.end` set to the value of `effective.start` when the status is `active` and associated `Order` has no `dispenseRequest.validityPeriod.end`.
* Add unit tests to assert the current behaviour depending on the `MedicationStatement.status`
* Add functionality to `MedicationRequestMapper` for the above.
* Update integration test files to now test that the `end` value is correctly populated.

## Why

Currently we only set `effective.start` value when generating a `MedicationStatement` whilst mapping an acute `plan` where multiple `ehrSupplyPrescribe` reference a single acute `ehrSupplyAuthorise`, whilst when building new `MedicationStatements` we also set `end` to the same value as `start` when `status` is `active` and the is not a `end` value provided.

This change is to ensure the functionality remains consistent.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes