### PR TITLE
Running every test scenario in a separate transaction to make the tests more independent and predictable

### DIFF
--- a/gpc-api-facade/src/integrationTest/java/uk/nhs/adaptors/pss/gpc/controller/PatientTransferControllerIT.java
+++ b/gpc-api-facade/src/integrationTest/java/uk/nhs/adaptors/pss/gpc/controller/PatientTransferControllerIT.java
@@ -27,6 +27,7 @@ import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
 import org.springframework.test.web.servlet.MockMvc;
 
+import org.springframework.transaction.annotation.Transactional;
 import uk.nhs.adaptors.common.util.fhir.FhirParser;
 import uk.nhs.adaptors.connector.dao.MigrationStatusLogDao;
 import uk.nhs.adaptors.connector.dao.PatientMigrationRequestDao;
@@ -38,6 +39,7 @@ import uk.nhs.adaptors.connector.service.MigrationStatusLogService;
 @ExtendWith({SpringExtension.class})
 @DirtiesContext
 @AutoConfigureMockMvc
+@Transactional
 public class PatientTransferControllerIT {
 
     private static final int NHS_NUMBER_MIN_MAX_LENGTH = 10;


### PR DESCRIPTION

## What

Running every test scenario in a separate transaction 

## Why

Running every test scenario in a separate transaction makes them independent which each other and doesn't leave a trace in a database that affects other scenarios

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Internal change (non-breaking change with no effect on the functionality affecting end users)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:

- [x] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] I have updated the [Changelog](/CHANGELOG.md) with details of my change in the UNRELEASED section if this change will affect end users
- [ ] A corresponding change has been made to the [Mapping Documentation repository][mapping-docs]

[mapping-docs]: https://github.com/NHSDigital/patient-switching-adaptors-mapping-documentation