### PR TITLE
add 7 day cooldown to gradle package updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -14,3 +14,5 @@ updates:
       - "/smoke-tests"
     schedule:
       interval: "weekly"
+    cooldown:
+      default-days: 7

--- a/REDACTIONS.md
+++ b/REDACTIONS.md
@@ -32,7 +32,7 @@ To enable Redactions, the GP2GP Adaptor should be deployed with the following en
 ***`GP2GP_REDACTIONS_ENABLED: true`***
 
 To disable Redactions, the GP2GP Adaptor should be deployed with the following environment variable:
-
+                                               
 ***`GP2GP_REDACTIONS_ENABLED: false`***
 
 Note that if Redactions are not enabled, the resultant XML will be produced with an `interactionId` of `RCMR_IN030000UK06` and

--- a/REDACTIONS.md
+++ b/REDACTIONS.md
@@ -32,7 +32,7 @@ To enable Redactions, the GP2GP Adaptor should be deployed with the following en
 ***`GP2GP_REDACTIONS_ENABLED: true`***
 
 To disable Redactions, the GP2GP Adaptor should be deployed with the following environment variable:
-                                               
+
 ***`GP2GP_REDACTIONS_ENABLED: false`***
 
 Note that if Redactions are not enabled, the resultant XML will be produced with an `interactionId` of `RCMR_IN030000UK06` and


### PR DESCRIPTION
## What

Add default cooldown of 7 days to dependabot.yml for gradle packages.

## Why

Following on from recent compromised package updates, we want to enforce a 7 day cooldown on any package updates to ensure that we're not potentially bringing dangerous updates into our deployments.

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Internal change (non-breaking change with no effect on the functionality affecting end users)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:

- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes