### PR TITLE
Fix canMergeCompleteBundle returning true for empty attachment logs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 * Updated the Requesting Adaptor to map newly granular EHRSupplyType values from EMIS into the corresponding GPC JSON record fields.
 * Corrected the EHR Extract interaction identifier used by timeout handling from RCMR_IN030000UK06 to RCMR_IN030000UK07.
 * The length of varchar columns in 'patient_attachment_log' table have been extended to 1024 characters.
+* Fixed `canMergeCompleteBundle` incorrectly returning `true` when attachment logs are empty, causing a blank patient record after large message GP2GP transfers.
 
 ### Added
 * Added support for mapping different EhrSupplyType (e.g. NHS prescription, OTC sale) into the Medication Statement Prescribing Agency extension

--- a/gp2gp-translator/src/main/java/uk/nhs/adaptors/pss/translator/service/InboundMessageMergingService.java
+++ b/gp2gp-translator/src/main/java/uk/nhs/adaptors/pss/translator/service/InboundMessageMergingService.java
@@ -55,12 +55,16 @@ public class InboundMessageMergingService {
     private static final String CONVERSATION_ID_HAS_NOT_BEEN_GIVEN = "Conversation Id has not been given";
 
     public boolean canMergeCompleteBundle(String conversationId) throws ValidationException {
-
         if (!StringUtils.hasText(conversationId)) {
             throw new ValidationException(CONVERSATION_ID_HAS_NOT_BEEN_GIVEN);
         }
 
         var undeletedLogs = getUndeletedLogsForConversation(conversationId);
+
+        if (undeletedLogs.isEmpty()) {
+            return false;
+        }
+
         return undeletedLogs.stream().allMatch(log -> log.getUploaded().equals(true));
     }
 

--- a/gp2gp-translator/src/test/java/uk/nhs/adaptors/pss/translator/service/InboundMessageMergingServiceTests.java
+++ b/gp2gp-translator/src/test/java/uk/nhs/adaptors/pss/translator/service/InboundMessageMergingServiceTests.java
@@ -469,11 +469,11 @@ public class InboundMessageMergingServiceTests {
     }
 
     @Test
-public void When_AllAttachmentLogsDeleted_CanMergeCompleteBundle_Expect_ReturnFalse() throws JAXBException {
-    var attachmentLogs = createPatientAttachmentList(true, true);
-    attachmentLogs.forEach(log -> log.setDeleted(true));
+    public void When_AllAttachmentLogsDeleted_CanMergeCompleteBundle_Expect_ReturnFalse() throws JAXBException {
+        var emptyAttachmentLogs = new ArrayList<PatientAttachmentLog>();
 
-    when(patientAttachmentLogService.findAttachmentLogs(CONVERSATION_ID)).thenReturn(attachmentLogs);
+        when(patientAttachmentLogService.findAttachmentLogs(CONVERSATION_ID)).thenReturn(emptyAttachmentLogs);
+
         var result = inboundMessageMergingService.canMergeCompleteBundle(CONVERSATION_ID);
 
         assertFalse(result);

--- a/gp2gp-translator/src/test/java/uk/nhs/adaptors/pss/translator/service/InboundMessageMergingServiceTests.java
+++ b/gp2gp-translator/src/test/java/uk/nhs/adaptors/pss/translator/service/InboundMessageMergingServiceTests.java
@@ -469,11 +469,11 @@ public class InboundMessageMergingServiceTests {
     }
 
     @Test
-    public void When_AllAttachmentLogsDeleted_CanMergeCompleteBundle_Expect_ReturnFalse() throws JAXBException {
-        var emptyAttachmentLogs = new ArrayList<PatientAttachmentLog>();
+public void When_AllAttachmentLogsDeleted_CanMergeCompleteBundle_Expect_ReturnFalse() throws JAXBException {
+    var attachmentLogs = createPatientAttachmentList(true, true);
+    attachmentLogs.forEach(log -> log.setDeleted(true));
 
-        when(patientAttachmentLogService.findAttachmentLogs(CONVERSATION_ID)).thenReturn(emptyAttachmentLogs);
-
+    when(patientAttachmentLogService.findAttachmentLogs(CONVERSATION_ID)).thenReturn(attachmentLogs);
         var result = inboundMessageMergingService.canMergeCompleteBundle(CONVERSATION_ID);
 
         assertFalse(result);

--- a/gp2gp-translator/src/test/java/uk/nhs/adaptors/pss/translator/service/InboundMessageMergingServiceTests.java
+++ b/gp2gp-translator/src/test/java/uk/nhs/adaptors/pss/translator/service/InboundMessageMergingServiceTests.java
@@ -425,7 +425,7 @@ public class InboundMessageMergingServiceTests {
     }
 
     @Test
-    public void When_AllUploadsComplete_CanMergeCompleteBundle_Expect_ReturnTrue() throws JAXBException {
+    public void When_AllUploadsComplete_AndLogsNotEmpty_CanMergeCompleteBundle_Expect_ReturnTrue() throws JAXBException {
         var attachmentLogs = createPatientAttachmentList(true, true);
         when(patientAttachmentLogService.findAttachmentLogs(CONVERSATION_ID)).thenReturn(attachmentLogs);
 
@@ -466,6 +466,17 @@ public class InboundMessageMergingServiceTests {
 
         verify(attachmentReferenceUpdaterService).replaceOriginalFilenameWithStorageFilenameInEhrExtract(any(), any(), any());
         verify(nackAckPreparationService, never()).sendNackMessage(any(NACKReason.class), any(RCMRIN030000UKMessage.class), any());
+    }
+
+    @Test
+    public void When_AllAttachmentLogsDeleted_CanMergeCompleteBundle_Expect_ReturnFalse() throws JAXBException {
+        var emptyAttachmentLogs = new ArrayList<PatientAttachmentLog>();
+
+        when(patientAttachmentLogService.findAttachmentLogs(CONVERSATION_ID)).thenReturn(emptyAttachmentLogs);
+
+        var result = inboundMessageMergingService.canMergeCompleteBundle(CONVERSATION_ID);
+
+        assertFalse(result);
     }
 
 


### PR DESCRIPTION
## What
Add an empty list guard to `canMergeCompleteBundle` in `InboundMessageMergingService` to prevent premature bundle building when all attachment logs have been deleted. Also adds a new unit test `When_AllAttachmentLogsDeleted_CanMergeCompleteBundle_Expect_ReturnFalse` and renames `When_AllUploadsComplete_CanMergeCompleteBundle_Expect_ReturnTrue` to `When_AllUploadsComplete_AndLogsNotEmpty_CanMergeCompleteBundle_Expect_ReturnTrue` for clarity.

## Why

When the last attachment chunk of a large GP2GP patient record transfer  arrives, `checkAndMergeFileParts` merges the fragments and then deletes their logs from the DB as cleanup. Immediately after, `canMergeCompleteBundle` checks those same logs to decide if the bundle is ready to build but they've just been deleted, so the list is empty. Java's `allMatch()` on an empty list always returns `true`, so the bundle gets built too early with no attachments.

The result is a blank patient record in Medicus after the transfer.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Internal change (non-breaking change with no effect on the functionality affecting end users)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:

- [x] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] I have updated the [Changelog](/CHANGELOG.md) with details of my change in the UNRELEASED section if this change will affect end users
- [ ] A corresponding change has been made to the [Mapping Documentation repository][mapping-docs]

[mapping-docs]: https://github.com/NHSDigital/patient-switching-adaptors-mapping-documentation