### PR TITLE
Add missing CHANGELOG entry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 ## [Unreleased]
 
 ### Added
-* Added a guidance that highlights the specific focus on the dependent services and how the PS Adaptor operates when those services are unavailable
+* Documented how the Adaptor behaves when dependent services are unavailable.
+* Expanded the functionality added in [version 2.1.0](#210---2024-04-17) to deduplicate SystmOne Problems.
+  Handle the case where a duplicate, empty `ObservationStatement` is provided by SystmOne and ignore it from the
+  generated FHIR output.
 
 ## [3.0.4] - 2024-10-28
 


### PR DESCRIPTION
Following on from 64473d8778717e1da2a1914e55017fd27b4d946e

## Checklist:

- [x] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] I have updated the [Changelog](/CHANGELOG.md) with details of my change in the UNRELEASED section if this change will affect end users
- [ ] A corresponding change has been made to the [Mapping Documentation repository][mapping-docs]

[mapping-docs]: https://github.com/NHSDigital/patient-switching-adaptors-mapping-documentation