### PR TITLE
Refactor `AzureStorageService` to inject `BlobContainerClient` instead of `BlobClient`

### DIFF
--- a/config/spotbugs/exclude.xml
+++ b/config/spotbugs/exclude.xml
@@ -44,4 +44,14 @@
         <Bug pattern="MS_EXPOSE_REP"/>
     </Match>
 
+    <Match>
+        <Class name="uk.nhs.adaptors.pss.translator.storage.AzureStorageService"/>
+        <Bug pattern="EI_EXPOSE_REP2"/>
+    </Match>
+
+    <Match>
+        <Class name="uk.nhs.adaptors.pss.translator.storage.AWSStorageService"/>
+        <Bug pattern="EI_EXPOSE_REP2"/>
+    </Match>
+
 </FindBugsFilter>

--- a/gp2gp-translator/src/integrationTest/java/uk/nhs/adaptors/pss/translator/storage/AzureStorageServiceTest.java
+++ b/gp2gp-translator/src/integrationTest/java/uk/nhs/adaptors/pss/translator/storage/AzureStorageServiceTest.java
@@ -32,10 +32,9 @@ public class AzureStorageServiceTest {
                 .buildClient();
         blobServiceClient.createBlobContainer(CONTAINER_NAME);
 
-        StorageServiceConfiguration config = new StorageServiceConfiguration();
-        config.setContainerName(CONTAINER_NAME);
+        var blobContainerClient = blobServiceClient.getBlobContainerClient(CONTAINER_NAME);
 
-        azureStorageService = new AzureStorageService(blobServiceClient, config);
+        azureStorageService = new AzureStorageService(blobContainerClient);
     }
 
     @AfterEach

--- a/gp2gp-translator/src/main/java/uk/nhs/adaptors/pss/translator/storage/AWSStorageService.java
+++ b/gp2gp-translator/src/main/java/uk/nhs/adaptors/pss/translator/storage/AWSStorageService.java
@@ -6,7 +6,6 @@ import java.io.InputStream;
 import java.net.URL;
 import java.time.Duration;
 
-import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.io.IOUtils;
 import software.amazon.awssdk.auth.credentials.AwsBasicCredentials;
@@ -23,7 +22,6 @@ import software.amazon.awssdk.services.s3.presigner.S3Presigner;
 import software.amazon.awssdk.services.s3.presigner.model.GetObjectPresignRequest;
 
 @Slf4j
-@SuppressFBWarnings(value = "EI_EXPOSE_REP2", justification = "S3Client is immutable and thread-safe.")
 public class AWSStorageService implements StorageService {
 
     private static final long SIXTY_MINUTES = 60;

--- a/gp2gp-translator/src/main/java/uk/nhs/adaptors/pss/translator/storage/AzureStorageService.java
+++ b/gp2gp-translator/src/main/java/uk/nhs/adaptors/pss/translator/storage/AzureStorageService.java
@@ -6,19 +6,14 @@ import java.io.IOException;
 import java.io.InputStream;
 
 import com.azure.storage.blob.BlobContainerClient;
-import com.azure.storage.blob.BlobServiceClient;
 import com.azure.storage.blob.specialized.BlockBlobClient;
-import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 
-@SuppressFBWarnings(value = "EI_EXPOSE_REP2", justification = "BlobServiceClient is immutable and thread-safe.")
 public class AzureStorageService implements StorageService {
 
-    private final BlobServiceClient blobServiceClient;
-    private final String containerName;
+    private final BlobContainerClient blobContainerClient;
 
-    public AzureStorageService(BlobServiceClient client, StorageServiceConfiguration config) {
-        blobServiceClient = client;
-        containerName = config.getContainerName();
+    public AzureStorageService(BlobContainerClient client) {
+        blobContainerClient = client;
     }
 
     public void uploadFile(String filename, byte[] fileAsString) throws StorageException {
@@ -35,23 +30,15 @@ public class AzureStorageService implements StorageService {
     }
 
     public void deleteFile(String filename) {
-        BlobContainerClient containerClient = createBlobContainerClient();
-        BlockBlobClient blobClient = containerClient.getBlobClient(filename).getBlockBlobClient();
-        blobClient.delete();
+        createBlobBlockClient(filename).delete();
     }
 
     public String getFileLocation(String filename) {
-        var blobClient = createBlobBlockClient(filename);
-        return blobClient.getBlobUrl();
-    }
-
-    private BlobContainerClient createBlobContainerClient() {
-        return blobServiceClient.getBlobContainerClient(containerName);
+        return createBlobBlockClient(filename).getBlobUrl();
     }
 
     private BlockBlobClient createBlobBlockClient(String filename) {
-        BlobContainerClient containerClient = createBlobContainerClient();
-        return containerClient.getBlobClient(filename).getBlockBlobClient();
+        return blobContainerClient.getBlobClient(filename).getBlockBlobClient();
     }
 
     private void addFileStringToMainContainer(String filename, byte[] fileAsString) throws StorageException, IOException {
@@ -75,5 +62,4 @@ public class AzureStorageService implements StorageService {
             throw new StorageException("Failed to download blob from Azure Blob storage", e);
         }
     }
-
 }

--- a/gp2gp-translator/src/main/java/uk/nhs/adaptors/pss/translator/storage/StorageServiceConfig.java
+++ b/gp2gp-translator/src/main/java/uk/nhs/adaptors/pss/translator/storage/StorageServiceConfig.java
@@ -34,7 +34,9 @@ public class StorageServiceConfig {
                 .credential(credentials)
                 .buildClient();
 
-        return new AzureStorageService(blobServiceClient, configuration);
+        var blobContainerClient = blobServiceClient.getBlobContainerClient(configuration.getContainerName());
+
+        return new AzureStorageService(blobContainerClient);
     }
 
     @Bean

--- a/gp2gp-translator/src/test/java/uk/nhs/adaptors/pss/translator/storage/AzureStorageServiceTest.java
+++ b/gp2gp-translator/src/test/java/uk/nhs/adaptors/pss/translator/storage/AzureStorageServiceTest.java
@@ -1,7 +1,6 @@
 package uk.nhs.adaptors.pss.translator.storage;
 
 import com.azure.storage.blob.BlobContainerClient;
-import com.azure.storage.blob.BlobServiceClient;
 import com.azure.storage.blob.models.BlobProperties;
 import com.azure.storage.blob.specialized.BlockBlobClient;
 import com.azure.storage.blob.BlobClient;
@@ -25,15 +24,9 @@ import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
 public class AzureStorageServiceTest {
-
-    private static final String CONTAINER_NAME = "container";
     private static final String FILE_NAME = "testfile.txt";
     private static final byte[] FILE_CONTENT = "mock-content".getBytes(StandardCharsets.UTF_8);
 
-    @Mock
-    private BlobServiceClient blobServiceClient;
-    @Mock
-    private StorageServiceConfiguration configuration;
     @Mock
     private BlobContainerClient blobContainerClient;
     @Mock
@@ -47,19 +40,17 @@ public class AzureStorageServiceTest {
 
     @BeforeEach
     void setUp() {
-        when(configuration.getContainerName()).thenReturn(CONTAINER_NAME);
-        azureStorageService = new AzureStorageService(blobServiceClient, configuration);
+        azureStorageService = new AzureStorageService(blobContainerClient);
     }
 
-    private void mockBlobClientChain() {
-        when(blobServiceClient.getBlobContainerClient(CONTAINER_NAME)).thenReturn(blobContainerClient);
+    private void mockBlobContainerClientChain() {
         when(blobContainerClient.getBlobClient(FILE_NAME)).thenReturn(blobClient);
         when(blobClient.getBlockBlobClient()).thenReturn(blockBlobClient);
     }
 
     @Test
     void When_UploadFile_Expect_SuccessfullyUploadsToAzure() throws StorageException {
-        mockBlobClientChain();
+        mockBlobContainerClientChain();
 
         azureStorageService.uploadFile(FILE_NAME, FILE_CONTENT);
 
@@ -68,7 +59,7 @@ public class AzureStorageServiceTest {
 
     @Test
     void When_DownloadFile_Expect_SuccessfullyDownloadsFromAzure() throws StorageException {
-        mockBlobClientChain();
+        mockBlobContainerClientChain();
         when(blockBlobClient.getProperties()).thenReturn(blobProperties);
         when(blobProperties.getBlobSize()).thenReturn((long) FILE_CONTENT.length);
 
@@ -85,7 +76,7 @@ public class AzureStorageServiceTest {
 
     @Test
     void When_DeleteFile_Expect_SuccessfullyDeletesFromAzure() {
-        mockBlobClientChain();
+        mockBlobContainerClientChain();
 
         azureStorageService.deleteFile(FILE_NAME);
 
@@ -94,7 +85,7 @@ public class AzureStorageServiceTest {
 
     @Test
     void When_GetFileLocation_Expect_ReturnsCorrectUrl() {
-        mockBlobClientChain();
+        mockBlobContainerClientChain();
         String expectedUrl = "https://azuremock.blob.core.windows.net/test-container/testfile.txt";
         when(blockBlobClient.getBlobUrl()).thenReturn(expectedUrl);
 


### PR DESCRIPTION
## What

* Move SpotBug suppression warning to the exclude file, for consistency when suppressing the warning for thread safe immutable cloud dependencies.
* Refactor `AzureStorageService` and dependent tests to now inject the container client service, reducing the need to create a new one each time a work function is called against the service.

## Why

The adaptor only ever accesses a single blob container with the name as provided in the configuration.  At present the adaptor injects a `BlobClient` and creates a new `BlobContainerClient` each time an operation is performed against that container.  That is inefficient and wasteful of resources.

This fix corrects that by injecting the `BlobContainerClient` instead.

This also moves the `SpotBugs` suppression warnings to the `SpotBugs Exclusion File` to ensure consistency and remove code bloat.

## Type of change

Please delete options that are not relevant.

- [x] Internal change (non-breaking change with no effect on the functionality affecting end users)

## Checklist:

- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes