### PR TITLE
NIAD-3187: Deduplicate Observations where the CodableConcept is identical to another within the same EhrExtract and contains no additional information

### DIFF
--- a/gp2gp-translator/build.gradle
+++ b/gp2gp-translator/build.gradle
@@ -40,6 +40,7 @@ dependencies {
     testImplementation 'pl.pragmatists:JUnitParams:1.1.1'
     testImplementation 'org.skyscreamer:jsonassert:1.5.3'
     testImplementation 'org.awaitility:awaitility:4.2.2'
+    testImplementation group: 'com.github.valfirst', name: 'slf4j-test', version: '3.0.1'
 
     implementation 'com.azure:azure-storage-blob:12.27.1'
 

--- a/gp2gp-translator/build.gradle
+++ b/gp2gp-translator/build.gradle
@@ -40,7 +40,6 @@ dependencies {
     testImplementation 'pl.pragmatists:JUnitParams:1.1.1'
     testImplementation 'org.skyscreamer:jsonassert:1.5.3'
     testImplementation 'org.awaitility:awaitility:4.2.2'
-    testImplementation group: 'com.github.valfirst', name: 'slf4j-test', version: '3.0.1'
 
     implementation 'com.azure:azure-storage-blob:12.27.1'
 

--- a/gp2gp-translator/src/integrationTest/java/uk/nhs/adaptors/pss/translator/service/BundleMapperServiceIT.java
+++ b/gp2gp-translator/src/integrationTest/java/uk/nhs/adaptors/pss/translator/service/BundleMapperServiceIT.java
@@ -46,7 +46,9 @@ public class BundleMapperServiceIT {
     private FhirParser fhirParser;
 
     @Test
-    public void When_MappingBundle_With_Documents_Expect_BundleWithJson() throws BundleMappingException {
+    public void When_MappingBundle_With_ObservationsThatHaveDuplicateCodeableConcepts_Expect_ObservationsRemoved()
+        throws BundleMappingException {
+
         var ehrMessage = unmarshallEhrExtractFromFile("ehr-document-and-no-organisations.xml");
 
         var bundle = bundleMapperService.mapToBundle(ehrMessage, LOSING_PRACTICE_ODS_CODE, new ArrayList<>());

--- a/gp2gp-translator/src/integrationTest/java/uk/nhs/adaptors/pss/translator/service/BundleMapperServiceIT.java
+++ b/gp2gp-translator/src/integrationTest/java/uk/nhs/adaptors/pss/translator/service/BundleMapperServiceIT.java
@@ -46,7 +46,7 @@ public class BundleMapperServiceIT {
     private FhirParser fhirParser;
 
     @Test
-    public void When_MappingBundle_With_ObservationsThatHaveDuplicateCodeableConcepts_Expect_ObservationsRemoved()
+    public void When_MappingBundle_With_ObservationsThatHaveDuplicateCodeableConcepts_Expect_ObservationRemoved()
         throws BundleMappingException {
 
         var ehrMessage = unmarshallEhrExtractFromFile("ehr-document-and-no-organisations.xml");

--- a/gp2gp-translator/src/integrationTest/java/uk/nhs/adaptors/pss/translator/service/BundleMapperServiceIT.java
+++ b/gp2gp-translator/src/integrationTest/java/uk/nhs/adaptors/pss/translator/service/BundleMapperServiceIT.java
@@ -11,6 +11,7 @@ import java.util.List;
 
 import org.hl7.fhir.dstu3.model.Bundle;
 import org.hl7.fhir.dstu3.model.DocumentReference;
+import org.hl7.fhir.dstu3.model.Observation;
 import org.hl7.fhir.dstu3.model.Organization;
 import org.hl7.fhir.dstu3.model.Practitioner;
 import org.hl7.fhir.dstu3.model.PractitionerRole;
@@ -26,6 +27,7 @@ import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
 
 import lombok.SneakyThrows;
+import uk.nhs.adaptors.common.util.fhir.FhirParser;
 import uk.nhs.adaptors.pss.translator.exception.BundleMappingException;
 
 @SpringBootTest(webEnvironment = RANDOM_PORT)
@@ -39,6 +41,19 @@ public class BundleMapperServiceIT {
 
     @Autowired
     private BundleMapperService bundleMapperService;
+
+    @Autowired
+    private FhirParser fhirParser;
+
+    @Test
+    public void When_MappingBundle_With_Documents_Expect_BundleWithJson() throws BundleMappingException {
+        var ehrMessage = unmarshallEhrExtractFromFile("ehr-document-and-no-organisations.xml");
+
+        var bundle = bundleMapperService.mapToBundle(ehrMessage, LOSING_PRACTICE_ODS_CODE, new ArrayList<>());
+        var observations = extractObservationsFromBundle(bundle);
+
+        assertThat(observations.size()).isOne();
+    }
 
     @Test
     public void When_MappingBundle_With_RepresentedOrganisation_Expect_OrganisationMapped() throws BundleMappingException {
@@ -193,6 +208,14 @@ public class BundleMapperServiceIT {
             .map(Bundle.BundleEntryComponent::getResource)
             .filter(resource -> resource.getResourceType().equals(ResourceType.DocumentReference))
             .map(DocumentReference.class::cast)
+            .toList();
+    }
+
+    private List<Observation> extractObservationsFromBundle(Bundle bundle) {
+        return bundle.getEntry().stream()
+            .map(Bundle.BundleEntryComponent::getResource)
+            .filter(resource -> resource.getResourceType().equals(ResourceType.Observation))
+            .map(Observation.class::cast)
             .toList();
     }
 }

--- a/gp2gp-translator/src/integrationTest/resources/xml/mapping/ehr-extract/ehr-document-and-no-organisations.xml
+++ b/gp2gp-translator/src/integrationTest/resources/xml/mapping/ehr-extract/ehr-document-and-no-organisations.xml
@@ -85,6 +85,100 @@
                         </responsibleParty>
                         <component typeCode="COMP">
                             <ehrComposition classCode="COMPOSITION" moodCode="EVN">
+                                <id root="B18C520A-7671-11EF-9D98-00155D78C707"/>
+                                <code code="37351000000107" codeSystem="2.16.840.1.113883.2.1.3.2.4.15" displayName="Administration Note"/>
+                                <statusCode code="COMPLETE"/>
+                                <effectiveTime>
+                                    <center value="20240919112245"/>
+                                </effectiveTime>
+                                <availabilityTime value="20240919112245"/>
+                                <author typeCode="AUT" contextControlCode="OP">
+                                    <time value="20240919112245"/>
+                                    <agentRef classCode="AGNT">
+                                        <id root="B18C5205-7671-11EF-9D98-00155D78C707"/>
+                                    </agentRef>
+                                </author>
+                                <location typeCode="LOC">
+                                    <locatedEntity classCode="LOCE">
+                                        <locatedPlace classCode="PLC" determinerCode="INSTANCE">
+                                            <name>FIRSTCARE PRACTICE</name>
+                                            <telecom use="WP" value="tel:01132050099">
+                                                <useablePeriod>
+                                                    <low value="20240919"/>
+                                                </useablePeriod>
+                                            </telecom>
+                                            <addr use="WP">
+                                                <streetAddressLine>2434 Troy Road</streetAddressLine>
+                                                <streetAddressLine>Horsforth</streetAddressLine>
+                                                <streetAddressLine>Leeds</streetAddressLine>
+                                                <streetAddressLine>West Yorkshire</streetAddressLine>
+                                                <postalCode>LS18 5TN</postalCode>
+                                                <useablePeriod>
+                                                    <low value="20240919"/>
+                                                </useablePeriod>
+                                            </addr>
+                                        </locatedPlace>
+                                    </locatedEntity>
+                                </location>
+                                <Participant2 typeCode="PRF" contextControlCode="OP">
+                                    <agentRef classCode="AGNT">
+                                        <id root="B18C5205-7671-11EF-9D98-00155D78C707"/>
+                                    </agentRef>
+                                </Participant2>
+                                <component typeCode="COMP">
+                                    <ObservationStatement classCode="OBS" moodCode="EVN">
+                                        <id root="B18C520B-7671-11EF-9D98-00155D78C707"/>
+                                        <code code="XE0s9" codeSystem="2.16.840.1.113883.2.1.3.2.4.14" displayName="Hearing loss">
+                                            <translation code="15188001" codeSystem="2.16.840.1.113883.2.1.3.2.4.15" displayName="Hearing loss"/>
+                                            <translation code="F59..00" codeSystem="2.16.840.1.113883.2.1.6.2" displayName="Hearing loss"/>
+                                        </code>
+                                        <statusCode code="COMPLETE"/>
+                                        <effectiveTime>
+                                            <low value="20240919"/>
+                                        </effectiveTime>
+                                        <availabilityTime value="20240919"/>
+                                        <pertinentInformation typeCode="PERT">
+                                            <sequenceNumber value="+1"/>
+                                            <pertinentAnnotation classCode="OBS" moodCode="EVN">
+                                                <text>Problem severity: Major</text>
+                                            </pertinentAnnotation>
+                                        </pertinentInformation>
+                                    </ObservationStatement>
+                                </component>
+                                <component typeCode="COMP">
+                                    <LinkSet classCode="OBS" moodCode="EVN">
+                                        <id root="B18C520C-7671-11EF-9D98-00155D78C707"/>
+                                        <code code="394774009" codeSystem="2.16.840.1.113883.2.1.3.2.4.15" displayName="Active Problem"/>
+                                        <statusCode code="COMPLETE"/>
+                                        <effectiveTime>
+                                            <low value="20240919000000"/>
+                                        </effectiveTime>
+                                        <availabilityTime value="20240919112245"/>
+                                        <conditionNamed typeCode="NAME" inversionInd="true">
+                                            <namedStatementRef classCode="OBS" moodCode="EVN">
+                                                <id root="B18C520B-7671-11EF-9D98-00155D78C707"/>
+                                            </namedStatementRef>
+                                        </conditionNamed>
+                                    </LinkSet>
+                                </component>
+                                <component typeCode="COMP">
+                                    <ObservationStatement classCode="OBS" moodCode="EVN">
+                                        <id root="B1910CF0-7671-11EF-9D98-00155D78C707"/>
+                                        <code code="XE0s9" codeSystem="2.16.840.1.113883.2.1.3.2.4.14" displayName="Hearing loss">
+                                            <translation code="15188001" codeSystem="2.16.840.1.113883.2.1.3.2.4.15" displayName="Hearing loss"/>
+                                            <translation code="F59..00" codeSystem="2.16.840.1.113883.2.1.6.2" displayName="Hearing loss"/>
+                                        </code>
+                                        <statusCode code="COMPLETE"/>
+                                        <effectiveTime>
+                                            <center nullFlavor="NI"/>
+                                        </effectiveTime>
+                                        <availabilityTime value="20240919112245"/>
+                                    </ObservationStatement>
+                                </component>
+                            </ehrComposition>
+                        </component>
+                        <component typeCode="COMP">
+                            <ehrComposition classCode="COMPOSITION" moodCode="EVN">
                                 <id root="62A39454-299F-432E-993E-5A6232B4E099"/>
                                 <code code="37351000000107" codeSystem="2.16.840.1.113883.2.1.3.2.4.15" displayName="Administration Note"/>
                                 <statusCode code="COMPLETE"/>

--- a/gp2gp-translator/src/main/java/uk/nhs/adaptors/pss/translator/mapper/DuplicateObservationStatementMapper.java
+++ b/gp2gp-translator/src/main/java/uk/nhs/adaptors/pss/translator/mapper/DuplicateObservationStatementMapper.java
@@ -79,7 +79,7 @@ public class DuplicateObservationStatementMapper {
         components.removeIf(component -> {
             var candidateObservationStatement = component.getObservationStatement();
 
-            if (!hasSinglePertinentInformation(candidateObservationStatement)
+            if (hasNoPertinentInformation(candidateObservationStatement)
                         && isExactCodeableConceptDuplicate(observationStatement, candidateObservationStatement)) {
                 LOGGER.info("Removed duplicate ObservationStatement: '{}' matching '{}'.",
                             candidateObservationStatement.getId().getRoot(),
@@ -144,6 +144,10 @@ public class DuplicateObservationStatementMapper {
 
     private static RCMRMT030101UKAnnotation getPertinentAnnotation(RCMRMT030101UKObservationStatement linkedObservationStatement) {
         return linkedObservationStatement.getPertinentInformation().getFirst().getPertinentAnnotation();
+    }
+
+    private static boolean hasNoPertinentInformation(RCMRMT030101UKObservationStatement observation) {
+        return observation != null && observation.getPertinentInformation().isEmpty();
     }
 
     private static boolean hasSinglePertinentInformation(RCMRMT030101UKObservationStatement observation) {

--- a/gp2gp-translator/src/main/java/uk/nhs/adaptors/pss/translator/mapper/DuplicateObservationStatementMapper.java
+++ b/gp2gp-translator/src/main/java/uk/nhs/adaptors/pss/translator/mapper/DuplicateObservationStatementMapper.java
@@ -79,7 +79,8 @@ public class DuplicateObservationStatementMapper {
         components.removeIf(component -> {
             var candidateObservationStatement = component.getObservationStatement();
 
-            if (isExactCodeableConceptDuplicate(observationStatement, candidateObservationStatement)) {
+            if (!hasSinglePertinentInformation(candidateObservationStatement)
+                        && isExactCodeableConceptDuplicate(observationStatement, candidateObservationStatement)) {
                 LOGGER.info("Removed duplicate ObservationStatement: '{}' matching '{}'.",
                             candidateObservationStatement.getId().getRoot(),
                             observationStatement.getId().getRoot());
@@ -146,7 +147,8 @@ public class DuplicateObservationStatementMapper {
     }
 
     private static boolean hasSinglePertinentInformation(RCMRMT030101UKObservationStatement observation) {
-        return observation.getPertinentInformation().size() == 1
+        return observation != null
+                && observation.getPertinentInformation().size() == 1
                 && observation.getPertinentInformation().getFirst().getSequenceNumber().getValue().intValueExact() == 1;
     }
 

--- a/gp2gp-translator/src/main/java/uk/nhs/adaptors/pss/translator/mapper/DuplicateObservationStatementMapper.java
+++ b/gp2gp-translator/src/main/java/uk/nhs/adaptors/pss/translator/mapper/DuplicateObservationStatementMapper.java
@@ -29,14 +29,14 @@ public class DuplicateObservationStatementMapper {
     public static final int CHAR_LIMIT_FOR_TRUNCATION = 50;
     public static final String ELLIPSIS = "...";
 
-    public void mergeDuplicateObservationStatements(RCMRMT030101UKEhrExtract ehrExtract) {
+    public void mergeOrRemoveDuplicateObservationStatements(RCMRMT030101UKEhrExtract ehrExtract) {
         ehrExtract.getComponent()
                 .stream()
                 .map(RCMRMT030101UKComponent::getEhrFolder)
                 .map(RCMRMT030101UKEhrFolder::getComponent)
                 .flatMap(List::stream)
                 .map(RCMRMT030101UKComponent3::getEhrComposition)
-                .forEach(DuplicateObservationStatementMapper::mergeDuplicateObservationStatements);
+                .forEach(DuplicateObservationStatementMapper::mergeOrRemoveDuplicateObservationStatements);
     }
 
     private static @NotNull Stream<RCMRMT030101UKEhrComposition> getEhrCompositionFromEhrExtract(RCMRMT030101UKEhrExtract ehrExtract) {
@@ -48,34 +48,18 @@ public class DuplicateObservationStatementMapper {
             .map(RCMRMT030101UKComponent3::getEhrComposition);
     }
 
-    public void removeDuplicateObservationStatements(RCMRMT030101UKEhrExtract ehrExtract) {
-        getEhrCompositionFromEhrExtract(ehrExtract)
-            .forEach(DuplicateObservationStatementMapper::removeDuplicateObservationStatements);
-    }
-
-    private static void removeDuplicateObservationStatements(RCMRMT030101UKEhrComposition ehrComposition) {
-        getLinksetsIn(ehrComposition).stream()
-            .map(id -> getLinkedObservationStatement(ehrComposition, id))
-            .filter(Optional::isPresent)
-            .map(Optional::get)
-            .filter(DuplicateObservationStatementMapper::hasSinglePertinentInformation)
-            .filter(DuplicateObservationStatementMapper::areAdditionalFieldsEmpty)
-            .forEach(observationStatement -> removeDeplicatedObservationStatements(observationStatement, ehrComposition.getComponent()));
-    }
-
-    private static void mergeDuplicateObservationStatements(RCMRMT030101UKEhrComposition ehrComposition) {
+    private static void mergeOrRemoveDuplicateObservationStatements(RCMRMT030101UKEhrComposition ehrComposition) {
         getLinksetsIn(ehrComposition).stream()
                 .map(id -> getLinkedObservationStatement(ehrComposition, id))
                 .filter(Optional::isPresent)
                 .map(Optional::get)
                 .filter(DuplicateObservationStatementMapper::hasSinglePertinentInformation)
-                .filter(DuplicateObservationStatementMapper::isAnnotationTruncated)
+                //.filter(DuplicateObservationStatementMapper::isAnnotationTruncated)
                 .filter(DuplicateObservationStatementMapper::areAdditionalFieldsEmpty)
-                .forEach(truncatedObservationStatement ->
-                        findAndMergeNonTruncatedObservationStatementIntoTruncatedObservationStatement(
-                                truncatedObservationStatement,
-                                ehrComposition.getComponent()
-                        ));
+                .forEach(observationStatement ->
+                             findAndMergeNonTruncatedObservationStatementIntoTruncatedObservationStatementOrRemoveDuplicates(
+                                 observationStatement,
+                                 ehrComposition.getComponent()));
     }
 
     @NotNull
@@ -91,8 +75,19 @@ public class DuplicateObservationStatementMapper {
                 .toList();
     }
 
-    private static void removeDeplicatedObservationStatements(RCMRMT030101UKObservationStatement observationStatementWithPertinentInfo,
-                                                              List<RCMRMT030101UKComponent4> components) {
+    private static void findAndMergeNonTruncatedObservationStatementIntoTruncatedObservationStatementOrRemoveDuplicates(
+            RCMRMT030101UKObservationStatement observationStatementWithPertinentInfo, List<RCMRMT030101UKComponent4> components) {
+
+
+        RCMRMT030101UKAnnotation truncatedPertinentAnnotation = null;
+        String annotationPrefix = null;
+        boolean isTruncated = isAnnotationTruncated(observationStatementWithPertinentInfo);
+
+        if (isTruncated) {
+            truncatedPertinentAnnotation = getPertinentAnnotation(observationStatementWithPertinentInfo);
+            String truncatedAnnotation = truncatedPertinentAnnotation.getText();
+            annotationPrefix = truncatedAnnotation.substring(0, truncatedAnnotation.length() - CHAR_LIMIT_FOR_TRUNCATION);
+        }
 
         for (Iterator<RCMRMT030101UKComponent4> observationIterator = components.iterator(); observationIterator.hasNext();) {
             var observationStatement = observationIterator.next().getObservationStatement();
@@ -100,49 +95,31 @@ public class DuplicateObservationStatementMapper {
                 && !areSameObservationStatements(observationStatementWithPertinentInfo, observationStatement)
                 && observationsAreCodedTheSame(observationStatementWithPertinentInfo, observationStatement)
                 && areAdditionalFieldsEmpty(observationStatement)) {
-                observationIterator.remove();
 
-                LOGGER.info("ObservationStatement: '{}' Is truncated version of '{}' and will be merged into a single observation.",
-                            observationStatementWithPertinentInfo.getId().getRoot(),
-                            observationStatement.getId().getRoot());
-                return;
+                if (isTruncated && hasSinglePertinentInformation(observationStatement)
+                    && doesTruncatedAnnotationMatchOtherAnnotation(truncatedPertinentAnnotation,
+                                                                   getPertinentAnnotation(observationStatement))) {
+
+                    observationIterator.remove();
+                    truncatedPertinentAnnotation.setText(annotationPrefix + getPertinentAnnotation(observationStatement).getText());
+                    LOGGER.info(
+                        "ObservationStatement: '{}' Is truncated version of '{}' and will be merged into a single observation.",
+                        observationStatementWithPertinentInfo.getId().getRoot(),
+                        observationStatement.getId().getRoot()
+                               );
+                    return;
+                } else if (!isTruncated) {
+                    observationIterator.remove();
+                    LOGGER.info("ObservationStatement: '{}' Is truncated version of '{}' and will be merged into a single observation.",
+                                observationStatementWithPertinentInfo.getId().getRoot(),
+                                observationStatement.getId().getRoot());
+                    return;
+                }
             }
         }
+
         LOGGER.info("ObservationStatement: '{}' appears to have been truncated but no match was found.",
                     observationStatementWithPertinentInfo.getId().getRoot());
-    }
-
-    private static void findAndMergeNonTruncatedObservationStatementIntoTruncatedObservationStatement(
-            RCMRMT030101UKObservationStatement truncatedObservationStatement, List<RCMRMT030101UKComponent4> components) {
-
-
-        RCMRMT030101UKAnnotation truncatedPertinentAnnotation = getPertinentAnnotation(truncatedObservationStatement);
-        String truncatedAnnotation = truncatedPertinentAnnotation.getText();
-        String annotationPrefix = truncatedAnnotation.substring(0, truncatedAnnotation.length() - CHAR_LIMIT_FOR_TRUNCATION);
-
-        for (Iterator<RCMRMT030101UKComponent4> observationIterator = components.iterator(); observationIterator.hasNext();) {
-            var observationStatement = observationIterator.next().getObservationStatement();
-            if (observationStatement != null
-                    && !areSameObservationStatements(truncatedObservationStatement, observationStatement)
-                    && hasSinglePertinentInformation(observationStatement)
-                    && doesTruncatedAnnotationMatchOtherAnnotation(truncatedPertinentAnnotation,
-                          getPertinentAnnotation(observationStatement))
-                    && observationsAreCodedTheSame(truncatedObservationStatement, observationStatement)
-                    && areAdditionalFieldsEmpty(observationStatement)) {
-                observationIterator.remove();
-                truncatedPertinentAnnotation.setText(annotationPrefix + getPertinentAnnotation(observationStatement).getText());
-                LOGGER.info(
-                        "ObservationStatement: '{}' Is truncated version of '{}' and will be merged into a single observation.",
-                        truncatedObservationStatement.getId().getRoot(),
-                        observationStatement.getId().getRoot()
-                );
-                return;
-            }
-        }
-        LOGGER.info(
-                "ObservationStatement: '{}' appears to have been truncated but no match was found.",
-                truncatedObservationStatement.getId().getRoot()
-        );
     }
 
     @NotNull
@@ -163,8 +140,8 @@ public class DuplicateObservationStatementMapper {
                 && observation.getPertinentInformation().getFirst().getSequenceNumber().getValue().intValueExact() == 1;
     }
 
-    private static boolean doesTruncatedAnnotationMatchOtherAnnotation(
-            RCMRMT030101UKAnnotation truncatedPertinentAnnotation, RCMRMT030101UKAnnotation candidateMatchingPertinentAnnotation) {
+    private static boolean doesTruncatedAnnotationMatchOtherAnnotation(RCMRMT030101UKAnnotation truncatedPertinentAnnotation,
+                                                                       RCMRMT030101UKAnnotation candidateMatchingPertinentAnnotation) {
         String truncatedObservationText = truncatedPertinentAnnotation.getText();
         String truncatedObservationTextWithoutEllipsis = truncatedObservationText.substring(
                 truncatedObservationText.length() - CHAR_LIMIT_FOR_TRUNCATION,

--- a/gp2gp-translator/src/main/java/uk/nhs/adaptors/pss/translator/mapper/DuplicateObservationStatementMapper.java
+++ b/gp2gp-translator/src/main/java/uk/nhs/adaptors/pss/translator/mapper/DuplicateObservationStatementMapper.java
@@ -105,8 +105,10 @@ public class DuplicateObservationStatementMapper {
             }
         }
 
-        LOGGER.info("ObservationStatement: '{}' appears to have been truncated but no match was found.",
-                    observationStatementWithPertinentInfo.getId().getRoot());
+        if (isTruncated) {
+            LOGGER.info("ObservationStatement: '{}' appears to have been truncated but no match was found.",
+                        observationStatementWithPertinentInfo.getId().getRoot());
+        }
     }
 
     @NotNull

--- a/gp2gp-translator/src/main/java/uk/nhs/adaptors/pss/translator/service/BundleMapperService.java
+++ b/gp2gp-translator/src/main/java/uk/nhs/adaptors/pss/translator/service/BundleMapperService.java
@@ -95,8 +95,8 @@ public class BundleMapperService {
 
             Bundle bundle = generator.generateBundle();
             final RCMRMT030101UKEhrExtract ehrExtract = getEhrExtract(xmlMessage);
-            duplicateObservationStatementMapper.mergeDuplicateObservationStatements(ehrExtract);
-            duplicateObservationStatementMapper.removeDuplicateObservationStatements(ehrExtract);
+            duplicateObservationStatementMapper.mergeOrRemoveDuplicateObservationStatements(ehrExtract);
+
             final RCMRMT030101UKEhrFolder ehrFolder = getEhrFolder(xmlMessage);
 
             var locations = mapLocations(ehrFolder, losingPracticeOdsCode);

--- a/gp2gp-translator/src/main/java/uk/nhs/adaptors/pss/translator/service/BundleMapperService.java
+++ b/gp2gp-translator/src/main/java/uk/nhs/adaptors/pss/translator/service/BundleMapperService.java
@@ -96,6 +96,7 @@ public class BundleMapperService {
             Bundle bundle = generator.generateBundle();
             final RCMRMT030101UKEhrExtract ehrExtract = getEhrExtract(xmlMessage);
             duplicateObservationStatementMapper.mergeDuplicateObservationStatements(ehrExtract);
+            duplicateObservationStatementMapper.removeDuplicateObservationStatements(ehrExtract);
             final RCMRMT030101UKEhrFolder ehrFolder = getEhrFolder(xmlMessage);
 
             var locations = mapLocations(ehrFolder, losingPracticeOdsCode);

--- a/gp2gp-translator/src/test/java/uk/nhs/adaptors/pss/translator/mapper/DuplicateObservationStatementMapperTest.java
+++ b/gp2gp-translator/src/test/java/uk/nhs/adaptors/pss/translator/mapper/DuplicateObservationStatementMapperTest.java
@@ -51,29 +51,6 @@ class DuplicateObservationStatementMapperTest {
     private final DuplicateObservationStatementMapper mapper = new DuplicateObservationStatementMapper();
 
     @Test
-    public void doesntMergeObservationNorDeleteItWhereObservationsAreTheSameAndHaveDifferentSameCodeableConcepts() {
-        Logger fooLogger = (Logger) LoggerFactory.getLogger(DuplicateObservationStatementMapper.class);
-        ListAppender<ILoggingEvent> listAppender = new ListAppender<>();
-        listAppender.start();
-        fooLogger.addAppender(listAppender);
-
-        var ehrExtract = createExtract(List.of(
-            createObservation("ID-1", "101", "This text is too short to be replaced and should be replaced..."),
-            createObservation("ID-2", "102", "This text is too short to be replaced and should be replaced."),
-            generateLinksetComponent("ID-1")));
-
-        mapper.mergeOrRemoveDuplicateObservationStatements(ehrExtract);
-
-        assertThat(firstEhrComposition(ehrExtract)).hasSize(3);
-
-        List<ILoggingEvent> logsList = listAppender.list;
-        assertEquals(Level.INFO, logsList.get(0).getLevel());
-        assertEquals("ObservationStatement: 'ID-1' appears to have been truncated but no match was found.",
-                     logsList.get(0).getFormattedMessage());
-
-    }
-
-    @Test
     public void ignoresLinksetsWithoutAConditionNamedElement() {
         var ehrExtract = createExtract(List.of(
                 generateLinksetComponent()
@@ -187,15 +164,24 @@ class DuplicateObservationStatementMapperTest {
 
     @Test
     public void doesntMergeObservationWhereTheCodesArentTheSame() {
+        Logger fooLogger = (Logger) LoggerFactory.getLogger(DuplicateObservationStatementMapper.class);
+        ListAppender<ILoggingEvent> listAppender = new ListAppender<>();
+        listAppender.start();
+        fooLogger.addAppender(listAppender);
+
         var ehrExtract = createExtract(List.of(
-                createObservation("ID-1", "101", "This is an observation which ends with ellipses..."),
-                createObservation("ID-2", "102", "This is an observation which ends with ellipses but there is more."),
-                generateLinksetComponent("ID-1")
-        ));
+            createObservation("ID-1", "101", "This is an observation which ends with ellipses..."),
+            createObservation("ID-2", "102", "This is an observation which ends with ellipses but there is more."),
+            generateLinksetComponent("ID-1")
+                                              ));
 
         mapper.mergeOrRemoveDuplicateObservationStatements(ehrExtract);
 
         assertThat(firstEhrComposition(ehrExtract)).hasSize(3);
+        List<ILoggingEvent> logsList = listAppender.list;
+        assertEquals(Level.INFO, logsList.get(0).getLevel());
+        assertEquals("ObservationStatement: 'ID-1' appears to have been truncated but no match was found.",
+                     logsList.get(0).getFormattedMessage());
     }
 
 

--- a/gp2gp-translator/src/test/java/uk/nhs/adaptors/pss/translator/mapper/DuplicateObservationStatementMapperTest.java
+++ b/gp2gp-translator/src/test/java/uk/nhs/adaptors/pss/translator/mapper/DuplicateObservationStatementMapperTest.java
@@ -161,7 +161,6 @@ class DuplicateObservationStatementMapperTest {
         assertThat(firstEhrComposition(ehrExtract)).hasSize(3);
     }
 
-
     @Test
     public void doesntMergeObservationWhereTheCodesArentTheSame() {
         Logger fooLogger = (Logger) LoggerFactory.getLogger(DuplicateObservationStatementMapper.class);

--- a/gp2gp-translator/src/test/java/uk/nhs/adaptors/pss/translator/mapper/DuplicateObservationStatementMapperTest.java
+++ b/gp2gp-translator/src/test/java/uk/nhs/adaptors/pss/translator/mapper/DuplicateObservationStatementMapperTest.java
@@ -253,7 +253,7 @@ class DuplicateObservationStatementMapperTest {
     public void doesntMergeObservationWhereTheObservationDoesNotEndInEllipses() {
         var ehrExtract = createExtract(List.of(
                 createObservation("ID-1", "101", "This is an observation doesnt end with ellipses:::"),
-                createObservation("ID-2", "102", "This is an observation which ends with ellipses removed."),
+                createObservation("ID-2", "101", "This is an observation which ends with ellipses removed."),
                 generateLinksetComponent("ID-1")
         ));
 
@@ -284,6 +284,19 @@ class DuplicateObservationStatementMapperTest {
         mapper.mergeOrRemoveDuplicateObservationStatements(ehrExtract);
 
         assertThat(firstEhrComposition(ehrExtract)).hasSize(2);
+    }
+
+    @Test
+    public void doesNotRemoveObservationWithTwoPertinentAnnotations() {
+        var ehrExtract = createExtract(
+            List.of(createObservation("ID-1", "101", "This is an observation doesnt end with ellipses:::"),
+                    createObservationWithTwoPertinentAnnotations("ID-2", "101", "Pertinent annotation 1",
+                                                                 "Pertinent annotation 2"),
+                    generateLinksetComponent("ID-1")));
+
+        mapper.mergeOrRemoveDuplicateObservationStatements(ehrExtract);
+
+        assertThat(firstEhrComposition(ehrExtract)).hasSize(3);
     }
 
     @Test
@@ -414,8 +427,30 @@ class DuplicateObservationStatementMapperTest {
     }
 
     @NotNull
+    private static RCMRMT030101UKComponent4 createObservationWithTwoPertinentAnnotations(String id,
+                                                                                         String code,
+                                                                                         String pertinentAnnotation1,
+                                                                                         String pertinentAnnotation2) {
+        return createObservationWithTwoPertinentAnnotations(id, generateCodeableConcept(code),
+                                                            pertinentAnnotation1, pertinentAnnotation2, 1);
+    }
+
+    @NotNull
     private static RCMRMT030101UKComponent4 createObservation(String id, String code, String pertinentAnnotation) {
         return createObservation(id, generateCodeableConcept(code), pertinentAnnotation, 1);
+    }
+
+    @NotNull
+    private static RCMRMT030101UKComponent4 createObservationWithTwoPertinentAnnotations(
+        String id, @NotNull CD code, String pertinentAnnotation1, String pertinentAnnotation2, int annotationSequenceNumber) {
+        RCMRMT030101UKComponent4 rcmrmt030101UKComponent4 = new RCMRMT030101UKComponent4();
+        RCMRMT030101UKObservationStatement observationStatement = new RCMRMT030101UKObservationStatement();
+        observationStatement.setCode(code);
+        observationStatement.setId(generateId(id));
+        observationStatement.getPertinentInformation().add(getPertinentInformation(pertinentAnnotation1, annotationSequenceNumber));
+        observationStatement.getPertinentInformation().add(getPertinentInformation(pertinentAnnotation2, annotationSequenceNumber + 1));
+        rcmrmt030101UKComponent4.setObservationStatement(observationStatement);
+        return rcmrmt030101UKComponent4;
     }
 
     @NotNull

--- a/gp2gp-translator/src/test/java/uk/nhs/adaptors/pss/translator/mapper/DuplicateObservationStatementMapperTest.java
+++ b/gp2gp-translator/src/test/java/uk/nhs/adaptors/pss/translator/mapper/DuplicateObservationStatementMapperTest.java
@@ -263,10 +263,22 @@ class DuplicateObservationStatementMapperTest {
     }
 
     @Test
-    public void removeObservationWhereTheObservationDoesNotEndInEllipsesButCodeableConceptCodesAreTheSame() {
+    public void doNotRemoveObservationWhereTheObservationDoesNotEndInEllipsesButObservationStatementsAllHavePertinentAnnotation() {
         var ehrExtract = createExtract(
             List.of(createObservation("ID-1", "101", "This is an observation doesnt end with ellipses:::"),
                     createObservation("ID-2", "101", "This is an observation which ends with ellipses removed."),
+                    generateLinksetComponent("ID-1")));
+
+        mapper.mergeOrRemoveDuplicateObservationStatements(ehrExtract);
+
+        assertThat(firstEhrComposition(ehrExtract)).hasSize(3);
+    }
+
+    @Test
+    public void removeObservationWhereTheObservationDoesNotEndInEllipsesButCodeableConceptCodesAreTheSame() {
+        var ehrExtract = createExtract(
+            List.of(createObservation("ID-1", "101", "This is an observation doesnt end with ellipses:::"),
+                    createObservationWithoutPertinentAnnotation("ID-2", "101"),
                     generateLinksetComponent("ID-1")));
 
         mapper.mergeOrRemoveDuplicateObservationStatements(ehrExtract);
@@ -397,6 +409,11 @@ class DuplicateObservationStatementMapperTest {
     }
 
     @NotNull
+    private static RCMRMT030101UKComponent4 createObservationWithoutPertinentAnnotation(String id, String code) {
+        return createObservationWithoutPertinentAnnotation(id, generateCodeableConcept(code));
+    }
+
+    @NotNull
     private static RCMRMT030101UKComponent4 createObservation(String id, String code, String pertinentAnnotation) {
         return createObservation(id, generateCodeableConcept(code), pertinentAnnotation, 1);
     }
@@ -409,6 +426,16 @@ class DuplicateObservationStatementMapperTest {
         observationStatement.setCode(code);
         observationStatement.setId(generateId(id));
         observationStatement.getPertinentInformation().add(getPertinentInformation(pertinentAnnotation, annotationSequenceNumber));
+        rcmrmt030101UKComponent4.setObservationStatement(observationStatement);
+        return rcmrmt030101UKComponent4;
+    }
+
+    @NotNull
+    private static RCMRMT030101UKComponent4 createObservationWithoutPertinentAnnotation(String id, @NotNull CD code) {
+        RCMRMT030101UKComponent4 rcmrmt030101UKComponent4 = new RCMRMT030101UKComponent4();
+        RCMRMT030101UKObservationStatement observationStatement = new RCMRMT030101UKObservationStatement();
+        observationStatement.setCode(code);
+        observationStatement.setId(generateId(id));
         rcmrmt030101UKComponent4.setObservationStatement(observationStatement);
         return rcmrmt030101UKComponent4;
     }

--- a/gp2gp-translator/src/test/java/uk/nhs/adaptors/pss/translator/mapper/DuplicateObservationStatementMapperTest.java
+++ b/gp2gp-translator/src/test/java/uk/nhs/adaptors/pss/translator/mapper/DuplicateObservationStatementMapperTest.java
@@ -49,7 +49,7 @@ class DuplicateObservationStatementMapperTest {
                 generateLinksetComponent()
         ));
 
-        mapper.mergeDuplicateObservationStatements(ehrExtract);
+        mapper.mergeOrRemoveDuplicateObservationStatements(ehrExtract);
 
         assertThat(firstEhrComposition(ehrExtract)).hasSize(1);
     }
@@ -62,7 +62,7 @@ class DuplicateObservationStatementMapperTest {
                 generateLinksetComponent("ID-1")
         ));
 
-        mapper.mergeDuplicateObservationStatements(ehrExtract);
+        mapper.mergeOrRemoveDuplicateObservationStatements(ehrExtract);
 
         assertThat(firstEhrComposition(ehrExtract)).hasSize(2);
         assertThat(firstEhrComposition(ehrExtract).getFirst().getObservationStatement().getId().getRoot()).isEqualTo("ID-1");
@@ -77,7 +77,7 @@ class DuplicateObservationStatementMapperTest {
                 generateLinksetComponent("ID-1")
         ));
 
-        mapper.mergeDuplicateObservationStatements(ehrExtract);
+        mapper.mergeOrRemoveDuplicateObservationStatements(ehrExtract);
 
         assertThat(firstEhrComposition(ehrExtract)).hasSize(3);
         assertThat(firstEhrComposition(ehrExtract).getFirst().getObservationStatement().getId().getRoot()).isEqualTo("ID-3");
@@ -94,7 +94,7 @@ class DuplicateObservationStatementMapperTest {
                 )
         );
 
-        mapper.mergeDuplicateObservationStatements(ehrExtract);
+        mapper.mergeOrRemoveDuplicateObservationStatements(ehrExtract);
 
         assertThat(secondEhrComposition(firstEhrFolder(ehrExtract)).getComponent()).hasSize(2);
     }
@@ -110,7 +110,7 @@ class DuplicateObservationStatementMapperTest {
                 ))
         );
 
-        mapper.mergeDuplicateObservationStatements(ehrExtract);
+        mapper.mergeOrRemoveDuplicateObservationStatements(ehrExtract);
 
         assertThat(firstEhrComposition(secondEhrFolder(ehrExtract)).getComponent()).hasSize(2);
     }
@@ -123,7 +123,7 @@ class DuplicateObservationStatementMapperTest {
                 createObservation("ID-1", "101", "This is an observation which ends with ellipses...")
         ));
 
-        mapper.mergeDuplicateObservationStatements(ehrExtract);
+        mapper.mergeOrRemoveDuplicateObservationStatements(ehrExtract);
 
         assertThat(firstEhrComposition(ehrExtract)).hasSize(3);
     }
@@ -136,7 +136,7 @@ class DuplicateObservationStatementMapperTest {
                 generateLinksetComponent("ID-3")
         ));
 
-        mapper.mergeDuplicateObservationStatements(ehrExtract);
+        mapper.mergeOrRemoveDuplicateObservationStatements(ehrExtract);
 
         assertThat(firstEhrComposition(ehrExtract)).hasSize(3);
     }
@@ -149,7 +149,7 @@ class DuplicateObservationStatementMapperTest {
                 generateLinksetComponent("ID-1")
         ));
 
-        mapper.mergeDuplicateObservationStatements(ehrExtract);
+        mapper.mergeOrRemoveDuplicateObservationStatements(ehrExtract);
 
         assertThat(firstEhrComposition(ehrExtract)).hasSize(3);
     }
@@ -163,7 +163,7 @@ class DuplicateObservationStatementMapperTest {
                 generateLinksetComponent("ID-1")
         ));
 
-        mapper.mergeDuplicateObservationStatements(ehrExtract);
+        mapper.mergeOrRemoveDuplicateObservationStatements(ehrExtract);
 
         assertThat(firstEhrComposition(ehrExtract)).hasSize(3);
     }
@@ -177,7 +177,7 @@ class DuplicateObservationStatementMapperTest {
                 generateLinksetComponent("ID-1")
         ));
 
-        mapper.mergeDuplicateObservationStatements(ehrExtract);
+        mapper.mergeOrRemoveDuplicateObservationStatements(ehrExtract);
 
         assertThat(firstEhrComposition(ehrExtract)).hasSize(2);
     }
@@ -190,7 +190,7 @@ class DuplicateObservationStatementMapperTest {
                 generateLinksetComponent("ID-1")
         ));
 
-        mapper.mergeDuplicateObservationStatements(ehrExtract);
+        mapper.mergeOrRemoveDuplicateObservationStatements(ehrExtract);
 
         assertThat(firstEhrComposition(ehrExtract)).hasSize(3);
     }
@@ -203,7 +203,7 @@ class DuplicateObservationStatementMapperTest {
                 generateLinksetComponent("ID-1")
         ));
 
-        mapper.mergeDuplicateObservationStatements(ehrExtract);
+        mapper.mergeOrRemoveDuplicateObservationStatements(ehrExtract);
 
         assertThat(firstEhrComposition(ehrExtract)).hasSize(3);
     }
@@ -216,7 +216,7 @@ class DuplicateObservationStatementMapperTest {
                 generateLinksetComponent("ID-1")
         ));
 
-        mapper.mergeDuplicateObservationStatements(ehrExtract);
+        mapper.mergeOrRemoveDuplicateObservationStatements(ehrExtract);
 
         assertThat(firstEhrComposition(ehrExtract)).hasSize(3);
     }
@@ -229,7 +229,7 @@ class DuplicateObservationStatementMapperTest {
             generateLinksetComponent("ID-1")
         ));
 
-        mapper.mergeDuplicateObservationStatements(ehrExtract);
+        mapper.mergeOrRemoveDuplicateObservationStatements(ehrExtract);
 
         assertThat(firstEhrComposition(ehrExtract)).hasSize(3);
     }
@@ -242,7 +242,7 @@ class DuplicateObservationStatementMapperTest {
                 generateLinksetComponent("ID-1")
         ));
 
-        mapper.mergeDuplicateObservationStatements(ehrExtract);
+        mapper.mergeOrRemoveDuplicateObservationStatements(ehrExtract);
 
         assertThat(firstEhrComposition(ehrExtract)).hasSize(3);
     }
@@ -255,7 +255,7 @@ class DuplicateObservationStatementMapperTest {
                 generateLinksetComponent("ID-1")
         ));
 
-        mapper.mergeDuplicateObservationStatements(ehrExtract);
+        mapper.mergeOrRemoveDuplicateObservationStatements(ehrExtract);
 
         assertThat(firstEhrComposition(ehrExtract)).hasSize(3);
     }
@@ -268,7 +268,7 @@ class DuplicateObservationStatementMapperTest {
                 generateLinksetComponent("ID-1")
         ));
 
-        mapper.mergeDuplicateObservationStatements(ehrExtract);
+        mapper.mergeOrRemoveDuplicateObservationStatements(ehrExtract);
 
         assertThat(firstPertinentInformationText(firstEhrComposition(ehrExtract).getFirst().getObservationStatement())).isEqualTo(
                 "FIRST PREFIX SECOND PREFIX This is an observation which ends with ellipses removed."
@@ -286,7 +286,7 @@ class DuplicateObservationStatementMapperTest {
                 generateLinksetComponent("ID-3")
         ));
 
-        mapper.mergeDuplicateObservationStatements(ehrExtract);
+        mapper.mergeOrRemoveDuplicateObservationStatements(ehrExtract);
 
         assertThat(firstEhrComposition(ehrExtract)).hasSize(4);
     }
@@ -303,7 +303,7 @@ class DuplicateObservationStatementMapperTest {
                 generateLinksetComponent("ID-1")
         ));
 
-        mapper.mergeDuplicateObservationStatements(ehrExtract);
+        mapper.mergeOrRemoveDuplicateObservationStatements(ehrExtract);
         assertThat(firstEhrComposition(ehrExtract)).hasSize(3);
 
     }
@@ -321,7 +321,7 @@ class DuplicateObservationStatementMapperTest {
                 generateLinksetComponent("ID-1")
         ));
 
-        mapper.mergeDuplicateObservationStatements(ehrExtract);
+        mapper.mergeOrRemoveDuplicateObservationStatements(ehrExtract);
         assertThat(firstEhrComposition(ehrExtract)).hasSize(3);
 
     }

--- a/gp2gp-translator/src/test/java/uk/nhs/adaptors/pss/translator/mapper/DuplicateObservationStatementMapperTest.java
+++ b/gp2gp-translator/src/test/java/uk/nhs/adaptors/pss/translator/mapper/DuplicateObservationStatementMapperTest.java
@@ -1,8 +1,5 @@
 package uk.nhs.adaptors.pss.translator.mapper;
 
-import com.github.valfirst.slf4jtest.LoggingEvent;
-import com.github.valfirst.slf4jtest.TestLogger;
-import com.github.valfirst.slf4jtest.TestLoggerFactory;
 import org.hl7.v3.CD;
 import org.hl7.v3.CV;
 import org.hl7.v3.II;
@@ -29,13 +26,11 @@ import org.hl7.v3.RCMRMT030101UKSpecimen;
 import org.hl7.v3.RCMRMT030101UKStatementRef;
 import org.hl7.v3.RCMRMT030101UKSubject;
 import org.jetbrains.annotations.NotNull;
-import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Named;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
-import org.slf4j.event.Level;
 
 import java.math.BigInteger;
 import java.util.List;
@@ -43,37 +38,11 @@ import java.util.function.Consumer;
 import java.util.stream.Stream;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.jupiter.api.Assertions.assertEquals;
 
 @SuppressWarnings("checkstyle:MagicNumber")
 class DuplicateObservationStatementMapperTest {
 
     private final DuplicateObservationStatementMapper mapper = new DuplicateObservationStatementMapper();
-
-    private final TestLogger logger = TestLoggerFactory.getTestLogger(DuplicateObservationStatementMapper.class);
-
-    @AfterEach
-    void tearDown() {
-        logger.clear();
-    }
-
-    @Test
-    public void doesntMergeObservationNorDeleteItWhereObservationsAreTheSameAndHaveDifferentSameCodeableConcepts() {
-
-        var ehrExtract = createExtract(List.of(
-            createObservation("ID-1", "101", "This text is too short to be replaced and should be replaced..."),
-            createObservation("ID-2", "102", "This text is too short to be replaced and should be replaced."),
-            generateLinksetComponent("ID-1")));
-
-        mapper.mergeOrRemoveDuplicateObservationStatements(ehrExtract);
-
-        assertThat(firstEhrComposition(ehrExtract)).hasSize(3);
-        LoggingEvent loggingEvent = logger.getLoggingEvents().get(0);
-        assertEquals(Level.INFO, loggingEvent.getLevel());
-        assertEquals("ObservationStatement: '{}' appears to have been truncated but no match was found.",
-                     loggingEvent.getMessage());
-        assertEquals("ID-1", loggingEvent.getArguments().get(0));
-    }
 
     @Test
     public void ignoresLinksetsWithoutAConditionNamedElement() {

--- a/gp2gp-translator/src/test/java/uk/nhs/adaptors/pss/translator/mapper/DuplicateObservationStatementMapperTest.java
+++ b/gp2gp-translator/src/test/java/uk/nhs/adaptors/pss/translator/mapper/DuplicateObservationStatementMapperTest.java
@@ -235,10 +235,10 @@ class DuplicateObservationStatementMapperTest {
     }
 
     @Test
-    public void doesntMergeObservationWhereTheObservationDoesNotEndInEllipses() {
+    public void doesntMergeObservationWhereTheObservationDoesNotEndInEllipsesAndCodeableConceptCodesAreDifferent() {
         var ehrExtract = createExtract(List.of(
                 createObservation("ID-1", "101", "This is an observation doesnt end with ellipses:::"),
-                createObservation("ID-2", "101", "This is an observation which ends with ellipses removed."),
+                createObservation("ID-2", "102", "This is an observation which ends with ellipses removed."),
                 generateLinksetComponent("ID-1")
         ));
 
@@ -248,16 +248,40 @@ class DuplicateObservationStatementMapperTest {
     }
 
     @Test
-    public void doesntMergeObservationWhereTheObservationIsLessThan47Chars() {
+    public void removeObservationWhereTheObservationDoesNotEndInEllipsesButCodeableConceptCodesAreTheSame() {
+        var ehrExtract = createExtract(
+            List.of(createObservation("ID-1", "101", "This is an observation doesnt end with ellipses:::"),
+                    createObservation("ID-2", "101", "This is an observation which ends with ellipses removed."),
+                    generateLinksetComponent("ID-1")));
+
+        mapper.mergeOrRemoveDuplicateObservationStatements(ehrExtract);
+
+        assertThat(firstEhrComposition(ehrExtract)).hasSize(2);
+    }
+
+    @Test
+    public void doesntMergeObservationWhereTheObservationIsLessThan47CharsAndCodeableConceptsAreDifferent() {
         var ehrExtract = createExtract(List.of(
                 createObservation("ID-1", "101", "This text is too short..."),
-                createObservation("ID-2", "101", "This text is too short to be replaced."),
+                createObservation("ID-2", "102", "This text is too short to be replaced."),
                 generateLinksetComponent("ID-1")
         ));
 
         mapper.mergeOrRemoveDuplicateObservationStatements(ehrExtract);
 
         assertThat(firstEhrComposition(ehrExtract)).hasSize(3);
+    }
+
+    @Test
+    public void removeObservationWhereTheObservationIsLessThan47CharsButCodeableConceptsAreTheSame() {
+        var ehrExtract = createExtract(
+            List.of(createObservation("ID-1", "101", "This text is too short..."),
+                    createObservation("ID-2", "101", "This text is too short to be replaced."),
+                    generateLinksetComponent("ID-1")));
+
+        mapper.mergeOrRemoveDuplicateObservationStatements(ehrExtract);
+
+        assertThat(firstEhrComposition(ehrExtract)).hasSize(2);
     }
 
     @Test

--- a/gp2gp-translator/src/test/java/uk/nhs/adaptors/pss/translator/mapper/DuplicateObservationStatementMapperTest.java
+++ b/gp2gp-translator/src/test/java/uk/nhs/adaptors/pss/translator/mapper/DuplicateObservationStatementMapperTest.java
@@ -250,7 +250,7 @@ class DuplicateObservationStatementMapperTest {
     }
 
     @Test
-    public void doesntMergeObservationWhereTheObservationDoesNotEndInEllipsesAndCodeableConceptCodesAreDifferent() {
+    public void doesntMergeObservationWhereTheObservationDoesNotEndInEllipses() {
         var ehrExtract = createExtract(List.of(
                 createObservation("ID-1", "101", "This is an observation doesnt end with ellipses:::"),
                 createObservation("ID-2", "102", "This is an observation which ends with ellipses removed."),
@@ -285,18 +285,6 @@ class DuplicateObservationStatementMapperTest {
         mapper.mergeOrRemoveDuplicateObservationStatements(ehrExtract);
 
         assertThat(firstEhrComposition(ehrExtract)).hasSize(3);
-    }
-
-    @Test
-    public void removeObservationWhereTheObservationIsLessThan47CharsButCodeableConceptsAreTheSame() {
-        var ehrExtract = createExtract(
-            List.of(createObservation("ID-1", "101", "This text is too short..."),
-                    createObservation("ID-2", "101", "This text is too short to be replaced."),
-                    generateLinksetComponent("ID-1")));
-
-        mapper.mergeOrRemoveDuplicateObservationStatements(ehrExtract);
-
-        assertThat(firstEhrComposition(ehrExtract)).hasSize(2);
     }
 
     @Test

--- a/gp2gp-translator/src/test/java/uk/nhs/adaptors/pss/translator/mapper/DuplicateObservationStatementMapperTest.java
+++ b/gp2gp-translator/src/test/java/uk/nhs/adaptors/pss/translator/mapper/DuplicateObservationStatementMapperTest.java
@@ -275,7 +275,7 @@ class DuplicateObservationStatementMapperTest {
     }
 
     @Test
-    public void removeObservationWhereTheObservationDoesNotEndInEllipsesButCodeableConceptCodesAreTheSame() {
+    public void removeObservationWithoutPertinentAnnotation() {
         var ehrExtract = createExtract(
             List.of(createObservation("ID-1", "101", "This is an observation doesnt end with ellipses:::"),
                     createObservationWithoutPertinentAnnotation("ID-2", "101"),

--- a/gp2gp-translator/src/test/java/uk/nhs/adaptors/pss/translator/service/BundleMapperServiceTest.java
+++ b/gp2gp-translator/src/test/java/uk/nhs/adaptors/pss/translator/service/BundleMapperServiceTest.java
@@ -154,7 +154,7 @@ public class BundleMapperServiceTest {
 
         verify(patientMapper).mapToPatient(any(RCMRMT030101UKPatient.class), any(Organization.class));
         verify(organizationMapper).mapAuthorOrganization(anyString(), anyList());
-        verify(duplicateObservationStatementMapper).mergeDuplicateObservationStatements(any(RCMRMT030101UKEhrExtract.class));
+        verify(duplicateObservationStatementMapper).mergeOrRemoveDuplicateObservationStatements(any(RCMRMT030101UKEhrExtract.class));
         verify(agentDirectoryMapper).mapAgentDirectory(any(RCMRMT030101UKAgentDirectory.class));
         verify(locationMapper, atLeast(1)).mapToLocation(any(RCMRMT030101UKLocation.class), anyString());
         verify(encounterMapper).mapEncounters(any(RCMRMT030101UKEhrExtract.class), any(Patient.class), anyString(), anyList());


### PR DESCRIPTION
## What

Remove duplicate Observations with the same codeable concepts

## Why

This PR provides the removal of duplicate observations with the same codeable concepts that cause double entries in the final JSON output rendered by the PS Adaptor.

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Internal change (non-breaking change with no effect on the functionality affecting end users)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:

- [ ] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I have updated the [Changelog](/CHANGELOG.md) with details of my change in the UNRELEASED section if this change will affect end users
- [ ] A corresponding change has been made to the [Mapping Documentation repository][mapping-docs]

[mapping-docs]: https://github.com/NHSDigital/patient-switching-adaptors-mapping-documentation