### PR TITLE
Move Plan Mapping

### DIFF
--- a/gp2gp-translator/src/main/java/uk/nhs/adaptors/pss/translator/mapper/medication/MedicationMapperContext.java
+++ b/gp2gp-translator/src/main/java/uk/nhs/adaptors/pss/translator/mapper/medication/MedicationMapperContext.java
@@ -1,6 +1,7 @@
 package uk.nhs.adaptors.pss.translator.mapper.medication;
 
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.function.Function;
 
@@ -17,6 +18,7 @@ public class MedicationMapperContext {
     private final IdGeneratorService idGeneratorService;
 
     private final ThreadLocal<Map<String, String>> medicationIds = ThreadLocal.withInitial(HashMap::new);
+    private final ThreadLocal<Map<String, List<String>>> generatedPlanIdMap = ThreadLocal.withInitial(HashMap::new);
 
     public String getMedicationId(CD code) {
         var key = buildKey(code);
@@ -29,6 +31,14 @@ public class MedicationMapperContext {
             medicationIds.get().put(key, newId);
             return newId;
         }
+    }
+
+    public void addSupplyAuthoriseIdToGeneratedIdsMapping(String supplyAuthoriseId, List<String> generatedPlanIds) {
+        generatedPlanIdMap.get().put(supplyAuthoriseId, generatedPlanIds);
+    }
+
+    public List<String> getGeneratedPlansIdsByOriginalPlanId(String originalPlanId) {
+        return generatedPlanIdMap.get().getOrDefault(originalPlanId, List.of());
     }
 
     public void reset() {

--- a/gp2gp-translator/src/main/java/uk/nhs/adaptors/pss/translator/mapper/medication/MedicationRequestMapper.java
+++ b/gp2gp-translator/src/main/java/uk/nhs/adaptors/pss/translator/mapper/medication/MedicationRequestMapper.java
@@ -7,6 +7,7 @@ import static uk.nhs.adaptors.pss.translator.util.CompoundStatementResourceExtra
 
 import java.util.AbstractMap;
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.Comparator;
 import java.util.List;
 import java.util.Map;
@@ -304,14 +305,14 @@ public class MedicationRequestMapper extends AbstractMapper<DomainResource> {
 
         List<Medication> medications = mapMedications(medicationStatement);
 
-        List<MedicationRequest> medicationRequestsOrder = mapMedicationRequestsOrder(
+        List<MedicationRequest> medicationRequestsPlan = mapMedicationRequestsPlan(
             ehrExtract,
             ehrComposition,
             medicationStatement,
             practiseCode
         );
 
-        List<MedicationRequest> medicationRequestsPlan = mapMedicationRequestsPlan(
+        List<MedicationRequest> medicationRequestsOrder = mapMedicationRequestsOrder(
             ehrExtract,
             ehrComposition,
             medicationStatement,
@@ -418,6 +419,7 @@ public class MedicationRequestMapper extends AbstractMapper<DomainResource> {
             .map(RCMRMT030101UKComponent2::getEhrSupplyAuthorise)
             .map(supplyAuthorise -> medicationRequestPlanMapper.mapToPlanMedicationRequest(ehrExtract, ehrComposition, medicationStatement,
                 supplyAuthorise, practiseCode))
+            .flatMap(Collection::stream)
             .filter(Objects::nonNull)
             .toList();
     }

--- a/gp2gp-translator/src/test/java/uk/nhs/adaptors/pss/translator/mapper/medication/MedicationRequestMapperTest.java
+++ b/gp2gp-translator/src/test/java/uk/nhs/adaptors/pss/translator/mapper/medication/MedicationRequestMapperTest.java
@@ -882,7 +882,7 @@ public class MedicationRequestMapperTest {
                 any(RCMRMT030101UKAuthorise.class),
                 any(String.class)
             )
-        ).thenReturn(buildMedicationRequestPlan(planExtension));
+        ).thenReturn(List.of(buildMedicationRequestPlan(planExtension)));
 
         var orderValidityPeriodEnd = hasOrderValidityPeriodEnd
             ? "20240103"
@@ -922,7 +922,7 @@ public class MedicationRequestMapperTest {
             any(RCMRMT030101UKMedicationStatement.class),
             any(RCMRMT030101UKAuthorise.class),
             any(String.class)
-        )).thenReturn(new MedicationRequest());
+        )).thenReturn(List.of(new MedicationRequest()));
 
         Mockito.lenient().when(medicationRequestOrderMapper.mapToOrderMedicationRequest(
             any(RCMRMT030101UKEhrExtract.class),

--- a/gp2gp-translator/src/test/resources/xml/MedicationStatement/ehrExtract_TwoSupplyPrescribeInFulfillmentOfTheSameAcuteSupplyAuthorise.xml
+++ b/gp2gp-translator/src/test/resources/xml/MedicationStatement/ehrExtract_TwoSupplyPrescribeInFulfillmentOfTheSameAcuteSupplyAuthorise.xml
@@ -1,0 +1,59 @@
+<EhrExtract xmlns="urn:hl7-org:v3">
+    <component>
+        <ehrFolder>
+            <component>
+                <ehrComposition>
+                    <component>
+                        <MedicationStatement xmlns="urn:hl7-org:v3" classCode="SBADM" moodCode="INT">
+                            <id root="B4D70A6D-2EE4-41B6-B1FB-F9F0AD84C503"/>
+                            <component typeCode="COMP">
+                                <ehrSupplyAuthorise classCode="SPLY" moodCode="INT">
+                                    <id root="TEST_AUTHORISE_ID"/>
+                                    <effectiveTime>
+                                        <high value="20060427"/>
+                                    </effectiveTime>
+                                    <availabilityTime value="20100114"/>
+                                    <repeatNumber value="0"/>
+                                    <quantity value="28" unit="1" />
+                                </ehrSupplyAuthorise>
+                            </component>
+                            <component typeCode="COMP">
+                                <ehrSupplyPrescribe classCode="SPLY" moodCode="RQO">
+                                    <id root="LATEST_TEST_PRESCRIBE_ID"/>
+                                    <quantity value="1" unit="1" />
+                                    <availabilityTime value="20240202" />
+                                    <inFulfillmentOf typeCode="FLFS">
+                                        <priorMedicationRef moodCode="INT">
+                                            <id root="TEST_AUTHORISE_ID"/>
+                                        </priorMedicationRef>
+                                    </inFulfillmentOf>
+                                </ehrSupplyPrescribe>
+                            </component>
+                        </MedicationStatement>
+                    </component>
+                </ehrComposition>
+            </component>
+            <component>
+                <ehrComposition>
+                    <component>
+                        <MedicationStatement xmlns="urn:hl7-org:v3" classCode="SBADM" moodCode="INT">
+                            <id root="B4D70A6D-2EE4-41B6-B1FB-F9F0AD840000"/>
+                            <component typeCode="COMP">
+                                <ehrSupplyPrescribe classCode="SPLY" moodCode="RQO">
+                                    <id root="EARLIEST_TEST_PRESCRIBE_ID"/>
+                                    <quantity value="1" unit="1" />
+                                    <availabilityTime value="20240101" />
+                                    <inFulfillmentOf typeCode="FLFS">
+                                        <priorMedicationRef moodCode="INT">
+                                            <id root="TEST_AUTHORISE_ID"/>
+                                        </priorMedicationRef>
+                                    </inFulfillmentOf>
+                                </ehrSupplyPrescribe>
+                            </component>
+                        </MedicationStatement>
+                    </component>
+                </ehrComposition>
+            </component>
+        </ehrFolder>
+    </component>
+</EhrExtract>

--- a/gp2gp-translator/src/test/resources/xml/MedicationStatement/ehrExtract_TwoSupplyPrescribeInFulfillmentOfTheSameRepeatSupplyAuthorise.xml
+++ b/gp2gp-translator/src/test/resources/xml/MedicationStatement/ehrExtract_TwoSupplyPrescribeInFulfillmentOfTheSameRepeatSupplyAuthorise.xml
@@ -1,0 +1,59 @@
+<EhrExtract xmlns="urn:hl7-org:v3">
+    <component>
+        <ehrFolder>
+            <component>
+                <ehrComposition>
+                    <component>
+                        <MedicationStatement xmlns="urn:hl7-org:v3" classCode="SBADM" moodCode="INT">
+                            <id root="B4D70A6D-2EE4-41B6-B1FB-F9F0AD84C503"/>
+                            <component typeCode="COMP">
+                                <ehrSupplyAuthorise classCode="SPLY" moodCode="INT">
+                                    <id root="TEST_AUTHORISE_ID"/>
+                                    <effectiveTime>
+                                        <high value="20060427"/>
+                                    </effectiveTime>
+                                    <availabilityTime value="20100114"/>
+                                    <repeatNumber value="1"/>
+                                    <quantity value="28" unit="1" />
+                                </ehrSupplyAuthorise>
+                            </component>
+                            <component typeCode="COMP">
+                                <ehrSupplyPrescribe classCode="SPLY" moodCode="RQO">
+                                    <id root="LATEST_TEST_PRESCRIBE_ID"/>
+                                    <quantity value="1" unit="1" />
+                                    <availabilityTime value="20240202" />
+                                    <inFulfillmentOf typeCode="FLFS">
+                                        <priorMedicationRef moodCode="INT">
+                                            <id root="TEST_AUTHORISE_ID"/>
+                                        </priorMedicationRef>
+                                    </inFulfillmentOf>
+                                </ehrSupplyPrescribe>
+                            </component>
+                        </MedicationStatement>
+                    </component>
+                </ehrComposition>
+            </component>
+            <component>
+                <ehrComposition>
+                    <component>
+                        <MedicationStatement xmlns="urn:hl7-org:v3" classCode="SBADM" moodCode="INT">
+                            <id root="B4D70A6D-2EE4-41B6-B1FB-F9F0AD840000"/>
+                            <component typeCode="COMP">
+                                <ehrSupplyPrescribe classCode="SPLY" moodCode="RQO">
+                                    <id root="EARLIEST_TEST_PRESCRIBE_ID"/>
+                                    <quantity value="1" unit="1" />
+                                    <availabilityTime value="20240101" />
+                                    <inFulfillmentOf typeCode="FLFS">
+                                        <priorMedicationRef moodCode="INT">
+                                            <id root="TEST_AUTHORISE_ID"/>
+                                        </priorMedicationRef>
+                                    </inFulfillmentOf>
+                                </ehrSupplyPrescribe>
+                            </component>
+                        </MedicationStatement>
+                    </component>
+                </ehrComposition>
+            </component>
+        </ehrFolder>
+    </component>
+</EhrExtract>


### PR DESCRIPTION
Update MedicationRequestMapper so that `EhrSupplyAuthorise` are mapped to Plans, prior to `EhrSupplyPrescribe` are mapped to Orders.  This is to allow the filed updates for generated plans.

Update MedicationRequestPlanMapper to add the functionality for generating Plan from `EhrSupplyAuthorise`, rather than the other generated plans. Add / Update tests for the new functionality.
Update existing tests to handle that `mapToPlanMedicationRequest` may now generate multiple plans.

## What

Please include a summary of the changes and the related issue

## Why

Please include details of the reasoning for these changes

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Internal change (non-breaking change with no effect on the functionality affecting end users)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:

- [ ] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I have updated the [Changelog](/CHANGELOG.md) with details of my change in the UNRELEASED section if this change will affect end users
- [ ] A corresponding change has been made to the [Mapping Documentation repository][mapping-docs]

[mapping-docs]: https://github.com/NHSDigital/patient-switching-adaptors-mapping-documentation