### PR TITLE
NIAD-3467 Fixed undeleted logs bug

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 ### Fixed
 * Improved error handling in SkeletonProcessingService to throw a meaningful IllegalArgumentException
   when a payload node cannot be matched to a skeleton document ID, replacing an uninformative NullPointerException.
+* Fixed `canMergeCompleteBundle` incorrectly returning `true` when attachment logs are empty, causing a blank patient record after large message GP2GP transfers.
 
 ## [3.1.3] - 2025-09-19
 

--- a/gp2gp-translator/src/main/java/uk/nhs/adaptors/pss/translator/service/InboundMessageMergingService.java
+++ b/gp2gp-translator/src/main/java/uk/nhs/adaptors/pss/translator/service/InboundMessageMergingService.java
@@ -61,6 +61,11 @@ public class InboundMessageMergingService {
         }
 
         var undeletedLogs = getUndeletedLogsForConversation(conversationId);
+
+        if (undeletedLogs.isEmpty()) {
+            return false;
+        }
+
         return undeletedLogs.stream().allMatch(log -> log.getUploaded().equals(true));
     }
 

--- a/gp2gp-translator/src/test/java/uk/nhs/adaptors/pss/translator/service/InboundMessageMergingServiceTests.java
+++ b/gp2gp-translator/src/test/java/uk/nhs/adaptors/pss/translator/service/InboundMessageMergingServiceTests.java
@@ -468,6 +468,16 @@ public class InboundMessageMergingServiceTests {
         verify(nackAckPreparationService, never()).sendNackMessage(any(NACKReason.class), any(RCMRIN030000UKMessage.class), any());
     }
 
+    @Test
+    public void When_AllAttachmentLogsDeleted_CanMergeCompleteBundle_Expect_ReturnFalse() throws JAXBException {
+        var emptyAttachmentLogs = new ArrayList<PatientAttachmentLog>();
+
+        when(patientAttachmentLogService.findAttachmentLogs(CONVERSATION_ID)).thenReturn(emptyAttachmentLogs);
+        var result = inboundMessageMergingService.canMergeCompleteBundle(CONVERSATION_ID);
+
+        assertFalse(result);
+    }
+
 
     private ArrayList<PatientAttachmentLog> createPatientAttachmentList(Boolean isParentUploaded, Boolean isSkeleton) {
         var patientAttachmentLogs = new ArrayList<PatientAttachmentLog>();


### PR DESCRIPTION
## What
Add an empty list guard to `canMergeCompleteBundle` in `InboundMessageMergingService` to prevent premature bundle building when all attachment logs have been deleted.

## Why

When the last attachment chunk of a large GP2GP patient record transfer  arrives, `checkAndMergeFileParts` merges the fragments and then deletes their logs from the DB as cleanup. Immediately after, `canMergeCompleteBundle` checks those same logs to decide if the bundle is ready to build but they've just been deleted, so the list is empty. Java's `allMatch()` on an empty list always returns `true`, so the bundle gets built too early with no attachments.

The result is a blank patient record in Medicus after the transfer which is ofc wrong.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Internal change (non-breaking change with no effect on the functionality affecting end users)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:

- [x] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] I have updated the [Changelog](/CHANGELOG.md) with details of my change in the UNRELEASED section if this change will affect end users
- [ ] A corresponding change has been made to the [Mapping Documentation repository][mapping-docs]

[mapping-docs]: https://github.com/NHSDigital/patient-switching-adaptors-mapping-documentation