### PR TITLE
Add 3.0.7 to CHANGELOG.md

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## [Unreleased]
 
+## [3.0.7] - 2024-11-19
+
 ### Fixed
 
 * When provided an `agentPerson` without a `name` element, the adaptor will no longer throw an exception, but will

--- a/developer-information.md
+++ b/developer-information.md
@@ -77,18 +77,22 @@ Deploy this commit to the AWS Path to Live environment.
 
 [jenkins-terraform]: http://ec2-35-177-12-25.eu-west-2.compute.amazonaws.com/job/Terraform/build?delay=0sec
 
-Perform an end to end smoke test of the adaptor by transferring the patient 9729962871 from C88046 to P83007 using the
-[instructions on Confluence][e2e-ptl-test-instructions].
+Perform an end to end smoke test of the adaptor by transferring the patient 9732596910 from C88046 to P83007 using the
+[instructions on Confluence][e2e-ptl-test-instructions] by setting the `to-ods: C88046` and `to-asid: 858000001001`.
 This patient record has:
 
 1. An allergy to penicillin
-1. A picture of the Colosseum as a document
+1. A picture of some marbles as a document
 
 Request the patient using the adaptor and check that the allergy is mapped into the Bundle,
-and that the document has been transferred to S3.
+and that the document has been transferred to S3 and the image is downloadable via a browser.
+
+If you get a 404 response with an `OperationOutcome` coding of "PATIENT_NOT_FOUND" you may need to [regenerate the patient]
+and then request that patient instead.
 
 Reject the transfer by sending a FAILED_TO_INTEGRATE response, that way we can reuse the same patient.
 
+[regenerate the patient]: https://nhse-dsic.atlassian.net/wiki/spaces/NIA/pages/12540018795/Testing+an+NME+winning+scenario+PS+Adaptor#Recreating-the-Smoke-Test-Patient
 [e2e-ptl-test-instructions]: https://gpitbjss.atlassian.net/wiki/spaces/NIA/pages/12540018795/Testing+an+NME+winning+scenario+PS+Adaptor
 
 ### Performing the release


### PR DESCRIPTION
## Type of change

Internal change (non-breaking change with no effect on the functionality affecting end users)

## Checklist:

- [x] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I have updated the [Changelog](/CHANGELOG.md) with details of my change in the UNRELEASED section if this change will affect end users
- [ ] A corresponding change has been made to the [Mapping Documentation repository][mapping-docs]

[mapping-docs]: https://github.com/NHSDigital/patient-switching-adaptors-mapping-documentation