### PR TITLE
NIAD-3236: removing the limit of string size that can be processed by ObjectMaper

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,10 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
-## [Unreleased]
+## [Unreleased
+
+### Fixed
+* Removed 20 MB data processing limit to enable the Adaptor to handle larger pieces of data.
 
 ## [3.0.5] - 2024-11-05
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
-## [Unreleased
+## [Unreleased]
 
 ### Fixed
 * Removed 20 MB data processing limit to enable the Adaptor to handle larger pieces of data.

--- a/common/src/main/java/uk/nhs/adaptors/common/config/ObjectMapperConfig.java
+++ b/common/src/main/java/uk/nhs/adaptors/common/config/ObjectMapperConfig.java
@@ -1,0 +1,23 @@
+package uk.nhs.adaptors.common.config;
+
+import com.fasterxml.jackson.core.StreamReadConstraints;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.http.converter.json.Jackson2ObjectMapperBuilder;
+
+@Configuration
+public class ObjectMapperConfig {
+
+    @Bean
+    public ObjectMapper objectMapper(Jackson2ObjectMapperBuilder builder) {
+        ObjectMapper objectMapper = builder.build();
+        objectMapper.getFactory().setStreamReadConstraints(
+            StreamReadConstraints.builder()
+                .maxStringLength(Integer.MAX_VALUE)
+                .build());
+
+        return objectMapper;
+    }
+
+}

--- a/common/src/main/java/uk/nhs/adaptors/common/config/ObjectMapperConfig.java
+++ b/common/src/main/java/uk/nhs/adaptors/common/config/ObjectMapperConfig.java
@@ -13,9 +13,7 @@ public class ObjectMapperConfig {
     public ObjectMapper objectMapper(Jackson2ObjectMapperBuilder builder) {
         ObjectMapper objectMapper = builder.build();
         objectMapper.getFactory().setStreamReadConstraints(
-            StreamReadConstraints.builder()
-                .maxStringLength(Integer.MAX_VALUE)
-                .build());
+            StreamReadConstraints.builder().maxStringLength(Integer.MAX_VALUE).build());
 
         return objectMapper;
     }

--- a/gp2gp-translator/src/integrationTest/java/uk/nhs/adaptors/pss/translator/service/AcknowledgeRecordServiceIT.java
+++ b/gp2gp-translator/src/integrationTest/java/uk/nhs/adaptors/pss/translator/service/AcknowledgeRecordServiceIT.java
@@ -1,0 +1,89 @@
+package uk.nhs.adaptors.pss.translator.service;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import lombok.Getter;
+import lombok.SneakyThrows;
+import org.hl7.v3.RCMRIN030000UKMessage;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+import uk.nhs.adaptors.common.enums.ConfirmationResponse;
+import uk.nhs.adaptors.common.model.AcknowledgeRecordMessage;
+import uk.nhs.adaptors.pss.translator.mhs.model.InboundMessage;
+import uk.nhs.adaptors.pss.translator.model.NACKReason;
+
+import java.util.List;
+import java.util.UUID;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.doReturn;
+import static org.springframework.boot.test.context.SpringBootTest.WebEnvironment.RANDOM_PORT;
+import static uk.nhs.adaptors.common.enums.QueueMessageType.ACKNOWLEDGE_RECORD;
+import static uk.nhs.adaptors.common.util.FileUtil.readResourceAsString;
+
+@SpringBootTest(webEnvironment = RANDOM_PORT)
+@ExtendWith({SpringExtension.class, MockitoExtension.class})
+public class AcknowledgeRecordServiceIT {
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @Autowired
+    private AcknowledgeRecordService acknowledgeRecordService;
+
+    @MockBean
+    NackAckPrepInterface nackAckPrepInterface;
+
+    private static final String CONVERSATION_ID_VALUE = UUID.randomUUID().toString();
+    private static final String EBXML_PART_PATH = "/xml/RCMR_IN030000UK06/ebxml_part.xml";
+    @Getter
+    protected static final String CONVERSATION_ID_PLACEHOLDER = "{{conversationId}}";
+
+    @Test
+    public void prepareAndSendAcknowledgeMessageDoesNotThrowExceptionWhenMessageIsOver30MbTest() {
+
+        var acknowledgeRecordMessage = AcknowledgeRecordMessage.builder()
+            .conversationId(CONVERSATION_ID_VALUE)
+            .messageType(ACKNOWLEDGE_RECORD)
+            .confirmationResponse(ConfirmationResponse.FAILED_TO_INTEGRATE)
+            .originalMessage(parseMessageToString(createInboundMessage("/e2e-mapping/input-xml/PWTP2.xml")))
+            .build();
+
+        doReturn(true).when(nackAckPrepInterface).sendNackMessage(any(NACKReason.class),
+                                                                              any(RCMRIN030000UKMessage.class),
+                                                                              anyString());
+
+        assertTrue(() -> acknowledgeRecordService.prepareAndSendAcknowledgementMessage(acknowledgeRecordMessage));
+    }
+
+    private InboundMessage createInboundMessage(String payloadPartPath) {
+        var ebXml = readResourceAsString(EBXML_PART_PATH).replace(CONVERSATION_ID_PLACEHOLDER, CONVERSATION_ID_VALUE);
+
+        var inboundMessage = new InboundMessage();
+        inboundMessage.setPayload(readResourceAsString(payloadPartPath));
+        inboundMessage.setEbXML(ebXml);
+        inboundMessage.setAttachments(
+            List.of(InboundMessage.Attachment.builder()
+                                             .contentType("application/text")
+                                             .payload("1".repeat(22 * 1024 * 1024))
+                                             .build()));
+        return inboundMessage;
+    }
+
+    @SneakyThrows
+    private String parseMessageToString(InboundMessage inboundMessage) {
+        return objectMapper.writeValueAsString(inboundMessage);
+    }
+
+    private String sendInboundMessageAndWaitForBundle(String inputFilePath) {
+        final var inboundMessage = parseMessageToString(createInboundMessage(inputFilePath));
+        return inboundMessage;
+    }
+
+}

--- a/gp2gp-translator/src/integrationTest/java/uk/nhs/adaptors/pss/translator/service/AcknowledgeRecordServiceIT.java
+++ b/gp2gp-translator/src/integrationTest/java/uk/nhs/adaptors/pss/translator/service/AcknowledgeRecordServiceIT.java
@@ -31,6 +31,7 @@ import static uk.nhs.adaptors.common.util.FileUtil.readResourceAsString;
 @ExtendWith({SpringExtension.class, MockitoExtension.class})
 public class AcknowledgeRecordServiceIT {
 
+    public static final int SIZE_22_MB = 22 * 1024 * 1024;
     @Autowired
     private ObjectMapper objectMapper;
 
@@ -38,7 +39,7 @@ public class AcknowledgeRecordServiceIT {
     private AcknowledgeRecordService acknowledgeRecordService;
 
     @MockBean
-    NackAckPrepInterface nackAckPrepInterface;
+    private NackAckPrepInterface nackAckPrepInterface;
 
     private static final String CONVERSATION_ID_VALUE = UUID.randomUUID().toString();
     private static final String EBXML_PART_PATH = "/xml/RCMR_IN030000UK06/ebxml_part.xml";
@@ -71,7 +72,7 @@ public class AcknowledgeRecordServiceIT {
         inboundMessage.setAttachments(
             List.of(InboundMessage.Attachment.builder()
                                              .contentType("application/text")
-                                             .payload("1".repeat(22 * 1024 * 1024))
+                                             .payload("1".repeat(SIZE_22_MB))
                                              .build()));
         return inboundMessage;
     }

--- a/gp2gp-translator/src/main/java/uk/nhs/adaptors/pss/translator/service/AcknowledgeRecordService.java
+++ b/gp2gp-translator/src/main/java/uk/nhs/adaptors/pss/translator/service/AcknowledgeRecordService.java
@@ -49,7 +49,7 @@ public class AcknowledgeRecordService {
         try {
             message = parseOriginalMessage(acknowledgeRecordMessage);
         } catch (Exception exception) {
-            LOGGER.error("Original message wasn't parsed due to an exception", exception.getMessage());
+            LOGGER.error("Original message was not parsed due to an exception.", exception.getMessage());
             return false;
         }
 

--- a/gp2gp-translator/src/main/java/uk/nhs/adaptors/pss/translator/service/AcknowledgeRecordService.java
+++ b/gp2gp-translator/src/main/java/uk/nhs/adaptors/pss/translator/service/AcknowledgeRecordService.java
@@ -48,7 +48,8 @@ public class AcknowledgeRecordService {
 
         try {
             message = parseOriginalMessage(acknowledgeRecordMessage);
-        } catch (Exception e) {
+        } catch (Exception exception) {
+            LOGGER.error("Original message wasn't parsed due to an exception", exception.getMessage());
             return false;
         }
 
@@ -67,10 +68,9 @@ public class AcknowledgeRecordService {
         return nackAckPrepInterface.sendNackMessage(nackReason, message, conversationId);
     }
 
-    private RCMRIN030000UKMessage parseOriginalMessage(AcknowledgeRecordMessage message)
-        throws JAXBException, JsonProcessingException {
-        var payload = objectMapper.readValue(message.getOriginalMessage(), InboundMessage.class)
-                .getPayload();
+    private RCMRIN030000UKMessage parseOriginalMessage(AcknowledgeRecordMessage message) throws JAXBException, JsonProcessingException {
+
+        var payload = objectMapper.readValue(message.getOriginalMessage(), InboundMessage.class).getPayload();
 
         return unmarshallString(payload, RCMRIN030000UKMessage.class);
     }

--- a/gpc-api-facade/src/main/java/uk/nhs/adaptors/pss/gpc/config/ApplicationConfiguration.java
+++ b/gpc-api-facade/src/main/java/uk/nhs/adaptors/pss/gpc/config/ApplicationConfiguration.java
@@ -1,28 +1,27 @@
 package uk.nhs.adaptors.pss.gpc.config;
 
+import com.fasterxml.jackson.databind.module.SimpleModule;
 import org.hl7.fhir.dstu3.model.Parameters;
+import org.springframework.beans.BeansException;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.config.BeanPostProcessor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Import;
 import org.springframework.http.converter.json.MappingJackson2HttpMessageConverter;
-
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.databind.module.SimpleModule;
-
 import uk.nhs.adaptors.common.config.CommonConfiguration;
 import uk.nhs.adaptors.common.util.fhir.FhirParser;
 import uk.nhs.adaptors.connector.config.DbConnectorConfiguration;
 import uk.nhs.adaptors.pss.gpc.config.serialization.ParametersDeserializer;
 
+
 @Configuration
 @Import({DbConnectorConfiguration.class, CommonConfiguration.class})
-public class ApplicationConfiguration {
-    @Bean
-    public ObjectMapper objectMapper(FhirParser fhirParser) {
-        SimpleModule module = new SimpleModule();
-        module.addDeserializer(Parameters.class, new ParametersDeserializer(fhirParser));
-        return new ObjectMapper().registerModule(module);
-    }
+public class ApplicationConfiguration implements BeanPostProcessor {
+
+    @Autowired
+    private FhirParser fhirParser;
 
     @Bean
     public MappingJackson2HttpMessageConverter jacksonConverter(ObjectMapper objectMapper) {
@@ -30,5 +29,15 @@ public class ApplicationConfiguration {
         jacksonConverter.setObjectMapper(objectMapper);
 
         return jacksonConverter;
+    }
+
+    @Override
+    public Object postProcessAfterInitialization(Object bean, String beanName) throws BeansException {
+        if (bean instanceof ObjectMapper objectMapper) {
+            SimpleModule module = new SimpleModule();
+            module.addDeserializer(Parameters.class, new ParametersDeserializer(fhirParser));
+            objectMapper.registerModule(module);
+        }
+        return bean;
     }
 }


### PR DESCRIPTION
## What

Removal of the limit of string size that can be processed by Jackson ObjectMapper

## Why

ObjectMapper underneath uses Jackson which has a limit of 20 Mb of data that it can process. The data that PS Adaptor is working with can be much bigger in size than the limit hence we need to remove this limit and allow the adaptor to handle much bigger documents.

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Internal change (non-breaking change with no effect on the functionality affecting end users)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:

- [x] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have updated the [Changelog](/CHANGELOG.md) with details of my change in the UNRELEASED section if this change will affect end users
- [ ] A corresponding change has been made to the [Mapping Documentation repository][mapping-docs]

[mapping-docs]: https://github.com/NHSDigital/patient-switching-adaptors-mapping-documentation