### PR TITLE
Expose check for if `ehrSupplyAuthorise` is an acute prescription

### DIFF
--- a/gp2gp-translator/src/main/java/uk/nhs/adaptors/pss/translator/mapper/medication/MedicationMapperUtils.java
+++ b/gp2gp-translator/src/main/java/uk/nhs/adaptors/pss/translator/mapper/medication/MedicationMapperUtils.java
@@ -38,6 +38,7 @@ import org.hl7.v3.RCMRMT030101UKMedicationDosage;
 import lombok.extern.slf4j.Slf4j;
 import org.hl7.v3.RCMRMT030101UKReversalOf;
 import org.hl7.v3.RCMRMT030101UKSupplyAnnotation;
+import org.jetbrains.annotations.NotNull;
 import uk.nhs.adaptors.pss.translator.util.CompoundStatementUtil;
 import uk.nhs.adaptors.pss.translator.util.DateFormatUtil;
 
@@ -55,7 +56,7 @@ public class MedicationMapperUtils {
         = "https://fhir.nhs.uk/STU3/CodeSystem/CareConnect-PrescriptionType-1";
 
     public static Optional<Extension> buildPrescriptionTypeExtension(RCMRMT030101UKAuthorise supplyAuthorise) {
-        if (supplyAuthorise != null && supplyAuthorise.hasRepeatNumber() && supplyAuthorise.getRepeatNumber().getValue().intValue() == 0) {
+        if (supplyAuthorise != null && isAcutePrescription(supplyAuthorise)) {
             return Optional.of(new Extension(PRESCRIPTION_TYPE_EXTENSION_URL, new CodeableConcept(
                 new Coding(PRESCRIPTION_TYPE_CODING_SYSTEM, ACUTE.toLowerCase(), ACUTE)
             )));
@@ -63,6 +64,11 @@ public class MedicationMapperUtils {
         return Optional.of(new Extension(PRESCRIPTION_TYPE_EXTENSION_URL, new CodeableConcept(
             new Coding(PRESCRIPTION_TYPE_CODING_SYSTEM, REPEAT.toLowerCase(), REPEAT)
         )));
+    }
+
+    public static boolean isAcutePrescription(@NotNull RCMRMT030101UKAuthorise supplyAuthorise) {
+        return supplyAuthorise.hasRepeatNumber()
+            && supplyAuthorise.getRepeatNumber().getValue().intValue() == 0;
     }
 
     public static List<Annotation> buildNotes(List<RCMRMT030101UKPertinentInformation2> pertinentInformationList) {

--- a/gp2gp-translator/src/test/java/uk/nhs/adaptors/pss/translator/mapper/medication/MedicationMapperUtilsTest.java
+++ b/gp2gp-translator/src/test/java/uk/nhs/adaptors/pss/translator/mapper/medication/MedicationMapperUtilsTest.java
@@ -172,9 +172,9 @@ public class MedicationMapperUtilsTest {
 
     @NotNull
     private static INT createINTFromInteger(int value) {
-        INT i = new INT();
-        i.setValue(BigInteger.valueOf(value));
-        return i;
+        INT intValue = new INT();
+        intValue.setValue(BigInteger.valueOf(value));
+        return intValue;
     }
 
 }


### PR DESCRIPTION
## What

* Added public method `isAcutePrescription` to check if the provided `ehrSupplyPrescribe` has a `repeatNumber` with a value of `0`.
* Added unit tests for the above.

## Why

So that this check can be consumed in the `MedicationRequestMapper` without needing to duplicate code.

## Type of change

Please delete options that are not relevant.

- [x] Internal change (non-breaking change with no effect on the functionality affecting end users)

## Checklist:

- [x] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] I have updated the [Changelog](/CHANGELOG.md) with details of my change in the UNRELEASED section if this change will affect end users
- [ ] A corresponding change has been made to the [Mapping Documentation repository][mapping-docs]

[mapping-docs]: https://github.com/NHSDigital/patient-switching-adaptors-mapping-documentation