### PR TITLE
Introducing slices to GPC Api Facade tests to increase speed

### DIFF
--- a/gpc-api-facade/src/integrationTest/java/uk/nhs/adaptors/pss/gpc/HealthCheckIT.java
+++ b/gpc-api-facade/src/integrationTest/java/uk/nhs/adaptors/pss/gpc/HealthCheckIT.java
@@ -1,35 +1,31 @@
 package uk.nhs.adaptors.pss.gpc;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.springframework.boot.test.context.SpringBootTest.WebEnvironment.RANDOM_PORT;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.boot.test.web.server.LocalServerPort;
-import org.springframework.test.annotation.DirtiesContext;
-import org.springframework.test.context.junit.jupiter.SpringExtension;
-import org.springframework.web.reactive.function.client.WebClient;
+import org.springframework.test.web.servlet.MockMvc;
 
-@ExtendWith({SpringExtension.class})
-@SpringBootTest(webEnvironment = RANDOM_PORT)
-@DirtiesContext
+@SpringBootTest(classes = GpcFacadeApplication.class)
+@AutoConfigureMockMvc
 public class HealthCheckIT {
+
     private static final String HEALTHCHECK_ENDPOINT = "/healthcheck";
 
-    @LocalServerPort
-    private int port;
+    @Autowired
+    private MockMvc mockMvc;
 
     @Test
-    public void When_GettingHealthCheck_Expect_ServiceIsUp() {
-        String response = WebClient.builder()
-            .baseUrl("http://localhost:" + port)
-            .build()
-            .get()
-            .uri(builder -> builder.path(HEALTHCHECK_ENDPOINT).build())
-            .retrieve()
-            .bodyToMono(String.class)
-            .block();
+    public void When_GettingHealthCheck_Expect_ServiceIsUp() throws Exception {
+        var response = mockMvc.perform(get(HEALTHCHECK_ENDPOINT))
+            .andExpect(status().isOk())
+            .andReturn()
+            .getResponse()
+            .getContentAsString();
 
         assertThat(response).contains("UP");
     }

--- a/gpc-api-facade/src/integrationTest/java/uk/nhs/adaptors/pss/gpc/HealthCheckIT.java
+++ b/gpc-api-facade/src/integrationTest/java/uk/nhs/adaptors/pss/gpc/HealthCheckIT.java
@@ -1,31 +1,35 @@
 package uk.nhs.adaptors.pss.gpc;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.springframework.boot.test.context.SpringBootTest.WebEnvironment.RANDOM_PORT;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 import org.junit.jupiter.api.Test;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.boot.test.web.server.LocalServerPort;
+import org.springframework.web.reactive.function.client.WebClient;
 
-@SpringBootTest(classes = GpcFacadeApplication.class)
+@SpringBootTest(classes = GpcFacadeApplication.class, webEnvironment = RANDOM_PORT)
 @AutoConfigureMockMvc
 public class HealthCheckIT {
 
     private static final String HEALTHCHECK_ENDPOINT = "/healthcheck";
 
-    @Autowired
-    private MockMvc mockMvc;
+    @LocalServerPort
+    private int port;
 
     @Test
-    public void When_GettingHealthCheck_Expect_ServiceIsUp() throws Exception {
-        var response = mockMvc.perform(get(HEALTHCHECK_ENDPOINT))
-            .andExpect(status().isOk())
-            .andReturn()
-            .getResponse()
-            .getContentAsString();
+    public void When_GettingHealthCheck_Expect_ServiceIsUp() {
+        var response = WebClient.builder()
+                .baseUrl("http://localhost:" + port)
+                .build()
+                .get()
+                .uri(builder -> builder.path(HEALTHCHECK_ENDPOINT).build())
+                .retrieve()
+                .bodyToMono(String.class)
+                .block();
 
         assertThat(response).contains("UP");
     }

--- a/gpc-api-facade/src/integrationTest/java/uk/nhs/adaptors/pss/gpc/HealthCheckIT.java
+++ b/gpc-api-facade/src/integrationTest/java/uk/nhs/adaptors/pss/gpc/HealthCheckIT.java
@@ -2,9 +2,6 @@ package uk.nhs.adaptors.pss.gpc;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.springframework.boot.test.context.SpringBootTest.WebEnvironment.RANDOM_PORT;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
-
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;

--- a/gpc-api-facade/src/integrationTest/java/uk/nhs/adaptors/pss/gpc/controller/AcknowledgeRecordControllerIT.java
+++ b/gpc-api-facade/src/integrationTest/java/uk/nhs/adaptors/pss/gpc/controller/AcknowledgeRecordControllerIT.java
@@ -1,7 +1,6 @@
 package uk.nhs.adaptors.pss.gpc.controller;
 
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.EnumSource;
@@ -9,18 +8,16 @@ import org.junit.jupiter.params.provider.MethodSource;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.test.annotation.DirtiesContext;
-import org.springframework.test.context.junit.jupiter.SpringExtension;
 import org.springframework.test.web.servlet.MockMvc;
 import uk.nhs.adaptors.common.enums.ConfirmationResponse;
 import uk.nhs.adaptors.connector.dao.PatientMigrationRequestDao;
 import uk.nhs.adaptors.common.enums.MigrationStatus;
 import uk.nhs.adaptors.connector.service.MigrationStatusLogService;
+import uk.nhs.adaptors.pss.gpc.GpcFacadeApplication;
 
 import java.util.UUID;
 import java.util.stream.Stream;
 
-import static org.springframework.boot.test.context.SpringBootTest.WebEnvironment.RANDOM_PORT;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
@@ -28,9 +25,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import static uk.nhs.adaptors.common.util.FileUtil.readResourceAsString;
 import static uk.nhs.adaptors.common.enums.MigrationStatus.MIGRATION_COMPLETED;
 
-@SpringBootTest(webEnvironment = RANDOM_PORT)
-@ExtendWith({SpringExtension.class})
-@DirtiesContext
+@SpringBootTest(classes = GpcFacadeApplication.class)
 @AutoConfigureMockMvc
 public class AcknowledgeRecordControllerIT {
     private static final String ACKNOWLEDGE_RECORD_ENDPOINT = "/$gpc.ack";

--- a/gpc-api-facade/src/integrationTest/java/uk/nhs/adaptors/pss/gpc/controller/PatientTransferControllerIT.java
+++ b/gpc-api-facade/src/integrationTest/java/uk/nhs/adaptors/pss/gpc/controller/PatientTransferControllerIT.java
@@ -1,7 +1,6 @@
 package uk.nhs.adaptors.pss.gpc.controller;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.springframework.boot.test.context.SpringBootTest.WebEnvironment.RANDOM_PORT;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
@@ -17,14 +16,11 @@ import java.util.UUID;
 import org.apache.commons.lang3.RandomStringUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.MediaType;
-import org.springframework.test.annotation.DirtiesContext;
-import org.springframework.test.context.junit.jupiter.SpringExtension;
 import org.springframework.test.web.servlet.MockMvc;
 
 import org.springframework.transaction.annotation.Transactional;
@@ -34,10 +30,9 @@ import uk.nhs.adaptors.connector.dao.PatientMigrationRequestDao;
 import uk.nhs.adaptors.connector.model.PatientMigrationRequest;
 import uk.nhs.adaptors.common.enums.MigrationStatus;
 import uk.nhs.adaptors.connector.service.MigrationStatusLogService;
+import uk.nhs.adaptors.pss.gpc.GpcFacadeApplication;
 
-@SpringBootTest(webEnvironment = RANDOM_PORT)
-@ExtendWith({SpringExtension.class})
-@DirtiesContext
+@SpringBootTest(classes = GpcFacadeApplication.class)
 @AutoConfigureMockMvc
 @Transactional
 public class PatientTransferControllerIT {


### PR DESCRIPTION
## What

Introducing slices to GPC API Facade tests to increase speed

## Why

Instead of creating the entire Spring Boot context for a test, which can be expensive and time-consuming, this change limits the scope and loads only the classes needed for the test, making it much faster.

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Internal change (non-breaking change with no effect on the functionality affecting end users)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:

- [x] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] I have updated the [Changelog](/CHANGELOG.md) with details of my change in the UNRELEASED section if this change will affect end users
- [ ] A corresponding change has been made to the [Mapping Documentation repository][mapping-docs]

[mapping-docs]: https://github.com/NHSDigital/patient-switching-adaptors-mapping-documentation