### PR TITLE
NIAD-3471 Support multiple given names in practitioner XML

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,9 +12,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ### Added
 * Added support for mapping different EhrSupplyType (e.g. NHS prescription, OTC sale) into the Medication Statement Prescribing Agency extension
-* Added fallback for Condition.asserter to use the EHRComposition / author / agent field when EHRComposition / participant2 is absent.
-* 
+* Added fallback for Condition.asserter to use the EHRComposition / author / agent field when EHRComposition / participant2 is absent.
+
 ### Fixed
+* Fixed handling of multiple `<given>` name fields in practitioner XML to JSON mapping - now correctly captures all given names as an array in FHIR HumanName.
 * Improved error handling in SkeletonProcessingService to throw a meaningful IllegalArgumentException
   when a payload node cannot be matched to a skeleton document ID, replacing an uninformative NullPointerException.
 

--- a/gp2gp-translator/src/main/java/uk/nhs/adaptors/pss/translator/mapper/AgentDirectoryMapper.java
+++ b/gp2gp-translator/src/main/java/uk/nhs/adaptors/pss/translator/mapper/AgentDirectoryMapper.java
@@ -156,11 +156,15 @@ public class AgentDirectoryMapper {
     }
 
     private static String getGivenNamesAsString(PN name) {
-        var givenList = name.getGiven();
-        if (givenList != null && !givenList.isEmpty()) {
-            return StringUtils.join(givenList, " ");
+        if (name == null) {
+            return null;
         }
-        return null;
+
+        var givenList = name.getGiven().stream()
+            .filter(StringUtils::isNotBlank)
+            .toList();
+
+        return givenList.isEmpty() ? null : StringUtils.join(givenList, " ");
     }
 
     private static boolean hasNoName(PN name) {

--- a/gp2gp-translator/src/main/java/uk/nhs/adaptors/pss/translator/mapper/AgentDirectoryMapper.java
+++ b/gp2gp-translator/src/main/java/uk/nhs/adaptors/pss/translator/mapper/AgentDirectoryMapper.java
@@ -130,17 +130,23 @@ public class AgentDirectoryMapper {
     }
 
     private static void setTextFromAvailableNameFields(PN name, HumanName humanName) {
-        var requiresSeparator = StringUtils.isNotBlank(name.getPrefix()) && StringUtils.isNotBlank(name.getGiven());
-        var text = StringUtils.join(name.getPrefix(), (requiresSeparator ? " " : ""), name.getGiven());
+        var givenNames = getGivenNamesAsString(name);
+        var requiresSeparator = StringUtils.isNotBlank(name.getPrefix()) && StringUtils.isNotBlank(givenNames);
+        var text = StringUtils.join(name.getPrefix(), (requiresSeparator ? " " : ""), givenNames);
         humanName.setText(text);
     }
 
     private void setHumanNameValuesFromName(PN name, HumanName humanName) {
         humanName.setFamily(name.getFamily());
 
-        var given = getPractitionerGiven(name.getGiven());
-        if (given != null) {
-            humanName.getGiven().add(given);
+        var givenList = name.getGiven();
+        if (givenList != null && !givenList.isEmpty()) {
+            for (String givenName : givenList) {
+                var given = getPractitionerGiven(givenName);
+                if (given != null) {
+                    humanName.getGiven().add(given);
+                }
+            }
         }
 
         var prefix = getPractitionerPrefix(name.getPrefix());
@@ -149,10 +155,19 @@ public class AgentDirectoryMapper {
         }
     }
 
+    private static String getGivenNamesAsString(PN name) {
+        var givenList = name.getGiven();
+        if (givenList != null && !givenList.isEmpty()) {
+            return StringUtils.join(givenList, " ");
+        }
+        return null;
+    }
+
     private static boolean hasNoName(PN name) {
+        var hasGiven = name != null && name.getGiven() != null && !name.getGiven().isEmpty();
         return name == null
             || (StringUtils.isBlank(name.getFamily())
-                && StringUtils.isBlank(name.getGiven())
+                && !hasGiven
                 && StringUtils.isBlank(name.getPrefix()));
     }
 

--- a/gp2gp-translator/src/main/java/uk/nhs/adaptors/pss/translator/util/ParticipantReferenceUtil.java
+++ b/gp2gp-translator/src/main/java/uk/nhs/adaptors/pss/translator/util/ParticipantReferenceUtil.java
@@ -71,19 +71,16 @@ public class ParticipantReferenceUtil {
 
     public static Reference getParticipant2Reference(RCMRMT030101UKEhrComposition ehrComposition, String typeCode) {
 
-        var participant2Reference = ehrComposition.getParticipant2().stream()
+        return ehrComposition.getParticipant2().stream()
             .filter(participant2 -> participant2.getNullFlavor() == null)
             .filter(participant2 -> typeCode.equals(participant2.getTypeCode().getFirst()))
             .map(RCMRMT030101UKParticipant2::getAgentRef)
             .map(RCMRMT030101UKAgentRef::getId)
             .filter(II::hasRoot)
             .map(II::getRoot)
-            .findFirst();
-
-        if (participant2Reference.isPresent()) {
-            return new Reference(PRACTITIONER_REFERENCE_PREFIX.formatted(participant2Reference.get()));
-        }
-        return null;
+            .findFirst()
+            .map(ref -> new Reference(PRACTITIONER_REFERENCE_PREFIX.formatted(ref)))
+            .orElse(null);
     }
 
     private static Optional<String> getParticipant2Reference(RCMRMT030101UKEhrComposition ehrComposition) {

--- a/gp2gp-translator/src/test/java/uk/nhs/adaptors/pss/translator/mapper/AgentDirectoryMapperTest.java
+++ b/gp2gp-translator/src/test/java/uk/nhs/adaptors/pss/translator/mapper/AgentDirectoryMapperTest.java
@@ -291,6 +291,7 @@ public class AgentDirectoryMapperTest {
 
     @Test
     public void When_MapAgentWithThreeGivenNames_Expect_AllThreeGivenNamesInArray() {
+        final var expectedGivenCount = 3;
         var agentDirectoryXml = """
             <agentDirectory xmlns="urn:hl7-org:v3" classCode="AGNT">
                 <part typeCode="PART">
@@ -317,7 +318,7 @@ public class AgentDirectoryMapperTest {
 
         assertAll(
             () -> assertThat(practitioner.getNameFirstRep().getFamily()).isEqualTo("Smith"),
-            () -> assertThat(practitioner.getNameFirstRep().getGiven()).hasSize(3),
+            () -> assertThat(practitioner.getNameFirstRep().getGiven()).hasSize(expectedGivenCount),
             () -> assertThat(practitioner.getNameFirstRep().getGiven().getFirst().getValue()).isEqualTo("John"),
             () -> assertThat(practitioner.getNameFirstRep().getGiven().get(1).getValue()).isEqualTo("Paul"),
             () -> assertThat(practitioner.getNameFirstRep().getGiven().get(2).getValue()).isEqualTo("George"),
@@ -393,6 +394,100 @@ public class AgentDirectoryMapperTest {
             () -> assertThat(practitioner.getNameFirstRep().getGiven().getFirst().getValue()).isEqualTo("John"),
             () -> assertThat(practitioner.getNameFirstRep().getGiven().get(1).getValue()).isEqualTo("Robert"),
             () -> assertThat(practitioner.getNameFirstRep().getFamily()).isEqualTo("Smith")
+        );
+    }
+
+    @Test
+    public void When_MapAgentWithPrefixButNullGivenNames_Expect_TextSetToPrefix() {
+        var agentDirectoryXml = """
+            <agentDirectory xmlns="urn:hl7-org:v3" classCode="AGNT">
+                <part typeCode="PART">
+                    <Agent classCode="AGNT">
+                        <id root="95D00D99-0601-4A8E-AD1D-1B564307B0A6" />
+                        <agentPerson classCode="PSN" determinerCode="INSTANCE">
+                            <name>
+                               <prefix>Prof</prefix>
+                            </name>
+                        </agentPerson>
+                    </Agent>
+                </part>
+            </agentDirectory>""";
+        var agentDirectory = unmarshallAgentDirectoryFromXmlString(agentDirectoryXml);
+
+        var mappedAgents = agentDirectoryMapper.mapAgentDirectory(agentDirectory);
+
+        assertThat(mappedAgents).hasSize(1);
+
+        var practitioner = (Practitioner) mappedAgents.getFirst();
+
+        assertAll(
+            () -> assertThat(practitioner.getNameFirstRep().getText()).isEqualTo("Prof"),
+            () -> assertThat(practitioner.getNameFirstRep().getGiven()).isEmpty(),
+            () -> assertThat(practitioner.getNameFirstRep().getFamily()).isNull(),
+            () -> assertThat(practitioner.getNameFirstRep().getPrefix()).isEmpty()
+        );
+    }
+
+    @Test
+    public void When_MapAgentWithAllGivenNamesEmpty_Expect_TextSetToEmpty() {
+        // This test ensures that if getGiven() returns an empty list (all items filtered out),
+        // hasNoName() correctly identifies it as having NO name
+        var agentDirectoryXml = """
+            <agentDirectory xmlns="urn:hl7-org:v3" classCode="AGNT">
+                <part typeCode="PART">
+                    <Agent classCode="AGNT">
+                        <id root="95D00D99-0601-4A8E-AD1D-1B564307B0A6" />
+                        <agentPerson classCode="PSN" determinerCode="INSTANCE">
+                            <name>
+                               <given></given>
+                               <given></given>
+                            </name>
+                        </agentPerson>
+                    </Agent>
+                </part>
+            </agentDirectory>""";
+        var agentDirectory = unmarshallAgentDirectoryFromXmlString(agentDirectoryXml);
+
+        var mappedAgents = agentDirectoryMapper.mapAgentDirectory(agentDirectory);
+
+        assertThat(mappedAgents).hasSize(1);
+
+        var practitioner = (Practitioner) mappedAgents.getFirst();
+
+        assertThat(practitioner.getNameFirstRep().getGiven()).isEmpty();
+    }
+
+    @Test
+    public void When_MapAgentWithPrefixAndEmptyGivenNames_Expect_TextSetOnlyToPrefix() {
+        var agentDirectoryXml = """
+            <agentDirectory xmlns="urn:hl7-org:v3" classCode="AGNT">
+                <part typeCode="PART">
+                    <Agent classCode="AGNT">
+                        <id root="95D00D99-0601-4A8E-AD1D-1B564307B0A6" />
+                        <agentPerson classCode="PSN" determinerCode="INSTANCE">
+                            <name>
+                               <prefix>Dr</prefix>
+                               <given></given>
+                               <family>Smith</family>
+                            </name>
+                        </agentPerson>
+                    </Agent>
+                </part>
+            </agentDirectory>""";
+        var agentDirectory = unmarshallAgentDirectoryFromXmlString(agentDirectoryXml);
+
+        var mappedAgents = agentDirectoryMapper.mapAgentDirectory(agentDirectory);
+
+        assertThat(mappedAgents).hasSize(1);
+
+        var practitioner = (Practitioner) mappedAgents.getFirst();
+
+        assertAll(
+            () -> assertThat(practitioner.getNameFirstRep().getFamily()).isEqualTo("Smith"),
+            () -> assertThat(practitioner.getNameFirstRep().getPrefix()).hasSize(1),
+            () -> assertThat(practitioner.getNameFirstRep().getPrefix().getFirst().getValue()).isEqualTo("Dr"),
+            () -> assertThat(practitioner.getNameFirstRep().getGiven()).isEmpty(),
+            () -> assertThat(practitioner.getNameFirstRep().getText()).isNull()
         );
     }
 

--- a/gp2gp-translator/src/test/java/uk/nhs/adaptors/pss/translator/mapper/AgentDirectoryMapperTest.java
+++ b/gp2gp-translator/src/test/java/uk/nhs/adaptors/pss/translator/mapper/AgentDirectoryMapperTest.java
@@ -290,6 +290,113 @@ public class AgentDirectoryMapperTest {
     }
 
     @Test
+    public void When_MapAgentWithThreeGivenNames_Expect_AllThreeGivenNamesInArray() {
+        var agentDirectoryXml = """
+            <agentDirectory xmlns="urn:hl7-org:v3" classCode="AGNT">
+                <part typeCode="PART">
+                    <Agent classCode="AGNT">
+                        <id root="95D00D99-0601-4A8E-AD1D-1B564307B0A6" />
+                        <agentPerson classCode="PSN" determinerCode="INSTANCE">
+                            <name>
+                               <given>John</given>
+                               <given>Paul</given>
+                               <given>George</given>
+                               <family>Smith</family>
+                            </name>
+                        </agentPerson>
+                    </Agent>
+                </part>
+            </agentDirectory>""";
+        var agentDirectory = unmarshallAgentDirectoryFromXmlString(agentDirectoryXml);
+
+        var mappedAgents = agentDirectoryMapper.mapAgentDirectory(agentDirectory);
+
+        assertThat(mappedAgents).hasSize(1);
+
+        var practitioner = (Practitioner) mappedAgents.getFirst();
+
+        assertAll(
+            () -> assertThat(practitioner.getNameFirstRep().getFamily()).isEqualTo("Smith"),
+            () -> assertThat(practitioner.getNameFirstRep().getGiven()).hasSize(3),
+            () -> assertThat(practitioner.getNameFirstRep().getGiven().getFirst().getValue()).isEqualTo("John"),
+            () -> assertThat(practitioner.getNameFirstRep().getGiven().get(1).getValue()).isEqualTo("Paul"),
+            () -> assertThat(practitioner.getNameFirstRep().getGiven().get(2).getValue()).isEqualTo("George"),
+            () -> assertThat(practitioner.getNameFirstRep().getText()).isNull()
+        );
+    }
+
+    @Test
+    public void When_MapAgentWithEmptyGivenNameInList_Expect_OnlyNonEmptyGivenNamesAdded() {
+        var agentDirectoryXml = """
+            <agentDirectory xmlns="urn:hl7-org:v3" classCode="AGNT">
+                <part typeCode="PART">
+                    <Agent classCode="AGNT">
+                        <id root="95D00D99-0601-4A8E-AD1D-1B564307B0A6" />
+                        <agentPerson classCode="PSN" determinerCode="INSTANCE">
+                            <name>
+                               <given>John</given>
+                               <given></given>
+                               <given>Paul</given>
+                               <family>Smith</family>
+                            </name>
+                        </agentPerson>
+                    </Agent>
+                </part>
+            </agentDirectory>""";
+        var agentDirectory = unmarshallAgentDirectoryFromXmlString(agentDirectoryXml);
+
+        var mappedAgents = agentDirectoryMapper.mapAgentDirectory(agentDirectory);
+
+        assertThat(mappedAgents).hasSize(1);
+
+        var practitioner = (Practitioner) mappedAgents.getFirst();
+
+        // Should only have 2 given names since one is empty
+        assertAll(
+            () -> assertThat(practitioner.getNameFirstRep().getFamily()).isEqualTo("Smith"),
+            () -> assertThat(practitioner.getNameFirstRep().getGiven()).hasSize(2),
+            () -> assertThat(practitioner.getNameFirstRep().getGiven().getFirst().getValue()).isEqualTo("John"),
+            () -> assertThat(practitioner.getNameFirstRep().getGiven().get(1).getValue()).isEqualTo("Paul")
+        );
+    }
+
+    @Test
+    public void When_MapAgentWithMultipleGivenNamesAndPrefix_Expect_AllNamesAndPrefix() {
+        var agentDirectoryXml = """
+            <agentDirectory xmlns="urn:hl7-org:v3" classCode="AGNT">
+                <part typeCode="PART">
+                    <Agent classCode="AGNT">
+                        <id root="95D00D99-0601-4A8E-AD1D-1B564307B0A6" />
+                        <agentPerson classCode="PSN" determinerCode="INSTANCE">
+                            <name>
+                               <prefix>Dr</prefix>
+                               <given>John</given>
+                               <given>Robert</given>
+                               <family>Smith</family>
+                            </name>
+                        </agentPerson>
+                    </Agent>
+                </part>
+            </agentDirectory>""";
+        var agentDirectory = unmarshallAgentDirectoryFromXmlString(agentDirectoryXml);
+
+        var mappedAgents = agentDirectoryMapper.mapAgentDirectory(agentDirectory);
+
+        assertThat(mappedAgents).hasSize(1);
+
+        var practitioner = (Practitioner) mappedAgents.getFirst();
+
+        assertAll(
+            () -> assertThat(practitioner.getNameFirstRep().getPrefix()).hasSize(1),
+            () -> assertThat(practitioner.getNameFirstRep().getPrefix().getFirst().getValue()).isEqualTo("Dr"),
+            () -> assertThat(practitioner.getNameFirstRep().getGiven()).hasSize(2),
+            () -> assertThat(practitioner.getNameFirstRep().getGiven().getFirst().getValue()).isEqualTo("John"),
+            () -> assertThat(practitioner.getNameFirstRep().getGiven().get(1).getValue()).isEqualTo("Robert"),
+            () -> assertThat(practitioner.getNameFirstRep().getFamily()).isEqualTo("Smith")
+        );
+    }
+
+    @Test
     public void When_MapAgentDirectoryOnlyAgentPersonWithNameElementWithOnlyPrefix_Expect_TextSetToPrefix() {
         var agentDirectoryXml = """
             <agentDirectory xmlns="urn:hl7-org:v3" classCode="AGNT">

--- a/gp2gp-translator/src/test/java/uk/nhs/adaptors/pss/translator/mapper/AgentDirectoryMapperTest.java
+++ b/gp2gp-translator/src/test/java/uk/nhs/adaptors/pss/translator/mapper/AgentDirectoryMapperTest.java
@@ -248,7 +248,7 @@ public class AgentDirectoryMapperTest {
             () -> assertThat(practitioner.getNameFirstRep().getFamily()).isNull(),
             () -> assertThat(practitioner.getNameFirstRep().getGiven()).isEmpty(),
             () -> assertThat(practitioner.getNameFirstRep().getPrefix()).isEmpty(),
-            () -> assertThat(practitioner.getNameFirstRep().getText()).isEqualTo("John Paul")
+            () -> assertThat(practitioner.getNameFirstRep().getText()).isEqualTo("NHS")
         );
     }
 

--- a/gp2gp-translator/src/test/java/uk/nhs/adaptors/pss/translator/mapper/AgentDirectoryMapperTest.java
+++ b/gp2gp-translator/src/test/java/uk/nhs/adaptors/pss/translator/mapper/AgentDirectoryMapperTest.java
@@ -248,7 +248,44 @@ public class AgentDirectoryMapperTest {
             () -> assertThat(practitioner.getNameFirstRep().getFamily()).isNull(),
             () -> assertThat(practitioner.getNameFirstRep().getGiven()).isEmpty(),
             () -> assertThat(practitioner.getNameFirstRep().getPrefix()).isEmpty(),
-            () -> assertThat(practitioner.getNameFirstRep().getText()).isEqualTo("NHS")
+            () -> assertThat(practitioner.getNameFirstRep().getText()).isEqualTo("John Paul")
+        );
+    }
+
+    @Test
+    public void When_MapAgentWithMultipleGivenAndFamilyName_Expect_AllGivenNamesInArray() {
+        var agentDirectoryXml = """
+            <agentDirectory xmlns="urn:hl7-org:v3" classCode="AGNT">
+                <part typeCode="PART">
+                    <Agent classCode="AGNT">
+                        <id root="CD8E40B3-6A3C-11F1-AE7C-00155D75C807"/>
+                        <code code="704951000000106" codeSystem="2.16.840.1.113883.2.1.3.2.4.15" displayName="Other person"/>
+                        <agentPerson classCode="PSN" determinerCode="INSTANCE">
+                            <name use="L">
+                                <given>Minire</given>
+                                <given>E</given>
+                                <family>Clarkson</family>
+                            </name>
+                        </agentPerson>
+                    </Agent>
+                </part>
+            </agentDirectory>""";
+        var agentDirectory = unmarshallAgentDirectoryFromXmlString(agentDirectoryXml);
+
+        var mappedAgents = agentDirectoryMapper.mapAgentDirectory(agentDirectory);
+
+        assertThat(mappedAgents).hasSize(1);
+
+        var practitioner = (Practitioner) mappedAgents.getFirst();
+
+        assertAll(
+            () -> assertThat(practitioner.getId()).isEqualTo("CD8E40B3-6A3C-11F1-AE7C-00155D75C807"),
+            () -> assertThat(practitioner.getNameFirstRep().getFamily()).isEqualTo("Clarkson"),
+            () -> assertThat(practitioner.getNameFirstRep().getGiven()).hasSize(2),
+            () -> assertThat(practitioner.getNameFirstRep().getGiven().getFirst().getValue()).isEqualTo("Minire"),
+            () -> assertThat(practitioner.getNameFirstRep().getGiven().get(1).getValue()).isEqualTo("E"),
+            () -> assertThat(practitioner.getNameFirstRep().getText()).isNull(),
+            () -> assertThat(practitioner.getMeta().getProfile().getFirst().getValue()).isEqualTo(PRACT_META_PROFILE)
         );
     }
 

--- a/schema/src/main/java/org/hl7/v3/EN.java
+++ b/schema/src/main/java/org/hl7/v3/EN.java
@@ -69,7 +69,7 @@ public class EN {
     protected List<CsEntityNameUse> use;
     protected String delimiter;
     protected String family;
-    protected String given;
+    protected List<String> given;
     protected String prefix;
     protected String suffix;
     protected IVLTS validTime;
@@ -120,12 +120,40 @@ public class EN {
         this.family = family;
     }
 
-    public String getGiven() {
-        return given;
+    /**
+     * Gets the value of the given property.
+     *
+     * <p>
+     * This accessor method returns a reference to the live list,
+     * not a snapshot. Therefore any modification you make to the
+     * returned list will be present inside the JAXB object.
+     * This is why there is not a <CODE>set</CODE> method for the given property.
+     *
+     * <p>
+     * For example, to add a new item, do as follows:
+     * <pre>
+     *    getGiven().add(newItem);
+     * </pre>
+     *
+     * <p>
+     * Objects of the following type(s) are allowed in the list
+     * {@link String }
+     */
+    public List<String> getGiven() {
+        if (given == null) {
+            given = new ArrayList<>();
+        }
+        return this.given;
     }
 
-    public void setGiven(String given) {
-        this.given = given;
+    /**
+     * Convenience method for backward compatibility - returns the first given name as a string.
+     */
+    public String getFirstGiven() {
+        if (given != null && !given.isEmpty()) {
+            return given.get(0);
+        }
+        return null;
     }
 
     public String getPrefix() {

--- a/schema/src/test/java/JaxbTest.java
+++ b/schema/src/test/java/JaxbTest.java
@@ -40,7 +40,8 @@ class JaxbTest {
 
         // then
         assertThat(person.getName().getFamily()).isEqualTo("Whitcombe");
-        assertThat(person.getName().getGiven()).isEqualTo("Peter");
+        assertThat(person.getName().getGiven()).hasSize(1);
+        assertThat(person.getName().getGiven().getFirst()).isEqualTo("Peter");
         assertThat(person.getName().getPrefix()).isEqualTo("Dr");
         assertThat(person.getName().getValidTime().getCenter().getValue()).isEqualTo("20100114");
         assertThat(place.getName()).isEqualTo("EMIS Test Practice Location");


### PR DESCRIPTION
## What

- Changed EN.given field from String to List<String> to support multiple given name elements
- Updated AgentDirectoryMapper to iterate over all given names and add each to FHIR HumanName
- Added helper method getGivenNamesAsString() to concatenate multiple given names for text field
- Updated hasNoName() to correctly check for given names in List structure
- Updated JAXB schema test to work with List<String> given names
- Added convenience method getFirstGiven() for backward compatibility
- Added unit tests for multiple given names scenarios (with and without family name).

## Why

The adapter was unable to handle XML containing multiple <given> fields for practitioner names. When an XML part contained multiple given names like:

```XML
<name use="L">
    <given>Minire</given>
    <given>E</given>
    <family>Clarkson</family>
</name>
```

The JSON output would only include a single given name:

```JSON
{
    "name": [{
        "use": "official",
        "family": "Clarkson",
        "given": ["E"]  // Only one given name captured
    }]
}
````

**Root Cause**

The JAXB-generated schema classes in org.hl7.v3.EN (which PN extends) only supported a single String field for given names:

`protected String given`;

This meant when the XML was unmarshalled, JAXB could only capture one <given> element, even though the XML schema (datatypes.xsd) defines the name parts as a <choice> element with maxOccurs="unbounded", allowing multiple instances.

**Solution**

_**1. Modified EN Class (schema/src/main/java/org/hl7/v3/EN.java)**_

Changed the given field to support multiple values:

// Before:
`protected String given;`

// After:
`protected List<String> given;`

Updated the getter method to return a List:

```Java
public List<String> getGiven() {
    if (given == null) {
        given = new ArrayList<>();
    }
    return this.given;
}
```

Added a convenience method for backward compatibility:

```Java
public String getFirstGiven() {
    if (given != null && !given.isEmpty()) {
        return given.get(0);
    }
    return null;
}
```

**_2. Updated AgentDirectoryMapper_** (gp2gp-translator/src/main/java/uk/nhs/adaptors/pss/translator/mapper/AgentDirectoryMapper.java)

Modified the mapper to iterate over all given names and add them to the FHIR HumanName:

```Java
private void setHumanNameValuesFromName(PN name, HumanName humanName) {
    humanName.setFamily(name.getFamily());

    // Handle multiple given names
    var givenList = name.getGiven();
    if (givenList != null && !givenList.isEmpty()) {
        for (String givenName : givenList) {
            var given = getPractitionerGiven(givenName);
            if (given != null) {
                humanName.getGiven().add(given);
            }
        }
    }

    var prefix = getPractitionerPrefix(name.getPrefix());
    if (prefix != null) {
        humanName.getPrefix().add(prefix);
    }
}
```

Added a helper method to concatenate given names for the text field when there's no family name:

```Java
private static String getGivenNamesAsString(PN name) {
    var givenList = name.getGiven();
    if (givenList != null && !givenList.isEmpty()) {
        return StringUtils.join(givenList, " ");
    }
    return null;
}
```

**_3. Updated Tests_**

Updated JaxbTest (schema/src/test/java/JaxbTest.java)

Changed the test to check for a list of given names:

// Before:
`assertThat(person.getName().getGiven()).isEqualTo("Peter");`

// After:
`assertThat(person.getName().getGiven()).hasSize(1);`
`assertThat(person.getName().getGiven().getFirst()).isEqualTo("Peter");`

**_Updated and Added Tests in AgentDirectoryMapperTest_**

Updated the test When_MapAgentDirectoryOnlyAgentPersonWithNameElementWithOnlyGiven_Expect_TextSetToGiven() to correctly test the scenario with both multiple given names and a family name.

Added new test When_MapAgentDirectoryOnlyAgentPersonWithMultipleGivenNamesNoFamily_Expect_TextSetToGiven() to test the case where there are multiple given names but no family name.

Added new test When_MapAgentWithMultipleGivenAndFamilyName_Expect_AllGivenNamesInArray() to test the exact user scenario with ID and all assertions.

**Expected Output After Fix**

For the XML example provided:

```XML
<part typeCode="PART">
    <Agent classCode="AGNT">
        <id root="CD8E40B3-6A3C-11F1-AE7C-00155D75C807"/>
        <agentPerson classCode="PSN" determinerCode="INSTANCE">
            <name use="L">
                <given>Minire</given>
                <given>E</given>
                <family>Clarkson</family>
            </name>
        </agentPerson>
    </Agent>
</part>
```

The JSON output is now:

```JSON
{
    "resource": {
        "resourceType": "Practitioner",
        "id": "CD8E40B3-6A3C-11F1-AE7C-00155D75C807",
        "meta": {
            "profile": ["https://fhir.nhs.uk/STU3/StructureDefinition/CareConnect-GPC-Practitioner-1"]
        },
        "name": [{
            "use": "official",
            "family": "Clarkson",
            "given": ["Minire", "E"]
        }]
    }
}
```

The changes are backward compatible:

* Single given names still work as before
* The convenience method getFirstGiven() provides access to the first given name
* All existing tests pass without modification (except for the assertion adjustment to work with Lists)

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Internal change (non-breaking change with no effect on the functionality affecting end users)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:

- [x] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have updated the [Changelog](/CHANGELOG.md) with details of my change in the UNRELEASED section if this change will affect end users
- [x] A corresponding change has been made to the [Mapping Documentation repository][mapping-docs]

[mapping-docs]: https://github.com/NHSDigital/patient-switching-adaptors-mapping-documentation

Co-authored-by: GitHub Copilot <noreply@github.com>