### PR TITLE
corrected spelling of milliliter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## Unreleased
 
+### Fixed
+
+* Fixed spelling error in measurement unit "milliliter".
+
 ## [3.3.1] - 2026-06-01
 
 ### Added

--- a/gp2gp-translator/src/integrationTest/resources/e2e-mapping/output-json/PWTP9-output.json
+++ b/gp2gp-translator/src/integrationTest/resources/e2e-mapping/output-json/PWTP9-output.json
@@ -11530,7 +11530,7 @@
       } ],
       "valueQuantity": {
         "value": 0.8,
-        "unit": "nanogram per millliiter",
+        "unit": "nanogram per milliliter",
         "code": "ng/mL"
       },
       "referenceRange": [ {

--- a/gp2gp-translator/src/main/java/uk/nhs/adaptors/pss/translator/util/MeasurementUnitsUtil.java
+++ b/gp2gp-translator/src/main/java/uk/nhs/adaptors/pss/translator/util/MeasurementUnitsUtil.java
@@ -627,7 +627,7 @@ public final class MeasurementUnitsUtil {
         UNITS.put("ng/mg/h", "nanogram per milligram per hour");
         UNITS.put("ng/mg{Protein}", "nanogram / milligram Protein");
         UNITS.put("ng/min", "nanogram per minute");
-        UNITS.put("ng/mL", "nanogram per millliiter");
+        UNITS.put("ng/mL", "nanogram per milliliter");
         UNITS.put("ng/mL/h", "nanogram per milliliter per hour");
         UNITS.put("ng/mL{rbc}", "nanogram / milliliter rbc");
         UNITS.put("ng/s", "nanogram per second");


### PR DESCRIPTION
## What

Corrected spelling of "Millliiter" to "Milliliter".

## Why

This was a typo in the unit mapping and needs correcting.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Internal change (non-breaking change with no effect on the functionality affecting end users)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:

- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings
- [x] I have updated the [Changelog](/CHANGELOG.md) with details of my change in the UNRELEASED section if this change will affect end users

[mapping-docs]: https://github.com/NHSDigital/patient-switching-adaptors-mapping-documentation