### PR TITLE
NIAD-3220: Detect Referral + Document LinkSets and not create a Problem (Condition) from them

### DIFF
--- a/gp2gp-translator/src/integrationTest/resources/e2e-mapping/output-json/PWTP7_vis-output.json
+++ b/gp2gp-translator/src/integrationTest/resources/e2e-mapping/output-json/PWTP7_vis-output.json
@@ -2073,6 +2073,11 @@
         } ],
         "text": "Referral to private doctor"
       } ],
+      "supportingInfo": [ {
+        "reference": "DocumentReference/BFBF038A-F142-4C67-B05B-D155E2C89990"
+      }, {
+        "reference": "DocumentReference/6DC83A17-4DFD-4C1C-A452-45F8F8A8FBA1"
+      } ],
       "note": [ {
         "text": "Priority: Routine"
       }, {
@@ -2622,61 +2627,6 @@
         "reference": "Practitioner/1E473786-E7FA-785E-C911-A8D38FB56F20"
       } ],
       "comment": "This is a dry eyes problem {Episodicity : code=255217005, displayName=First}"
-    }
-  }, {
-    "resource": {
-      "resourceType": "Condition",
-      "id": "E0EF416A-A513-4668-B454-1F3002573B80",
-      "meta": {
-        "profile": [ "https://fhir.nhs.uk/STU3/StructureDefinition/CareConnect-GPC-ProblemHeader-Condition-1" ]
-      },
-      "extension": [ {
-        "url": "https://fhir.hl7.org.uk/STU3/StructureDefinition/Extension-CareConnect-ProblemSignificance-1",
-        "valueCode": "minor"
-      }, {
-        "url": "https://fhir.hl7.org.uk/STU3/StructureDefinition/Extension-CareConnect-ActualProblem-1",
-        "valueReference": {
-          "reference": "ReferralRequest/E63AF323-919F-4D5F-9A1D-BA933BC230BC"
-        }
-      }, {
-        "url": "https://fhir.hl7.org.uk/STU3/StructureDefinition/Extension-CareConnect-RelatedClinicalContent-1",
-        "valueReference": {
-          "reference": "DocumentReference/BFBF038A-F142-4C67-B05B-D155E2C89990"
-        }
-      }, {
-        "url": "https://fhir.hl7.org.uk/STU3/StructureDefinition/Extension-CareConnect-RelatedClinicalContent-1",
-        "valueReference": {
-          "reference": "DocumentReference/6DC83A17-4DFD-4C1C-A452-45F8F8A8FBA1"
-        }
-      } ],
-      "identifier": [ {
-        "system": "https://PSSAdaptor/B83002",
-        "value": "E0EF416A-A513-4668-B454-1F3002573B80"
-      } ],
-      "clinicalStatus": "active",
-      "category": [ {
-        "coding": [ {
-          "system": "https://fhir.hl7.org.uk/STU3/CodeSystem/CareConnect-ConditionCategory-1",
-          "code": "problem-list-item",
-          "display": "Problem List Item"
-        } ]
-      } ],
-      "subject": {
-        "reference": "Patient/00000000-0000-0000-0000-000000000012"
-      },
-      "context": {
-        "reference": "Encounter/7626FAAD-8562-478D-B79C-598520953E86"
-      },
-      "onsetDateTime": "2010-01-19T11:32:00+00:00",
-      "assertedDate": "2010-01-19T11:32:30+00:00",
-      "asserter": {
-        "reference": "Practitioner/1E473786-E7FA-785E-C911-A8D38FB56F20"
-      },
-      "note": [ {
-        "text": "Defaulted status to active : Unknown status at source"
-      }, {
-        "text": "Unspecified Significance: Defaulted to Minor"
-      } ]
     }
   }, {
     "resource": {

--- a/gp2gp-translator/src/main/java/uk/nhs/adaptors/pss/translator/mapper/ConditionMapper.java
+++ b/gp2gp-translator/src/main/java/uk/nhs/adaptors/pss/translator/mapper/ConditionMapper.java
@@ -58,6 +58,7 @@ import lombok.extern.slf4j.Slf4j;
 import uk.nhs.adaptors.pss.translator.service.ConfidentialityService;
 import uk.nhs.adaptors.pss.translator.util.CompoundStatementResourceExtractors;
 import uk.nhs.adaptors.pss.translator.util.DegradedCodeableConcepts;
+import uk.nhs.adaptors.pss.translator.util.ResourceFilterUtil;
 import static uk.nhs.adaptors.common.util.CodeableConceptUtils.createCodeableConcept;
 
 @Service
@@ -96,6 +97,7 @@ public class ConditionMapper extends AbstractMapper<Condition> {
         return mapEhrExtractToFhirResource(ehrExtract, (extract, composition, component) ->
                 extractAllLinkSets(component)
                     .filter(Objects::nonNull)
+                    .filter(linkSet -> !ResourceFilterUtil.isReferralRequestToExternalDocumentLinkSet(ehrExtract, linkSet))
                     .map(linkSet -> getCondition(
                         patient,
                         encounters,

--- a/gp2gp-translator/src/test/java/uk/nhs/adaptors/pss/translator/mapper/ConditionMapperTest.java
+++ b/gp2gp-translator/src/test/java/uk/nhs/adaptors/pss/translator/mapper/ConditionMapperTest.java
@@ -363,6 +363,18 @@ class ConditionMapperTest {
         );
     }
 
+    @Test
+    void When_MappingLinksetWhichIsAReferralRequestToExternalDocumentLinkSet_Expect_ConditionNotToBeMapped() {
+        final var ehrExtract = unmarshallEhrExtract(
+            "ResourceFilter",
+            "ehr_extract_with_referral_request_to_external_document_linkset.xml"
+        );
+
+        final List<Condition> conditions = conditionMapper.mapResources(ehrExtract, patient, Collections.emptyList(), PRACTISE_CODE);
+
+        assertThat(conditions).hasSize(0);
+    }
+
     private void addMedicationRequestsToBundle(Bundle bundle) {
         var planMedicationRequest = new MedicationRequest().setId(AUTHORISE_ID);
         var orderMedicationRequest = new MedicationRequest().setId(PRESCRIBE_ID);
@@ -448,9 +460,14 @@ class ConditionMapperTest {
     }
 
     @SneakyThrows
-    private RCMRMT030101UKEhrExtract unmarshallEhrExtract(String filename) {
-        final File file = FileFactory.getXmlFileFor(TEST_FILES_DIRECTORY, filename);
+    private RCMRMT030101UKEhrExtract unmarshallEhrExtract(String testFilesDirectory, String filename) {
+        final File file = FileFactory.getXmlFileFor(testFilesDirectory, filename);
         return unmarshallFile(file, RCMRMT030101UKEhrExtract.class);
+    }
+
+    @SneakyThrows
+    private RCMRMT030101UKEhrExtract unmarshallEhrExtract(String filename) {
+        return unmarshallEhrExtract(TEST_FILES_DIRECTORY, filename);
     }
 
     private void configureCommonStubs() {


### PR DESCRIPTION
## What

* Add functionality to ConditionMapper to ensure that a `Condition` is not mapped from a `LinkSet` when it is a "ReferralRequestToExternalDocumentLinkSet." 
* Add unit test for the above functionality.
* Add functionality to ReferralRequestMapper to set `supportingInfo` with `DocumentReferences` to when the `ReferralRequest` is referenced from a "ReferralRequestToExternalDocumentLinkSet." 
* Add unit test for above functionality.
* Update PWTP7_vis-output.json to reflect the changes made.

## Why

In #936 the functionality was added to identify `LinkSets` which are a "Referral Request to External Document LinkSet".

A "ReferralRequest to ExternalDocument LinkSet" is defined as a `LinkSet` which matches the following criteria:

- It has a `code` with a `value` of `394776006` and a `system` of `2.16.840.1.113883.2.1.3.2.4.15` and no `qualifier` and no `originalText`
- The `conditionNamed / namedStatementRef / id[root]` is a `RequestStatement`
- It has at least 1 `component`
- All the `component / statementRef / id[root]` are references to GP2GP document/attachments.

The purpose of this PR is to use the resource filter previously add to ensure that:

* A `Condition` is not created from the LinkSet.
* In the mapped `ReferralRequest`, then the `supportingInfo` field should be populated by `DocumentRefrence` references taken from the Linkset `statementRef` field.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [x] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] I have updated the [Changelog](/CHANGELOG.md) with details of my change in the UNRELEASED section if this change will affect end users
- [ ] A corresponding change has been made to the [Mapping Documentation repository][mapping-docs]

[mapping-docs]: https://github.com/NHSDigital/patient-switching-adaptors-mapping-documentation