### PR TITLE
NIAD-3220: Add Resource filter to identify "ReferralRequest to ExternalDocument LinkSets"

### DIFF
--- a/gp2gp-translator/src/main/java/uk/nhs/adaptors/pss/translator/util/ResourceFilterUtil.java
+++ b/gp2gp-translator/src/main/java/uk/nhs/adaptors/pss/translator/util/ResourceFilterUtil.java
@@ -5,11 +5,17 @@ import static uk.nhs.adaptors.pss.translator.util.CDUtil.extractSnomedCode;
 import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 import lombok.AccessLevel;
 import lombok.NoArgsConstructor;
+import org.hl7.v3.RCMRMT030101UKComponent;
+import org.hl7.v3.RCMRMT030101UKComponent3;
+import org.hl7.v3.RCMRMT030101UKComponent4;
 import org.hl7.v3.RCMRMT030101UKCompoundStatement;
 import org.hl7.v3.RCMRMT030101UKEhrExtract;
+import org.hl7.v3.RCMRMT030101UKLinkSet;
 import org.hl7.v3.RCMRMT030101UKNarrativeStatement;
 
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
@@ -17,6 +23,8 @@ public class ResourceFilterUtil {
 
     private static final List<String> ALLERGY_CODES = List.of("SN53.00", "14L..00");
     private static final String CODE_SYSTEM_READ_CODE_V2 = "2.16.840.1.113883.2.1.6.2";
+    private static final String SNOMED_CODE_SYSTEM = "2.16.840.1.113883.2.1.3.2.4.15";
+    private static final String UNSPECIFIED_PROBLEM_CODE = "394776006";
     private static final String PATHOLOGY_CODE = "16488004";
     private static final String SPECIMEN_CODE = "123038009";
     private static final String BATTERY_VALUE = "BATTERY";
@@ -80,6 +88,63 @@ public class ResourceFilterUtil {
             && !isDiagnosticReport(compoundStatement)
             && !isSpecimen(compoundStatement)
             && List.of(BATTERY_VALUE, CLUSTER_VALUE).contains(compoundStatement.getClassCode().getFirst());
+    }
+
+    public static boolean isReferralRequestToExternalDocumentLinkSet(RCMRMT030101UKEhrExtract ehrExtract, RCMRMT030101UKLinkSet linkSet) {
+        return hasUnspecifiedProblemCodeWithoutQualifierOrOriginalText(linkSet)
+            && !linkSet.getComponent().isEmpty()
+            && hasNamedStatementRefReferencingARequestStatement(ehrExtract, linkSet)
+            && containsOnlyComponentsWithStatementRefReferencingADocument(ehrExtract, linkSet);
+    }
+
+    private static boolean hasUnspecifiedProblemCodeWithoutQualifierOrOriginalText(RCMRMT030101UKLinkSet linkSet) {
+        return linkSet.hasCode()
+            && SNOMED_CODE_SYSTEM.equals(linkSet.getCode().getCodeSystem())
+            && UNSPECIFIED_PROBLEM_CODE.equals(linkSet.getCode().getCode())
+            && linkSet.getCode().getQualifier().isEmpty()
+            && !linkSet.getCode().hasOriginalText();
+    }
+
+    private static boolean containsOnlyComponentsWithStatementRefReferencingADocument(
+        RCMRMT030101UKEhrExtract ehrExtract,
+        RCMRMT030101UKLinkSet linkSet
+    ) {
+        var statementRefIds = linkSet.getComponent()
+            .stream()
+            .map(component -> component.getStatementRef().getId().getRoot())
+            .collect(Collectors.toSet());
+
+        return extractAllEhrCompositionComponentsAsStream(ehrExtract)
+            .flatMap(CompoundStatementResourceExtractors::extractAllNonBloodPressureNarrativeStatements)
+            .filter(Objects::nonNull)
+            .filter(ResourceFilterUtil::isDocumentReference)
+            .map(narrativeStatement -> narrativeStatement.getId().getRoot())
+            .collect(Collectors.toSet())
+            .containsAll(statementRefIds);
+    }
+
+    private static boolean hasNamedStatementRefReferencingARequestStatement(
+        RCMRMT030101UKEhrExtract ehrExtract,
+        RCMRMT030101UKLinkSet linkSet
+    ) {
+        if (linkSet.getConditionNamed() == null) {
+            return false;
+        }
+        var namedStatementRefId = linkSet.getConditionNamed().getNamedStatementRef().getId().getRoot();
+
+        return extractAllEhrCompositionComponentsAsStream(ehrExtract)
+            .flatMap(CompoundStatementResourceExtractors::extractAllRequestStatements)
+            .filter(Objects::nonNull)
+            .anyMatch(requestStatement -> namedStatementRefId.equals(requestStatement.getId().getFirst().getRoot()));
+    }
+
+    private static Stream<RCMRMT030101UKComponent4> extractAllEhrCompositionComponentsAsStream(RCMRMT030101UKEhrExtract ehrExtract) {
+        return ehrExtract.getComponent()
+            .stream()
+            .map(RCMRMT030101UKComponent::getEhrFolder)
+            .flatMap(ehrFolder -> ehrFolder.getComponent().stream())
+            .map(RCMRMT030101UKComponent3::getEhrComposition)
+            .flatMap(ehrComposition -> ehrComposition.getComponent().stream());
     }
 
     private static boolean hasCode(RCMRMT030101UKCompoundStatement compoundStatement) {

--- a/gp2gp-translator/src/test/java/uk/nhs/adaptors/pss/translator/util/ResourceFilterUtilTest.java
+++ b/gp2gp-translator/src/test/java/uk/nhs/adaptors/pss/translator/util/ResourceFilterUtilTest.java
@@ -8,6 +8,7 @@ import static uk.nhs.adaptors.pss.translator.util.XmlUnmarshallUtil.unmarshallFi
 import java.util.Objects;
 import java.util.stream.Stream;
 
+import org.hl7.v3.CR;
 import org.hl7.v3.RCMRMT030101UKComponent;
 import org.hl7.v3.RCMRMT030101UKComponent4;
 import org.hl7.v3.RCMRMT030101UKCompoundStatement;
@@ -169,6 +170,76 @@ public class ResourceFilterUtilTest {
 
         assertThat(ResourceFilterUtil.isReferralRequestToExternalDocumentLinkSet(ehrExtract, linkSet))
             .isTrue();
+    }
+
+    @Test
+    public void When_ActiveProblem_Expect_IsNotReferralRequestToExternalDocumentLinkSet() {
+        final var ehrExtract = unmarshallEhrExtractElement("ehr_extract_with_referral_request_to_external_document_linkset.xml");
+        final var linkSet = extractFirstLinkSetFromEhrExtract(ehrExtract);
+        linkSet.getCode().setCode("394774009");
+
+        assertThat(ResourceFilterUtil.isReferralRequestToExternalDocumentLinkSet(ehrExtract, linkSet))
+            .isFalse();
+    }
+
+    @Test
+    public void When_LinkSetHasReadV2Code_Expect_IsNotReferralRequestToExternalDocumentLinkSet() {
+        final var ehrExtract = unmarshallEhrExtractElement("ehr_extract_with_referral_request_to_external_document_linkset.xml");
+        final var linkSet = extractFirstLinkSetFromEhrExtract(ehrExtract);
+        linkSet.getCode().setCodeSystem("2.16.840.1.113883.2.1.6.2");
+
+        assertThat(ResourceFilterUtil.isReferralRequestToExternalDocumentLinkSet(ehrExtract, linkSet))
+            .isFalse();
+    }
+
+    @Test
+    public void When_LinkSetHasCodeWithQualifier_Expect_IsNotReferralRequestToExternalDocumentLinkSet() {
+        final var ehrExtract = unmarshallEhrExtractElement("ehr_extract_with_referral_request_to_external_document_linkset.xml");
+        final var linkSet = extractFirstLinkSetFromEhrExtract(ehrExtract);
+        linkSet.getCode().getQualifier().add(new CR());
+
+        assertThat(ResourceFilterUtil.isReferralRequestToExternalDocumentLinkSet(ehrExtract, linkSet))
+            .isFalse();
+    }
+
+    @Test
+    public void When_LinkSetHasCodeWithOriginalText_Expect_IsNotReferralRequestToExternalDocumentLinkSet() {
+        final var ehrExtract = unmarshallEhrExtractElement("ehr_extract_with_referral_request_to_external_document_linkset.xml");
+        final var linkSet = extractFirstLinkSetFromEhrExtract(ehrExtract);
+        linkSet.getCode().setOriginalText("original-text");
+
+        assertThat(ResourceFilterUtil.isReferralRequestToExternalDocumentLinkSet(ehrExtract, linkSet))
+            .isFalse();
+    }
+
+    @Test
+    public void When_LinkSetHasNoComponents_Expect_IsNotReferralRequestToExternalDocumentLinkSet() {
+        final var ehrExtract = unmarshallEhrExtractElement("ehr_extract_with_referral_request_to_external_document_linkset.xml");
+        final var linkSet = extractFirstLinkSetFromEhrExtract(ehrExtract);
+        linkSet.getComponent().clear();
+
+        assertThat(ResourceFilterUtil.isReferralRequestToExternalDocumentLinkSet(ehrExtract, linkSet))
+            .isFalse();
+    }
+
+    @Test
+    public void When_LinkSetHasNamedStatementRefWhichIsANarrativeStatement_Expect_IsNotReferralRequestToExternalDocumentLinkSet() {
+        final var ehrExtract = unmarshallEhrExtractElement("ehr_extract_with_referral_request_to_external_document_linkset.xml");
+        final var linkSet = extractFirstLinkSetFromEhrExtract(ehrExtract);
+        linkSet.getConditionNamed().getNamedStatementRef().getId().setRoot("narrative-statement-1");
+
+        assertThat(ResourceFilterUtil.isReferralRequestToExternalDocumentLinkSet(ehrExtract, linkSet))
+            .isFalse();
+    }
+
+    @Test
+    public void When_LinkSetHasComponentWhichReferencesRequestStatement_Expect_IsNotReferralRequestToExternalDocumentLinkSet() {
+        final var ehrExtract = unmarshallEhrExtractElement("ehr_extract_with_referral_request_to_external_document_linkset.xml");
+        final var linkSet = extractFirstLinkSetFromEhrExtract(ehrExtract);
+        linkSet.getComponent().getFirst().getStatementRef().getId().setRoot("request-statement-1");
+
+        assertThat(ResourceFilterUtil.isReferralRequestToExternalDocumentLinkSet(ehrExtract, linkSet))
+            .isFalse();
     }
 
     private RCMRMT030101UKLinkSet extractFirstLinkSetFromEhrExtract(RCMRMT030101UKEhrExtract ehrExtract) {

--- a/gp2gp-translator/src/test/java/uk/nhs/adaptors/pss/translator/util/ResourceFilterUtilTest.java
+++ b/gp2gp-translator/src/test/java/uk/nhs/adaptors/pss/translator/util/ResourceFilterUtilTest.java
@@ -5,9 +5,14 @@ import static org.springframework.util.ResourceUtils.getFile;
 
 import static uk.nhs.adaptors.pss.translator.util.XmlUnmarshallUtil.unmarshallFile;
 
+import java.util.Objects;
 import java.util.stream.Stream;
 
+import org.hl7.v3.RCMRMT030101UKComponent;
+import org.hl7.v3.RCMRMT030101UKComponent4;
 import org.hl7.v3.RCMRMT030101UKCompoundStatement;
+import org.hl7.v3.RCMRMT030101UKEhrExtract;
+import org.hl7.v3.RCMRMT030101UKLinkSet;
 import org.hl7.v3.RCMRMT030101UKNarrativeStatement;
 import org.hl7.v3.RCMRMT030101UKObservationStatement;
 import org.junit.jupiter.api.Test;
@@ -157,6 +162,26 @@ public class ResourceFilterUtilTest {
         );
     }
 
+    @Test
+    public void testIsReferralRequestToExternalDocumentLinkSet() {
+        final var ehrExtract = unmarshallEhrExtractElement("ehr_extract_with_referral_request_to_external_document_linkset.xml");
+        final var linkSet = extractFirstLinkSetFromEhrExtract(ehrExtract);
+
+        assertThat(ResourceFilterUtil.isReferralRequestToExternalDocumentLinkSet(ehrExtract, linkSet))
+            .isTrue();
+    }
+
+    private RCMRMT030101UKLinkSet extractFirstLinkSetFromEhrExtract(RCMRMT030101UKEhrExtract ehrExtract) {
+        return ehrExtract.getComponent().stream()
+            .map(RCMRMT030101UKComponent::getEhrFolder)
+            .flatMap(ehrFolder -> ehrFolder.getComponent().stream())
+            .flatMap(component -> component.getEhrComposition().getComponent().stream())
+            .map(RCMRMT030101UKComponent4::getLinkSet)
+            .filter(Objects::nonNull)
+            .findFirst()
+            .orElseThrow();
+    }
+
     @SneakyThrows
     private RCMRMT030101UKCompoundStatement unmarshallCompoundStatementElement(String fileName) {
         return unmarshallFile(getFile("classpath:" + XML_RESOURCES + fileName),
@@ -173,5 +198,11 @@ public class ResourceFilterUtilTest {
     private RCMRMT030101UKNarrativeStatement unmarshallNarrativeStatementElement(String fileName) {
         return unmarshallFile(getFile("classpath:" + XML_RESOURCES + fileName),
             RCMRMT030101UKNarrativeStatement.class);
+    }
+
+    @SneakyThrows
+    private RCMRMT030101UKEhrExtract unmarshallEhrExtractElement(String fileName) {
+        return unmarshallFile(getFile("classpath:" + XML_RESOURCES + fileName),
+            RCMRMT030101UKEhrExtract.class);
     }
 }

--- a/gp2gp-translator/src/test/resources/xml/ResourceFilter/ehr_extract_with_referral_request_to_external_document_linkset.xml
+++ b/gp2gp-translator/src/test/resources/xml/ResourceFilter/ehr_extract_with_referral_request_to_external_document_linkset.xml
@@ -44,7 +44,7 @@
                                     <availabilityTime value="202105251602"/>
                                     <component contextConductionInd="true" typeCode="COMP">
                                         <RequestStatement classCode="OBS" moodCode="RQO">
-                                            <id root="22148CD1-B1ED-4D43-A62A-B5201471BB39"/>
+                                            <id root="request-statement-1"/>
                                             <code code="8H54.00" codeSystem="2.16.840.1.113883.2.1.6.2" displayName="Orthopaedic referral">
                                                 <qualifier codeSystem="2.16.840.1.113883.2.1.6.3" inverted="false">
                                                     <name code="RequestType" displayName="RequestType"/>
@@ -76,7 +76,7 @@
                                     <availabilityTime value="202105251602"/>
                                     <component contextConductionInd="true" typeCode="COMP">
                                         <NarrativeStatement classCode="OBS" moodCode="EVN">
-                                            <id root="5BFD7297-4ACC-420A-BF2F-3448D4665DDA"/>
+                                            <id root="narrative-statement-1"/>
                                             <text>NHS e-Referral UBRN [redacted] for Orthopaedic referral, NHS e-RS UBRN [redacted] for Orthopaedic referral</text>
                                             <statusCode code="COMPLETE"/>
                                             <availabilityTime value="20210525"/>
@@ -95,7 +95,7 @@
                                     </component>
                                     <component contextConductionInd="true" typeCode="COMP">
                                         <NarrativeStatement classCode="OBS" moodCode="EVN">
-                                            <id root="8227E990-A72F-11EF-BE87-0800200C9A66"/>
+                                            <id root="narrative-statement-2"/>
                                             <text>NHS e-Referral UBRN [redacted] for Orthopaedic referral, NHS e-RS UBRN [redacted] for Orthopaedic referral</text>
                                             <statusCode code="COMPLETE"/>
                                             <availabilityTime value="20210525"/>
@@ -127,17 +127,17 @@
                             <availabilityTime value="20230913121921"/>
                             <component typeCode="COMP">
                                 <statementRef classCode="OBS" moodCode="EVN">
-                                    <id root="5BFD7297-4ACC-420A-BF2F-3448D4665DDA"/>
+                                    <id root="narrative-statement-1"/>
                                 </statementRef>
                             </component>
                             <component typeCode="COMP">
                                 <statementRef classCode="OBS" moodCode="EVN">
-                                    <id root="8227E990-A72F-11EF-BE87-0800200C9A66"/>
+                                    <id root="narrative-statement-2"/>
                                 </statementRef>
                             </component>
                             <conditionNamed inversionInd="true" typeCode="NAME">
                                 <namedStatementRef classCode="OBS" moodCode="EVN">
-                                    <id root="22148CD1-B1ED-4D43-A62A-B5201471BB39"/>
+                                    <id root="request-statement-1"/>
                                 </namedStatementRef>
                             </conditionNamed>
                         </LinkSet>

--- a/gp2gp-translator/src/test/resources/xml/ResourceFilter/ehr_extract_with_referral_request_to_external_document_linkset.xml
+++ b/gp2gp-translator/src/test/resources/xml/ResourceFilter/ehr_extract_with_referral_request_to_external_document_linkset.xml
@@ -87,7 +87,26 @@
                                                         <originalText>e-RS Letter (25-May-2021)</originalText>
                                                     </code>
                                                     <text mediaType="text/rtf">
-                                                        <reference value="https://gb-nhs-prod-gp2gp-adaptor-documents.s3.eu-west-2.amazonaws.com/[url redacted]"/>
+                                                        <reference value="https://[url redacted]"/>
+                                                    </text>
+                                                </referredToExternalDocument>
+                                            </reference>
+                                        </NarrativeStatement>
+                                    </component>
+                                    <component contextConductionInd="true" typeCode="COMP">
+                                        <NarrativeStatement classCode="OBS" moodCode="EVN">
+                                            <id root="8227E990-A72F-11EF-BE87-0800200C9A66"/>
+                                            <text>NHS e-Referral UBRN [redacted] for Orthopaedic referral, NHS e-RS UBRN [redacted] for Orthopaedic referral</text>
+                                            <statusCode code="COMPLETE"/>
+                                            <availabilityTime value="20210525"/>
+                                            <reference typeCode="REFR">
+                                                <referredToExternalDocument classCode="DOC" moodCode="EVN">
+                                                    <id root="74E407FF-8C96-4B8F-873A-566B3AC921BE"/>
+                                                    <code code="25821000000100" codeSystem="2.16.840.1.113883.2.1.3.2.4.15" displayName="Original text document">
+                                                        <originalText>e-RS Letter (25-May-2021)</originalText>
+                                                    </code>
+                                                    <text mediaType="text/rtf">
+                                                        <reference value="https://[url redacted]"/>
                                                     </text>
                                                 </referredToExternalDocument>
                                             </reference>
@@ -109,6 +128,11 @@
                             <component typeCode="COMP">
                                 <statementRef classCode="OBS" moodCode="EVN">
                                     <id root="5BFD7297-4ACC-420A-BF2F-3448D4665DDA"/>
+                                </statementRef>
+                            </component>
+                            <component typeCode="COMP">
+                                <statementRef classCode="OBS" moodCode="EVN">
+                                    <id root="8227E990-A72F-11EF-BE87-0800200C9A66"/>
                                 </statementRef>
                             </component>
                             <conditionNamed inversionInd="true" typeCode="NAME">

--- a/gp2gp-translator/src/test/resources/xml/ResourceFilter/ehr_extract_with_referral_request_to_external_document_linkset.xml
+++ b/gp2gp-translator/src/test/resources/xml/ResourceFilter/ehr_extract_with_referral_request_to_external_document_linkset.xml
@@ -1,0 +1,125 @@
+<EhrExtract xmlns="urn:hl7-org:v3" classCode="EXTRACT" moodCode="EVN">
+    <availabilityTime value="20101209114846"/>
+    <component typeCode="COMP">
+        <ehrFolder classCode="FOLDER" moodCode="EVN">
+            <component typeCode="COMP">
+                <ehrComposition classCode="COMPOSITION" moodCode="EVN">
+                    <id root="B9727462-9F98-462A-BCC0-045181186927"/>
+                    <code code="24591000000103" codeSystem="2.16.840.1.113883.2.1.3.2.4.15" displayName="Other report">
+                        <originalText>Outbound Referral</originalText>
+                    </code>
+                    <statusCode code="COMPLETE"/>
+                    <effectiveTime>
+                        <center nullFlavor="NI"/>
+                    </effectiveTime>
+                    <availabilityTime value="202105251602"/>
+                    <author contextControlCode="OP" typeCode="AUT">
+                        <time value="20230913121921"/>
+                        <agentRef classCode="AGNT">
+                            <id root="2A964470-EE5A-D1DB-04D2-B08AA137DA1D"/>
+                        </agentRef>
+                    </author>
+                    <Participant2 contextControlCode="OP" typeCode="RESP">
+                        <agentRef classCode="AGNT">
+                            <id root="6B78D0BB-8E52-FEEC-4CFC-A15C50378396"/>
+                        </agentRef>
+                    </Participant2>
+                    <component typeCode="COMP">
+                        <CompoundStatement classCode="TOPIC" moodCode="EVN">
+                            <id root="F1ED066B-3BB5-4E8F-83DB-D58C0FB69BD7"/>
+                            <code code="Z....00" codeSystem="2.16.840.1.113883.2.1.6.2" displayName="UnspecifiedCondtions"/>
+                            <statusCode code="COMPLETE"/>
+                            <effectiveTime>
+                                <center nullFlavor="NI"/>
+                            </effectiveTime>
+                            <availabilityTime value="202105251602"/>
+                            <component contextConductionInd="true" typeCode="COMP">
+                                <CompoundStatement classCode="CATEGORY" moodCode="EVN">
+                                    <id root="F35A022F-8B2B-404C-9596-562672BCF718"/>
+                                    <code code="3457005" codeSystem="2.16.840.1.113883.2.1.3.2.4.15" displayName="Referral"/>
+                                    <statusCode code="COMPLETE"/>
+                                    <effectiveTime>
+                                        <center nullFlavor="NI"/>
+                                    </effectiveTime>
+                                    <availabilityTime value="202105251602"/>
+                                    <component contextConductionInd="true" typeCode="COMP">
+                                        <RequestStatement classCode="OBS" moodCode="RQO">
+                                            <id root="22148CD1-B1ED-4D43-A62A-B5201471BB39"/>
+                                            <code code="8H54.00" codeSystem="2.16.840.1.113883.2.1.6.2" displayName="Orthopaedic referral">
+                                                <qualifier codeSystem="2.16.840.1.113883.2.1.6.3" inverted="false">
+                                                    <name code="RequestType" displayName="RequestType"/>
+                                                    <value code="Unknown" displayName="Unknown"/>
+                                                </qualifier>
+                                                <translation code="183545006" codeSystem="2.16.840.1.113883.2.1.3.2.4.15"/>
+                                            </code>
+                                            <text>NHS e-Referral Service, Purpose: Unknown</text>
+                                            <statusCode code="COMPLETE"/>
+                                            <effectiveTime>
+                                                <center nullFlavor="NI"/>
+                                            </effectiveTime>
+                                            <availabilityTime value="20210525"/>
+                                            <priorityCode code="394848005" codeSystem="2.16.840.1.113883.2.1.3.2.4.15" displayName="Normal">
+                                                <originalText>Routine</originalText>
+                                            </priorityCode>
+                                        </RequestStatement>
+                                    </component>
+                                </CompoundStatement>
+                            </component>
+                            <component contextConductionInd="true" typeCode="COMP">
+                                <CompoundStatement classCode="CATEGORY" moodCode="EVN">
+                                    <id root="249D0BEC-B479-439F-AB85-1632FEFC3E11"/>
+                                    <code code="1712901000006107" codeSystem="2.16.840.1.113883.2.1.3.2.4.15" displayName="Document"/>
+                                    <statusCode code="COMPLETE"/>
+                                    <effectiveTime>
+                                        <center nullFlavor="NI"/>
+                                    </effectiveTime>
+                                    <availabilityTime value="202105251602"/>
+                                    <component contextConductionInd="true" typeCode="COMP">
+                                        <NarrativeStatement classCode="OBS" moodCode="EVN">
+                                            <id root="5BFD7297-4ACC-420A-BF2F-3448D4665DDA"/>
+                                            <text>NHS e-Referral UBRN [redacted] for Orthopaedic referral, NHS e-RS UBRN [redacted] for Orthopaedic referral</text>
+                                            <statusCode code="COMPLETE"/>
+                                            <availabilityTime value="20210525"/>
+                                            <reference typeCode="REFR">
+                                                <referredToExternalDocument classCode="DOC" moodCode="EVN">
+                                                    <id root="74E407FF-8C96-4B8F-873A-566B3AC921BE"/>
+                                                    <code code="25821000000100" codeSystem="2.16.840.1.113883.2.1.3.2.4.15" displayName="Original text document">
+                                                        <originalText>e-RS Letter (25-May-2021)</originalText>
+                                                    </code>
+                                                    <text mediaType="text/rtf">
+                                                        <reference value="https://gb-nhs-prod-gp2gp-adaptor-documents.s3.eu-west-2.amazonaws.com/[url redacted]"/>
+                                                    </text>
+                                                </referredToExternalDocument>
+                                            </reference>
+                                        </NarrativeStatement>
+                                    </component>
+                                </CompoundStatement>
+                            </component>
+                        </CompoundStatement>
+                    </component>
+                    <component typeCode="COMP">
+                        <LinkSet classCode="OBS" moodCode="EVN">
+                            <id root="F26B6571-EB9B-4821-A71F-FA046BBF690E"/>
+                            <code code="394776006" codeSystem="2.16.840.1.113883.2.1.3.2.4.15" displayName="Unspecified problem"/>
+                            <statusCode code="COMPLETE"/>
+                            <effectiveTime>
+                                <center value="202309131219"/>
+                            </effectiveTime>
+                            <availabilityTime value="20230913121921"/>
+                            <component typeCode="COMP">
+                                <statementRef classCode="OBS" moodCode="EVN">
+                                    <id root="5BFD7297-4ACC-420A-BF2F-3448D4665DDA"/>
+                                </statementRef>
+                            </component>
+                            <conditionNamed inversionInd="true" typeCode="NAME">
+                                <namedStatementRef classCode="OBS" moodCode="EVN">
+                                    <id root="22148CD1-B1ED-4D43-A62A-B5201471BB39"/>
+                                </namedStatementRef>
+                            </conditionNamed>
+                        </LinkSet>
+                    </component>
+                </ehrComposition>
+            </component>
+        </ehrFolder>
+    </component>
+</EhrExtract>


### PR DESCRIPTION
## What

* Add Test to check verify that the provided `LinkSet` is a "Referral Request to External Document LinkSet."
* Add test XML file containing a "Referral Request to External Document LinkSet."
* Add method `isReferralRequestToExternalDocumentLinkSet` to `ResourceFilterUtil` with parameters for the `EhrExtract` and the `LinkSet` itself to identify `LinkSets` matching the criteria for a "Referral Request to External Document LinkSet."

## Why

As part of the implementation for NIAD-3220, it is necessary to identify `LinkSets` which are a "Referral Request to External Document LinkSet" in order to be able to then use this for filtering in the `ConditionMapper` to exclude the `Condition` from being mapped, and in `ReferralRequest` mapper to identify any of these LinkSets when populating the `supportingInfo` field.

A "ReferralRequest to ExternalDocument LinkSet" is defined as a `LinkSet` which matches the following criteria:

- It has a `code` with a `value` of `394776006` and a `system` of `2.16.840.1.113883.2.1.3.2.4.15` and no `qualifier` and no `originalText`
- The `conditionNamed / namedStatementRef / id[root]` is a `RequestStatement`
- It has at least 1 `component`
- All the `component / statementRef / id[root]` are references to GP2GP document/attachments.

## Type of change

Please delete options that are not relevant.

- [x] Internal change (non-breaking change with no effect on the functionality affecting end users)

## Checklist:

- [x] I have performed a self-review of my code
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have updated the [Changelog](/CHANGELOG.md) with details of my change in the UNRELEASED section if this change will affect end users
- [x] A corresponding change has been made to the [Mapping Documentation repository][mapping-docs]

[mapping-docs]: https://github.com/NHSDigital/patient-switching-adaptors-mapping-documentation