### PR TITLE
Fix bug where if the name element was omitted for an `agentPerson` then an exception would be thrown

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## [Unreleased]
 
+### Fixed
+
+* When provided an `agentPerson` without a `name` element, the adaptor will no longer throw an exception, but will
+  instead map the `Practitioner` with a `familyName` of `"unknown"`.
+
 ## [3.0.6] - 2024-11-11
 
 ### Fixed

--- a/gp2gp-translator/src/main/java/uk/nhs/adaptors/pss/translator/mapper/AgentDirectoryMapper.java
+++ b/gp2gp-translator/src/main/java/uk/nhs/adaptors/pss/translator/mapper/AgentDirectoryMapper.java
@@ -114,11 +114,15 @@ public class AgentDirectoryMapper {
 
     private List<HumanName> getPractitionerName(PN name) {
         var nameList = new ArrayList<HumanName>();
-        var humanName = new HumanName();
+        var humanName = new HumanName().setUse(NameUse.OFFICIAL);
+        nameList.add(humanName);
 
-        humanName
-            .setUse(NameUse.OFFICIAL)
-            .setFamily(getPractitionerFamily(name.getFamily()));
+        if (name == null) {
+            humanName.setFamily(UNKNOWN);
+            return nameList;
+        }
+
+        humanName.setFamily(getPractitionerFamily(name.getFamily()));
 
         var given = getPractitionerGiven(name.getGiven());
         if (given != null) {
@@ -129,8 +133,6 @@ public class AgentDirectoryMapper {
         if (prefix != null) {
             humanName.getPrefix().add(prefix);
         }
-
-        nameList.add(humanName);
 
         return nameList;
     }

--- a/gp2gp-translator/src/test/java/uk/nhs/adaptors/pss/translator/mapper/AgentDirectoryMapperTest.java
+++ b/gp2gp-translator/src/test/java/uk/nhs/adaptors/pss/translator/mapper/AgentDirectoryMapperTest.java
@@ -161,7 +161,7 @@ public class AgentDirectoryMapperTest {
     }
 
     @Test
-    public void mapAgentDirectoryOnlyAgentPersonUnknownName() {
+    public void mapAgentDirectoryOnlyAgentPersonWithEmptyNameElement() {
         var agentDirectory = unmarshallAgentDirectoryElement("agent_person_only_no_name_example.xml");
 
         var mappedAgents = agentDirectoryMapper.mapAgentDirectory(agentDirectory);
@@ -176,6 +176,33 @@ public class AgentDirectoryMapperTest {
         assertThat(practitioner.getNameFirstRep().getFamily()).isEqualTo("Unknown");
         assertThat(practitioner.getNameFirstRep().getGiven()).isEmpty();
         assertThat(practitioner.getNameFirstRep().getPrefix()).isEmpty();
+    }
+
+    @Test
+    public void When_MappingAgentDirectoryWithAgentWithoutNameElement_Expect_ExpectFamilyNameIsSetToUnknown() {
+        var agentDirectoryXml = """
+            <agentDirectory xmlns="urn:hl7-org:v3" classCode="AGNT">
+                <part typeCode="PART">
+                    <Agent classCode="AGNT">
+                        <id root="6C8AC7E0-4D90-10C5-5FD3-F2C05C658E18" />
+                            <code code="125676002" codeSystem="2.16.840.1.113883.2.1.3.2.4.15" displayName="Person">
+                               <originalText>Other</originalText>
+                            </code>
+                        <agentPerson classCode="PSN" determinerCode="INSTANCE" />
+                    </Agent>
+                </part>
+            </agentDirectory>""";
+        var agentDirectory = unmarshallAgentDirectoryFromXmlString(agentDirectoryXml);
+
+        var mappedAgents = agentDirectoryMapper.mapAgentDirectory(agentDirectory);
+        var practitioner = (Practitioner) mappedAgents.getFirst();
+
+        assertAll(
+            () -> assertThat(practitioner.getNameFirstRep().getUse()).isEqualTo(NameUse.OFFICIAL),
+            () -> assertThat(practitioner.getNameFirstRep().getFamily()).isEqualTo("Unknown"),
+            () -> assertThat(practitioner.getNameFirstRep().getGiven()).isEmpty(),
+            () -> assertThat(practitioner.getNameFirstRep().getPrefix()).isEmpty()
+        );
     }
 
     @Test


### PR DESCRIPTION

## What

Fixed a bug where if the name element was omitted for an `agentPerson` (which is a valid use case) then an exception would be thrown.  Instead, this now produces a `Practitioner` with a family name of `"unknown"` as documented.

Added Unit Test for the above functionality.

## Why

When an `Agent` is provided in the XML with a `agentPerson` element but without a nested `name` element: 

```xml
<Agent classCode="AGNT">
    <id root="6C8AC7E0-4D90-10C5-5FD3-F2C05C658E18" />
    <code code="125676002" codeSystem="2.16.840.1.113883.2.1.3.2.4.15" displayName="Person">
        <originalText>Other</originalText>
    </code>
    <agentPerson classCode="PSN" determinerCode="INSTANCE" />
</Agent>
```

Then the adaptor currently throws a BundleMappingException.  It is expected instead that this is handled gracefully, with produced `Practitioner.familyName` being set to `"unknown"`

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes