### PR TITLE
Fix warnings for `raw use of parameterized class 'List'` in AgentDirectoryMapperTest

### DIFF
--- a/gp2gp-translator/src/test/java/uk/nhs/adaptors/pss/translator/mapper/AgentDirectoryMapperTest.java
+++ b/gp2gp-translator/src/test/java/uk/nhs/adaptors/pss/translator/mapper/AgentDirectoryMapperTest.java
@@ -23,8 +23,6 @@ import static org.springframework.util.ResourceUtils.getFile;
 import static uk.nhs.adaptors.pss.translator.util.XmlUnmarshallUtil.unmarshallFile;
 import static uk.nhs.adaptors.pss.translator.util.XmlUnmarshallUtil.unmarshallString;
 
-import java.util.List;
-
 public class AgentDirectoryMapperTest {
 
     private static final String XML_RESOURCES_BASE = "xml/AgentDirectory/";
@@ -42,7 +40,7 @@ public class AgentDirectoryMapperTest {
     public void mapAgentDirectoryWithMultipleAgents() {
         var agentDirectory = unmarshallAgentDirectoryElement("multiple_agents_example.xml");
 
-        List mappedAgents = agentDirectoryMapper.mapAgentDirectory(agentDirectory);
+        var mappedAgents = agentDirectoryMapper.mapAgentDirectory(agentDirectory);
 
         // asserts that for the 3 varying Agents in the input, that there are correctly 5 mapped resources output
         assertEquals(FIVE_RESOURCES_MAPPED, mappedAgents.size());
@@ -52,7 +50,7 @@ public class AgentDirectoryMapperTest {
     public void mapAgentDirectoryWithAgentPersonAndRepresentedOrganizationNoCode() {
         var agentDirectory = unmarshallAgentDirectoryElement("agent_person_and_represented_org_example.xml");
 
-        List mappedAgents = agentDirectoryMapper.mapAgentDirectory(agentDirectory);
+        var mappedAgents = agentDirectoryMapper.mapAgentDirectory(agentDirectory);
 
         assertEquals(THREE_RESOURCES_MAPPED, mappedAgents.size());
 
@@ -93,7 +91,7 @@ public class AgentDirectoryMapperTest {
     public void mapAgentDirectoryWithAgentPersonAndRepresentedOrganizationWithOriginalText() {
         var agentDirectory = unmarshallAgentDirectoryElement("agent_person_and_represented_org_with_original_text_example.xml");
 
-        List mappedAgents = agentDirectoryMapper.mapAgentDirectory(agentDirectory);
+        var mappedAgents = agentDirectoryMapper.mapAgentDirectory(agentDirectory);
 
         assertEquals(THREE_RESOURCES_MAPPED, mappedAgents.size());
 
@@ -121,7 +119,7 @@ public class AgentDirectoryMapperTest {
     public void mapAgentDirectoryWithAgentPersonAndRepresentedOrganizationWithDisplayName() {
         var agentDirectory = unmarshallAgentDirectoryElement("agent_person_and_represented_org_with_display_name_example.xml");
 
-        List mappedAgents = agentDirectoryMapper.mapAgentDirectory(agentDirectory);
+        var mappedAgents = agentDirectoryMapper.mapAgentDirectory(agentDirectory);
 
         assertEquals(THREE_RESOURCES_MAPPED, mappedAgents.size());
 
@@ -149,7 +147,7 @@ public class AgentDirectoryMapperTest {
     public void mapAgentDirectoryOnlyAgentPersonNoOptionalFields() {
         var agentDirectory = unmarshallAgentDirectoryElement("agent_person_only_example.xml");
 
-        List mappedAgents = agentDirectoryMapper.mapAgentDirectory(agentDirectory);
+        var mappedAgents = agentDirectoryMapper.mapAgentDirectory(agentDirectory);
 
         assertThat(mappedAgents).hasSize(1);
 
@@ -166,7 +164,7 @@ public class AgentDirectoryMapperTest {
     public void mapAgentDirectoryOnlyAgentPersonUnknownName() {
         var agentDirectory = unmarshallAgentDirectoryElement("agent_person_only_no_name_example.xml");
 
-        List mappedAgents = agentDirectoryMapper.mapAgentDirectory(agentDirectory);
+        var mappedAgents = agentDirectoryMapper.mapAgentDirectory(agentDirectory);
 
         assertThat(mappedAgents).hasSize(1);
 
@@ -184,7 +182,7 @@ public class AgentDirectoryMapperTest {
     public void mapAgentDirectoryOnlyAgentPersonFullName() {
         var agentDirectory = unmarshallAgentDirectoryElement("agent_person_only_full_name_example.xml");
 
-        List mappedAgents = agentDirectoryMapper.mapAgentDirectory(agentDirectory);
+        var mappedAgents = agentDirectoryMapper.mapAgentDirectory(agentDirectory);
 
         assertThat(mappedAgents).hasSize(1);
 
@@ -201,7 +199,7 @@ public class AgentDirectoryMapperTest {
     public void mapAgentDirectoryOnlyAgentOrganizationNoOptionalFields() {
         var agentDirectory = unmarshallAgentDirectoryElement("agent_org_only_example.xml");
 
-        List mappedAgents = agentDirectoryMapper.mapAgentDirectory(agentDirectory);
+        var mappedAgents = agentDirectoryMapper.mapAgentDirectory(agentDirectory);
 
         assertThat(mappedAgents).hasSize(1);
 
@@ -218,7 +216,7 @@ public class AgentDirectoryMapperTest {
     public void mapAgentDirectoryOnlyAgentOrganizationUnknownName() {
         var agentDirectory = unmarshallAgentDirectoryElement("agent_org_no_name_example.xml");
 
-        List mappedAgents = agentDirectoryMapper.mapAgentDirectory(agentDirectory);
+        var mappedAgents = agentDirectoryMapper.mapAgentDirectory(agentDirectory);
 
         assertThat(mappedAgents).hasSize(1);
 
@@ -235,7 +233,7 @@ public class AgentDirectoryMapperTest {
     public void mapAgentDirectoryOnlyAgentOrganizationWithValidIdentifier() {
         var agentDirectory = unmarshallAgentDirectoryElement("agent_org_valid_identifier_example.xml");
 
-        List mappedAgents = agentDirectoryMapper.mapAgentDirectory(agentDirectory);
+        var mappedAgents = agentDirectoryMapper.mapAgentDirectory(agentDirectory);
 
         assertEquals(1, mappedAgents.size());
 
@@ -253,7 +251,7 @@ public class AgentDirectoryMapperTest {
     public void mapAgentDirectoryOnlyAgentOrganizationWithInvalidIdentifier() {
         var agentDirectory = unmarshallAgentDirectoryElement("agent_org_invalid_identifier_example.xml");
 
-        List mappedAgents = agentDirectoryMapper.mapAgentDirectory(agentDirectory);
+        var mappedAgents = agentDirectoryMapper.mapAgentDirectory(agentDirectory);
 
         assertEquals(1, mappedAgents.size());
 
@@ -270,7 +268,7 @@ public class AgentDirectoryMapperTest {
     public void mapAgentDirectoryOnlyAgentOrganizationWithNonWPAddressAndTelecom() {
         var agentDirectory = unmarshallAgentDirectoryElement("agent_org_non_wp_address_and_telecom_example.xml");
 
-        List mappedAgents = agentDirectoryMapper.mapAgentDirectory(agentDirectory);
+        var mappedAgents = agentDirectoryMapper.mapAgentDirectory(agentDirectory);
 
         assertEquals(1, mappedAgents.size());
 
@@ -287,7 +285,7 @@ public class AgentDirectoryMapperTest {
     public void mapAgentDirectoryOnlyAgentOrganizationWithWPTelecom() {
         var agentDirectory = unmarshallAgentDirectoryElement("agent_org_wp_telecom_example.xml");
 
-        List mappedAgents = agentDirectoryMapper.mapAgentDirectory(agentDirectory);
+        var mappedAgents = agentDirectoryMapper.mapAgentDirectory(agentDirectory);
 
         assertEquals(1, mappedAgents.size());
 
@@ -304,7 +302,7 @@ public class AgentDirectoryMapperTest {
     public void  mapAgentDirectoryOnlyAgentOrganizationWithWPAddress() {
         var agentDirectory = unmarshallAgentDirectoryElement("agent_org_wp_address_example.xml");
 
-        List mappedAgents = agentDirectoryMapper.mapAgentDirectory(agentDirectory);
+        var mappedAgents = agentDirectoryMapper.mapAgentDirectory(agentDirectory);
 
         assertEquals(1, mappedAgents.size());
 


### PR DESCRIPTION


## What

Fix warnings for `raw use of parameterized class 'List'` which is the mirror of the javac rawtypes warning. Although this is valid in java, it allows any object to be inserted into the list, regardless of its assigned type.

Where the raw use of `List` was used in the file AgentDirectoryMapperTest it was suitable to use `var` rather than `List<? extends DomainResource`.

## Why

The following warning is reported:

**Raw use of parameterized class 'List'** 
Inspection info: _Reports generic classes with omitted type parameters. Such raw use of generic types is valid in Java, but it defeats the purpose of type parameters and may mask bugs. This inspection mirrors the rawtypes warning of javac._
Examples:

```java
//warning: Raw use of parameterized class 'List'
List list = new ArrayList<String>();
//list of strings was created but integer is accepted as well
list.add(1);
```

Although the raw use is permitted, it is not advisable and can have side-effects.  This code change is to fix these warnings and increase code quality.

## Type of change

Please delete options that are not relevant.

- [x] Internal change (non-breaking change with no effect on the functionality affecting end users)

## Checklist:

- [x] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] I have updated the [Changelog](/CHANGELOG.md) with details of my change in the UNRELEASED section if this change will affect end users
- [ ] A corresponding change has been made to the [Mapping Documentation repository][mapping-docs]

[mapping-docs]: https://github.com/NHSDigital/patient-switching-adaptors-mapping-documentation