### PR TITLE
NIAD-3463: Temporarily disable Mutation testing

### DIFF
--- a/.github/workflows/mutation-tests.yml
+++ b/.github/workflows/mutation-tests.yml
@@ -1,28 +1,28 @@
-name: "Mutation Testing Workflow"
-on:
-  pull_request:
-
-jobs:
-  gp2gp-translator-mutation-testing:
-    name: "Mutation Testing"
-    if: github.event.pull_request.head.repo.full_name == github.repository && github.actor != 'dependabot[bot]'
-    strategy:
-      matrix:
-        path: [ ./gpc-api-facade, ./gp2gp-translator]
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout project
-        uses: actions/checkout@1af3b93b6815bc44a9784bd300feb67ff0d1eeb3
-        with:
-          fetch-depth: 2
-      - name: Setup Java JDK
-        uses: actions/setup-java@dded0888837ed1f317902acf8a20df0ad188d165
-        with:
-          distribution: 'temurin'
-          java-version: 21
-
-      - name: run pitest
-        working-directory: ${{ matrix.path }}
-        run: ./gradlew pitest-github
-        env:
-          REPO_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+#name: "Mutation Testing Workflow"
+#on:
+#  pull_request:
+#
+#jobs:
+#  gp2gp-translator-mutation-testing:
+#    name: "Mutation Testing"
+#    if: github.event.pull_request.head.repo.full_name == github.repository && github.actor != 'dependabot[bot]'
+#    strategy:
+#      matrix:
+#        path: [ ./gpc-api-facade, ./gp2gp-translator]
+#    runs-on: ubuntu-latest
+#    steps:
+#      - name: Checkout project
+#        uses: actions/checkout@1af3b93b6815bc44a9784bd300feb67ff0d1eeb3
+#        with:
+#          fetch-depth: 2
+#      - name: Setup Java JDK
+#        uses: actions/setup-java@dded0888837ed1f317902acf8a20df0ad188d165
+#        with:
+#          distribution: 'temurin'
+#          java-version: 21
+#
+#      - name: run pitest
+#        working-directory: ${{ matrix.path }}
+#        run: ./gradlew pitest-github
+#        env:
+#          REPO_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/gp2gp-translator/build.gradle
+++ b/gp2gp-translator/build.gradle
@@ -7,8 +7,8 @@ plugins {
     id 'io.freefair.lombok' version '9.0.0'
 
     // Mutation testing
-    id 'info.solidsoft.pitest' version '1.15.0'
-    id 'com.arcmutate.github' version '2.0.0'
+//    id 'info.solidsoft.pitest' version '1.15.0'
+//    id 'com.arcmutate.github' version '2.0.0'
 }
 
 apply plugin: 'java'
@@ -52,11 +52,10 @@ dependencies {
     testImplementation 'io.findify:s3mock_2.13:0.2.6'
     testImplementation 'org.testcontainers:testcontainers-azure:2.0.5'
 
-    pitest 'com.arcmutate:base:1.3.2'
-    pitest 'com.arcmutate:pitest-git-plugin:2.0.0'
+//    pitest 'com.arcmutate:base:1.3.2'
+//    pitest 'com.arcmutate:pitest-git-plugin:2.0.0'
 
     implementation 'com.azure:azure-storage-blob:12.29.0'
-
     implementation 'software.amazon.awssdk:s3:2.30.11'
 }
 
@@ -125,25 +124,25 @@ tasks.withType(com.github.spotbugs.snom.SpotBugsTask) {
     }
 }
 
-pitest {
-    pitestVersion = '1.16.1'
-    junit5PluginVersion = '1.2.1'
-    outputFormats = ['gitci']
-
-    // git feature limits analysis to contents of PR only
-    features = ["+GIT(from[HEAD~1])"]
-
-    // PRs which don't introduce any production code changes, shouldn't fail the Mutation Testing Actions Workflow
-    failWhenNoMutations = false
-
-    mutators = ['STRONGER', 'EXTENDED_ALL']
-
-    threads = project.getGradle().getStartParameter().getMaxWorkerCount()
-}
-
-pitestGithub {
-    deleteOldSummaries = true
-}
+//pitest {
+//    pitestVersion = '1.16.1'
+//    junit5PluginVersion = '1.2.1'
+//    outputFormats = ['gitci']
+//
+//    // git feature limits analysis to contents of PR only
+//    features = ["+GIT(from[HEAD~1])"]
+//
+//    // PRs which don't introduce any production code changes, shouldn't fail the Mutation Testing Actions Workflow
+//    failWhenNoMutations = false
+//
+//    mutators = ['STRONGER', 'EXTENDED_ALL']
+//
+//    threads = project.getGradle().getStartParameter().getMaxWorkerCount()
+//}
+//
+//pitestGithub {
+//    deleteOldSummaries = true
+//}
 
 checkstyle {
     configFile file('../config/checkstyle/checkstyle.xml')

--- a/gpc-api-facade/build.gradle
+++ b/gpc-api-facade/build.gradle
@@ -7,8 +7,8 @@ plugins {
     id 'io.freefair.lombok' version '9.0.0'
 
     // Mutation testing
-    id 'info.solidsoft.pitest' version '1.15.0'
-    id 'com.arcmutate.github' version '2.0.0'
+//    id 'info.solidsoft.pitest' version '1.15.0'
+//    id 'com.arcmutate.github' version '2.0.0'
 }
 
 apply plugin: 'java'
@@ -40,8 +40,8 @@ dependencies {
     testImplementation 'org.mockito:mockito-inline:5.2.0'
     testImplementation 'io.rest-assured:rest-assured:5.5.0'
 
-    pitest 'com.arcmutate:base:1.3.2'
-    pitest 'com.arcmutate:pitest-git-plugin:2.0.0'
+//    pitest 'com.arcmutate:base:1.3.2'
+//    pitest 'com.arcmutate:pitest-git-plugin:2.0.0'
 
     compileOnly 'org.projectlombok:lombok'
     annotationProcessor 'org.projectlombok:lombok'
@@ -91,23 +91,23 @@ tasks.withType(com.github.spotbugs.snom.SpotBugsTask) {
         html.enabled = false
     }
 }
-
-pitest {
-    pitestVersion = '1.16.1'
-    junit5PluginVersion = '1.2.1'
-    outputFormats = ['gitci']
-
-    // git feature limits analysis to contents of PR only
-    features = ["+GIT(from[HEAD~1])"]
-
-    // PRs which don't introduce any production code changes, shouldn't fail the Mutation Testing Actions Workflow
-    failWhenNoMutations = false
-
-    mutators = ['STRONGER', 'EXTENDED_ALL']
-
-    threads = project.getGradle().getStartParameter().getMaxWorkerCount()
-}
-
-pitestGithub {
-    deleteOldSummaries = true
-}
+//
+//pitest {
+//    pitestVersion = '1.16.1'
+//    junit5PluginVersion = '1.2.1'
+//    outputFormats = ['gitci']
+//
+//    // git feature limits analysis to contents of PR only
+//    features = ["+GIT(from[HEAD~1])"]
+//
+//    // PRs which don't introduce any production code changes, shouldn't fail the Mutation Testing Actions Workflow
+//    failWhenNoMutations = false
+//
+//    mutators = ['STRONGER', 'EXTENDED_ALL']
+//
+//    threads = project.getGradle().getStartParameter().getMaxWorkerCount()
+//}
+//
+//pitestGithub {
+//    deleteOldSummaries = true
+//}


### PR DESCRIPTION
## What

* Comment out code relating to mutation tests in `build.gradle`s.
* Comment out `mutation-tests.yml` in `.github\workflows`.
 
## Why

In the case we do not get an exemption, we will need to temporarily make our GitHub repositories private whilst the NHS develops a strategy against malicious AI threat actors.

## Type of change

Please delete options that are not relevant.

- [x] Internal change (non-breaking change with no effect on the functionality affecting end users)

## Checklist:

- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes


[mapping-docs]: https://github.com/NHSDigital/patient-switching-adaptors-mapping-documentation